### PR TITLE
Fixed bug with nullable + default value

### DIFF
--- a/YamlDotNet.RepresentationModel/Serialization/FullObjectGraphTraversalStrategy.cs
+++ b/YamlDotNet.RepresentationModel/Serialization/FullObjectGraphTraversalStrategy.cs
@@ -52,6 +52,11 @@ namespace YamlDotNet.RepresentationModel.Serialization
 				return;
 			}
 
+			TraverseInternal(value, type, visitor, currentDepth);
+		}
+
+		protected virtual void TraverseInternal(object value, Type type, IObjectGraphVisitor visitor, int currentDepth)
+		{
 			var typeCode = Type.GetTypeCode(type);
 			switch (typeCode)
 			{
@@ -88,15 +93,15 @@ namespace YamlDotNet.RepresentationModel.Serialization
 					}
 
 					Type underlyingType = Nullable.GetUnderlyingType(type);
-					if (underlyingType == null)
+					if (underlyingType != null)
 					{
-						TraverseObject(value, type, visitor, currentDepth);
+						// This is a nullable type, recursively handle it with its underlying type.
+						// Note that if it contains null, the condition above already took care of it
+						TraverseInternal(value, underlyingType, visitor, currentDepth);
 						break;
 					}
 
-					// This is a nullable type, recursively handle it with its underlying type.
-					// Not that if it contains null, the condition above already took care of it
-					Traverse(value, underlyingType, visitor, currentDepth);
+					TraverseObject(value, type, visitor, currentDepth);
 					break;
 			}
 		}

--- a/YamlDotNet.UnitTests/RepresentationModel/SerializationTests.cs
+++ b/YamlDotNet.UnitTests/RepresentationModel/SerializationTests.cs
@@ -167,6 +167,14 @@ namespace YamlDotNet.UnitTests.RepresentationModel
 				get { return myNullableWithoutValue; }
 				set { myNullableWithoutValue = value; }
 			}
+
+			private int? myNullableWithDefaultValue = 0;
+
+			public int? MyNullableWithDefaultValue
+			{
+				get { return myNullableWithDefaultValue; }
+				set { myNullableWithDefaultValue = value; }
+			}
 		}
 
 		[Fact]


### PR DESCRIPTION
Trying to serialize a nullable containing the default value (e.g. 0 for
int) triggered a failure. Since Traverse for nullable types recursively
called Traverse, the Traverse operating on the underlying had no
knowledge/context of the nullable and considered 0 as a default value,
omitting it.

Fixed by separating the traversal entrance checks from the actual
traversal (i.e. dispatching to TraverseScalar, TraverseObject...)
