### PR TITLE
Fixed chomp indicator emitting logic

### DIFF
--- a/YamlDotNet.Core/Emitter.cs
+++ b/YamlDotNet.Core/Emitter.cs
@@ -1842,17 +1842,12 @@ namespace YamlDotNet.Core
 			isOpenEnded = false;
 
 			string chomp_hint = null;
-			if(value.Length == 0) {
+			if(value.Length == 0 || !analyzer.IsBreak(value.Length - 1)) {
 				chomp_hint = "-";
 			}
-			else {
-				if(analyzer.IsBreak(value.Length - 1)) {
-					chomp_hint = "-";
-				}
-				else if(value.Length < 2 || analyzer.IsBreak(value.Length - 2)) {
-					chomp_hint = "+";
-					isOpenEnded = true;
-				}
+			else if(value.Length >= 2 && analyzer.IsBreak(value.Length - 2)) {
+				chomp_hint = "+";
+				isOpenEnded = true;
 			}
 
 			if(chomp_hint != null){


### PR DESCRIPTION
Unit test RoundtripExample17 was failing because the correct chomp indicator wasn't being emitted

Hi Antoine, I think I found the bug causing the failing unit test. Please check what I've done since I don't know the YAML specs that well and especially not your source code.

The logic I implemented was simple:
- If a scalar does not end with a newline, a strip indicator "-" must be emitted
- If a scalar ends with two newlines, a keep indicator "+" must be emitted
- Otherwise, no indicator should be emitted (one newline).

The relevant section is http://www.yaml.org/spec/1.2/spec.html#id2794534.

The was a boolean isOpenEnded which I know nothing about, I left the previous behavior of setting it to true iff the chomp indicator is keep "+".

Let me know what you think...
