### PR TITLE
Removed needless quotes from TimeSpan representation

### DIFF
--- a/YamlDotNet.RepresentationModel/Serialization/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet.RepresentationModel/Serialization/TypeAssigningEventEmitter.cs
@@ -64,7 +64,6 @@ namespace YamlDotNet.RepresentationModel.Serialization
 					if (eventInfo.SourceType == typeof(TimeSpan))
 					{
 						eventInfo.RenderedValue = YamlFormatter.FormatTimeSpan(eventInfo.SourceValue);
-						eventInfo.Style = ScalarStyle.DoubleQuoted;
 						break;
 					}
 
@@ -152,7 +151,6 @@ namespace YamlDotNet.RepresentationModel.Serialization
 					if (eventInfo.SourceType == typeof(TimeSpan))
 					{
 						eventInfo.RenderedValue = YamlFormatter.FormatTimeSpan(eventInfo.SourceValue);
-						eventInfo.Style = ScalarStyle.DoubleQuoted;
 						break;
 					}
 


### PR DESCRIPTION
I accidentally put double quotes when I added TimeSpan support, it's useless and is driving me crazy :)
