### PR TITLE
Nullables and TimeSpan

### DIFF
--- a/YamlDotNet.RepresentationModel/Serialization/FullObjectGraphTraversalStrategy.cs
+++ b/YamlDotNet.RepresentationModel/Serialization/FullObjectGraphTraversalStrategy.cs
@@ -71,7 +71,7 @@ namespace YamlDotNet.RepresentationModel.Serialization
 					throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "TypeCode.{0} is not supported.", typeCode));
 
 				default:
-					if (value == null)
+					if (value == null || type == typeof(TimeSpan))
 					{
 						visitor.VisitScalar(value, type);
 						break;

--- a/YamlDotNet.RepresentationModel/Serialization/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet.RepresentationModel/Serialization/TypeAssigningEventEmitter.cs
@@ -61,6 +61,13 @@ namespace YamlDotNet.RepresentationModel.Serialization
 					break;
 
 				default:
+					if (eventInfo.SourceType == typeof(TimeSpan))
+					{
+						eventInfo.RenderedValue = YamlFormatter.FormatTimeSpan(eventInfo.SourceValue);
+						eventInfo.Style = ScalarStyle.DoubleQuoted;
+						break;
+					}
+
 					throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "TypeCode.{0} is not supported.", typeCode));
 			}
 
@@ -141,6 +148,13 @@ namespace YamlDotNet.RepresentationModel.Serialization
 					break;
 
 				default:
+					if (eventInfo.SourceType == typeof(TimeSpan))
+					{
+						eventInfo.RenderedValue = YamlFormatter.FormatTimeSpan(eventInfo.SourceValue);
+						eventInfo.Style = ScalarStyle.DoubleQuoted;
+						break;
+					}
+
 					throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "TypeCode.{0} is not supported.", typeCode));
 			}
 
@@ -177,6 +191,11 @@ namespace YamlDotNet.RepresentationModel.Serialization
 		public static string FormatDateTime(object dateTime)
 		{
 			return ((DateTime)dateTime).ToString("o", CultureInfo.InvariantCulture);
+		}
+
+		public static string FormatTimeSpan(object timeSpan)
+		{
+			return ((TimeSpan)timeSpan).ToString();
 		}
 	}
 }

--- a/YamlDotNet.UnitTests/RepresentationModel/SerializationTests.cs
+++ b/YamlDotNet.UnitTests/RepresentationModel/SerializationTests.cs
@@ -122,6 +122,20 @@ namespace YamlDotNet.UnitTests.RepresentationModel
 				}
 			}
 
+			private TimeSpan myTimeSpan = TimeSpan.FromHours(1);
+
+			public TimeSpan MyTimeSpan
+			{
+				get
+				{
+					return myTimeSpan;
+				}
+				set
+				{
+					myTimeSpan = value;
+				}
+			}
+
 			private Point myPoint = new Point(100, 200);
 
 			public Point MyPoint


### PR DESCRIPTION
Nullables were being serialized as objects (i.e. with HasValue and Value properties), and therefore could not be deserialized.

Also added support for the .NET TimeSpan type.
