### PR TITLE
Extracted text dump methods 

### DIFF
--- a/YamlDotNet.Converters.Test/Xml/XmlConverterTests.cs
+++ b/YamlDotNet.Converters.Test/Xml/XmlConverterTests.cs
@@ -19,8 +19,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-using System;
-using System.Xml;
 using Xunit;
 using YamlDotNet.RepresentationModel;
 using YamlDotNet.Converters.Xml;
@@ -32,80 +30,89 @@ namespace YamlDotNet.Converters.Test.Xml
 {
 	public class XmlConverterTests : YamlTest
 	{
-		private static YamlDocument GetDocument(string name) {
-			YamlStream stream = new YamlStream();
-			stream.Load(YamlFile(name));
-			Assert.True(stream.Documents.Count > 0);
-			return stream.Documents[0];
-		}
-		
 		[Fact]
 		public void ScalarToXml() {
-			YamlDocument yaml = GetDocument("test2.yaml");
-			
-			XmlConverter converter = new XmlConverter();
-			XmlDocument xml = converter.ToXml(yaml);
-			
-			xml.Save(Console.Out);
-		}			
-		
+			var writer = new StringWriter();
+			var yaml = GetDocument("test2.yaml");
+
+			var xml = new XmlConverter().ToXml(yaml);
+
+			xml.Save(writer);
+			Dump.Write(writer);
+		}
+
 		[Fact]
 		public void SequenceOfScalarsToXml() {
-			YamlDocument yaml = GetDocument("test8.yaml");
-			
-			XmlConverter converter = new XmlConverter();
-			XmlDocument xml = converter.ToXml(yaml);
-			
-			xml.Save(Console.Out);
-		}			
-		
+			var writer = new StringWriter();
+			var yaml = GetDocument("test8.yaml");
+
+			var xml = new XmlConverter().ToXml(yaml);
+
+			xml.Save(writer);
+			Dump.Write(writer);
+		}
+
 		[Fact]
 		public void MappingOfScalarsToXml() {
-			YamlDocument yaml = GetDocument("test9.yaml");
+			var writer = new StringWriter();
+			var yaml = GetDocument("test9.yaml");
 
-			XmlConverter converter = new XmlConverter();
-			XmlDocument xml = converter.ToXml(yaml);
-			
-			xml.Save(Console.Out);
-		}			
-		
+			var xml = new XmlConverter().ToXml(yaml);
+
+			xml.Save(writer);
+			Dump.Write(writer);
+		}
+
 		[Fact]
 		public void SequenceOfMappingAndSequencesToXml() {
-			YamlDocument yaml = GetDocument("test10.yaml");
-			
-			XmlConverter converter = new XmlConverter();
-			XmlDocument xml = converter.ToXml(yaml);
-			
-			xml.Save(Console.Out);
-		}			
-		
+			var writer = new StringWriter();
+			var yaml = GetDocument("test10.yaml");
+
+			var xml = new XmlConverter().ToXml(yaml);
+
+			xml.Save(writer);
+			Dump.Write(writer);
+		}
+
 		[Fact]
 		public void ToXmlUsingExtension() {
-			YamlDocument yaml = GetDocument("test10.yaml");
-			XmlDocument xml = yaml.ToXml();
-			xml.Save(Console.Out);
-		}			
+			var writer = new StringWriter();
+			var yaml = GetDocument("test10.yaml");
+
+			var xml = yaml.ToXml();
+
+			xml.Save(writer);
+			Dump.Write(writer);
+		}
 
 		[Fact]
 		public void Roundtrip()
 		{
-			YamlDocument yaml = GetDocument("test10.yaml");
+			var yaml = GetDocument("test10.yaml");
 
-			XmlConverter converter = new XmlConverter();
-			XmlDocument xml = converter.ToXml(yaml);
+			var converter = new XmlConverter();
+			var xml = converter.ToXml(yaml);
 
-			StringWriter firstBuffer = new StringWriter();
+			var firstBuffer = new StringWriter();
 			xml.Save(firstBuffer);
-			Console.Out.Write(firstBuffer.ToString());
+			Dump.Write(firstBuffer);
 
-			YamlDocument intermediate = converter.FromXml(xml);
-			XmlDocument final = converter.ToXml(intermediate);
+			var intermediate = converter.FromXml(xml);
+			var final = converter.ToXml(intermediate);
 
-			StringWriter secondBuffer = new StringWriter();
+			var secondBuffer = new StringWriter();
 			final.Save(secondBuffer);
-			Console.Error.Write(secondBuffer.ToString());
+			Dump.Write(secondBuffer);
 
 			Assert.Equal(firstBuffer.ToString(), secondBuffer.ToString());
+		}
+
+		private static YamlDocument GetDocument(string name)
+		{
+			var stream = new YamlStream();
+			stream.Load(YamlFile(name));
+			Assert.True(stream.Documents.Count > 0, "The file [" + name + "] did not contain any Yaml documents");
+			return stream.Documents[0];
 		}
 	}
 }

--- a/YamlDotNet.Converters.Test/YamlDotNet.Converters.Test.csproj
+++ b/YamlDotNet.Converters.Test/YamlDotNet.Converters.Test.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;TEST_DUMP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/YamlDotNet.Core.Test/Dump.cs
+++ b/YamlDotNet.Core.Test/Dump.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+
+namespace YamlDotNet.Core.Test
+{
+	public class Dump
+	{
+		[Conditional("TEST_DUMP")]
+		public static void Write(object value)
+		{
+			Debug.Write(value);
+		}
+
+		[Conditional("TEST_DUMP")]
+		public static void Write(string format, params object[] args)
+		{
+			Debug.Write(string.Format(format, args));
+		}
+
+		[Conditional("TEST_DUMP")]
+		public static void WriteLine()
+		{
+			Debug.WriteLine(string.Empty);
+		}
+
+		[Conditional("TEST_DUMP")]
+		public static void WriteLine(string value)
+		{
+			WriteLine((object)value);
+		}
+
+		[Conditional("TEST_DUMP")]
+		public static void WriteLine(object value)
+		{
+			WriteLine("{0}", value);
+		}
+
+		[Conditional("TEST_DUMP")]
+		public static void WriteLine(string format, params object[] args)
+		{
+			Debug.WriteLine(format, args);
+		}
+	}
+}

--- a/YamlDotNet.Core.Test/EmitterTests.cs
+++ b/YamlDotNet.Core.Test/EmitterTests.cs
@@ -19,13 +19,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-using System;
 using System.Linq;
-using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using Xunit.Extensions;
-using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.RepresentationModel;
 
@@ -33,145 +30,114 @@ namespace YamlDotNet.Core.Test
 {
 	public class EmitterTests : YamlTest
 	{
-		private void ParseAndEmit(string name) {
-			string testText = YamlFile(name).ReadToEnd();
-
-			IParser parser = new Parser(new StringReader(testText));
-			using(StringWriter output = new StringWriter()) {
-				IEmitter emitter = new Emitter(output, 2, int.MaxValue, false);
-				while(parser.MoveNext()) {
-					//Console.WriteLine(parser.Current.GetType().Name);
-					Console.Error.WriteLine(parser.Current);
-					emitter.Emit(parser.Current);
-				}
-				
-				string result = output.ToString();
-				
-				Console.WriteLine();
-				Console.WriteLine("------------------------------");
-				Console.WriteLine();
-				Console.WriteLine(testText);
-				Console.WriteLine();
-				Console.WriteLine("------------------------------");
-				Console.WriteLine();
-				Console.WriteLine(result);
-				Console.WriteLine();
-				Console.WriteLine("------------------------------");
-				Console.WriteLine();
-
-				/*
-				Parser resultParser = new Parser(new StringReader(result));
-				while(resultParser.MoveNext()) {
-					Console.WriteLine(resultParser.Current.GetType().Name);
-				}
-				*/
-				/*
-				
-				if(testText != result) {
-					Console.WriteLine();
-					Console.WriteLine("------------------------------");
-					Console.WriteLine();
-					Console.WriteLine("Expected:");
-					Console.WriteLine();
-					Console.WriteLine(testText);
-					Console.WriteLine();
-					Console.WriteLine("------------------------------");
-					Console.WriteLine();
-					Console.WriteLine("Result:");
-					Console.WriteLine();
-					Console.WriteLine(result);
-					Console.WriteLine();
-					Console.WriteLine("------------------------------");
-					Console.WriteLine();
-				}
-				
-				Assert.Equal(testText, result);
-				*/
-			}
-		}
-		
 		[Fact]
 		public void EmitExample1()
 		{
 			ParseAndEmit("test1.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample2()
 		{
 			ParseAndEmit("test2.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample3()
 		{
 			ParseAndEmit("test3.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample4()
 		{
 			ParseAndEmit("test4.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample5()
 		{
 			ParseAndEmit("test5.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample6()
 		{
 			ParseAndEmit("test6.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample7()
 		{
 			ParseAndEmit("test7.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample8()
 		{
 			ParseAndEmit("test8.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample9()
 		{
 			ParseAndEmit("test9.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample10()
 		{
 			ParseAndEmit("test10.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample11()
 		{
 			ParseAndEmit("test11.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample12()
 		{
 			ParseAndEmit("test12.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample13()
 		{
 			ParseAndEmit("test13.yaml");
 		}
-		
+
 		[Fact]
 		public void EmitExample14()
 		{
 			ParseAndEmit("test14.yaml");
+		}
+
+		private void ParseAndEmit(string name)
+		{
+			var testText = YamlFile(name).ReadToEnd();
+
+			var output = new StringWriter();
+			IParser parser = new Parser(new StringReader(testText));
+			IEmitter emitter = new Emitter(output, 2, int.MaxValue, false);
+			Dump.WriteLine("= Parse and emit yaml file ["+ name + "] =");
+			while (parser.MoveNext())
+			{
+				Dump.WriteLine(parser.Current);
+				emitter.Emit(parser.Current);
+			}
+			Dump.WriteLine();
+
+			Dump.WriteLine("= Original =");
+			Dump.WriteLine(testText);
+			Dump.WriteLine();
+
+			Dump.WriteLine("= Result =");
+			Dump.WriteLine(output);
+			Dump.WriteLine();
+
+			// Todo: figure out how (if?) to assert
 		}
 
 		private string EmitScalar(Scalar scalar)
@@ -207,7 +173,7 @@ namespace YamlDotNet.Core.Test
 		public void FoldedStyleDoesNotLooseCharacters(string text)
 		{
 			var yaml = EmitScalar(new Scalar(null, null, text, ScalarStyle.Folded, true, false));
-			Console.WriteLine(yaml);
+			Dump.WriteLine(yaml);
 			Assert.True(yaml.Contains("world"));
 		}
 
@@ -215,7 +181,7 @@ namespace YamlDotNet.Core.Test
 		public void FoldedStyleIsSelectedWhenNewLinesAreFoundInLiteral()
 		{
 			var yaml = EmitScalar(new Scalar(null, null, "hello\nworld", ScalarStyle.Any, true, false));
-			Console.WriteLine(yaml);
+			Dump.WriteLine(yaml);
 			Assert.True(yaml.Contains(">"));
 		}
 
@@ -223,8 +189,9 @@ namespace YamlDotNet.Core.Test
 		public void FoldedStyleDoesNotGenerateExtraLineBreaks()
 		{
 			var yaml = EmitScalar(new Scalar(null, null, "hello\nworld", ScalarStyle.Folded, true, false));
-			Console.WriteLine(yaml);
+			Dump.WriteLine(yaml);
 
+			// Todo: Why involve the rep. model when testing the Emitter? Can we match using a regex?
 			var stream = new YamlStream();
 			stream.Load(new StringReader(yaml));
 			var sequence = (YamlSequenceNode)stream.Documents[0].RootNode;
@@ -237,7 +204,7 @@ namespace YamlDotNet.Core.Test
 		public void FoldedStyleDoesNotCollapseLineBreaks()
 		{
 			var yaml = EmitScalar(new Scalar(null, null, ">+\n", ScalarStyle.Folded, true, false));
-			Console.WriteLine("${0}$", yaml);
+			Dump.WriteLine("${0}$", yaml);
 
 			var stream = new YamlStream();
 			stream.Load(new StringReader(yaml));
@@ -258,7 +225,7 @@ namespace YamlDotNet.Core.Test
 				new Scalar(null, null, input, ScalarStyle.Folded, true, false),
 				new MappingEnd()
 			);
-			Console.WriteLine(yaml);
+			Dump.WriteLine(yaml);
 
 			var stream = new YamlStream();
 			stream.Load(new StringReader(yaml));
@@ -266,9 +233,9 @@ namespace YamlDotNet.Core.Test
 			var mapping = (YamlMappingNode)stream.Documents[0].RootNode;
 			var value = (YamlScalarNode)mapping.Children.First().Value;
 
-			Console.WriteLine(value.Value);
-
-			Assert.Equal(input, value.Value);
+			var output = value.Value;
+			Dump.WriteLine(output);
+			Assert.Equal(input, output);
 		}
 	}
 }

--- a/YamlDotNet.Core.Test/ParserTests.cs
+++ b/YamlDotNet.Core.Test/ParserTests.cs
@@ -21,10 +21,7 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
 using Xunit;
-using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using VersionDirective = YamlDotNet.Core.Tokens.VersionDirective;
 using TagDirective = YamlDotNet.Core.Tokens.TagDirective;
@@ -32,90 +29,32 @@ using TagDirective = YamlDotNet.Core.Tokens.TagDirective;
 namespace YamlDotNet.Core.Test
 {
 	public class ParserTests : YamlTest
-	{	
-		private static IParser CreateParser(string name) {
-			return new Parser(YamlFile(name));
-		}
-			
-		private void AssertHasNext(IParser parser) {
-			Assert.True(parser.MoveNext());
-		}
-		
-		private void AssertDoesNotHaveNext(IParser parser) {
-			Assert.False(parser.MoveNext());
-		}
-	
-		private void AssertCurrent(IParser parser, ParsingEvent expected) {
-			Console.WriteLine(expected.GetType().Name);
-			Assert.True(expected.GetType().IsAssignableFrom(parser.Current.GetType()), string.Format("The event is not of the expected type. Exprected: {0}, Actual: {1}", expected.GetType().Name, parser.Current.GetType().Name));
-			
-			foreach (var property in expected.GetType().GetProperties()) {
-				if(property.PropertyType != typeof(Mark) && property.CanRead) {
-					object value = property.GetValue(parser.Current, null);
-					object expectedValue = property.GetValue(expected, null);
-					if(expectedValue != null && Type.GetTypeCode(expectedValue.GetType()) == TypeCode.Object && expectedValue is IEnumerable) {
-						Console.Write("\t{0} = {{", property.Name);
-						bool isFirst = true;
-						foreach(var item in (IEnumerable)value) {
-							if(isFirst) {
-								isFirst = false;
-							} else {
-								Console.Write(", ");
-							}
-							Console.Write(item);
-						}
-						Console.WriteLine("}");
-						
-						if(expectedValue is ICollection && value is ICollection) {
-							Assert.Equal(((ICollection)expectedValue).Count, ((ICollection)value).Count);
-						}
-						
-						IEnumerator values = ((IEnumerable)value).GetEnumerator();
-						IEnumerator expectedValues = ((IEnumerable)expectedValue).GetEnumerator();
-						while(expectedValues.MoveNext()) {
-							Assert.True(values.MoveNext());
-							Assert.Equal(expectedValues.Current, values.Current);
-						}
-						
-						Assert.False(values.MoveNext());
-					} else {
-						Console.WriteLine("\t{0} = {1}", property.Name, value);
-						Assert.Equal(expectedValue, value);
-					}
-				}
-			}
-		}
-	
-		private void AssertNext(IParser parser, ParsingEvent expected) {
-			AssertHasNext(parser);
-			AssertCurrent(parser, expected);
-		}
+	{
+		private static TagDirectiveCollection defaultDirectives = new TagDirectiveCollection(new[] {
+			new TagDirective("!", "!"),
+			new TagDirective("!!", "tag:yaml.org,2002:")
+		});
 
 		[Fact]
 		public void EmptyDocument()
 		{
-			IParser parser = CreateParser("empty.yaml");
+			var parser = CreateParser("empty.yaml");
 
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new StreamEnd());
 			AssertDoesNotHaveNext(parser);
 		}
-		
-		private static TagDirectiveCollection defaultDirectives = new TagDirectiveCollection(new TagDirective[] {
-			new TagDirective("!", "!"),
-			new TagDirective("!!", "tag:yaml.org,2002:"),
-		});
-		
+
 		[Fact]
 		public void VerifyEventsOnExample1()
 		{
-			IParser parser = CreateParser("test1.yaml");
+			var parser = CreateParser("test1.yaml");
 			
 			AssertNext(parser, new StreamStart());
-			AssertNext(parser, new DocumentStart(new VersionDirective(new Core.Version(1, 1)), new TagDirectiveCollection(new TagDirective[] {
+			AssertNext(parser, new DocumentStart(new VersionDirective(new Version(1, 1)), new TagDirectiveCollection(new[] {
 				new TagDirective("!", "!foo"),
 				new TagDirective("!yaml!", "tag:yaml.org,2002:"),
-				new TagDirective("!!", "tag:yaml.org,2002:"),
+				new TagDirective("!!", "tag:yaml.org,2002:")
 			}), false));
 			AssertNext(parser, new Scalar(null, null, string.Empty, ScalarStyle.Plain, true, false));
 			AssertNext(parser, new DocumentEnd(true));
@@ -126,7 +65,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample2()
 		{
-			IParser parser = CreateParser("test2.yaml");
+			var parser = CreateParser("test2.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -139,7 +78,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample3()
 		{
-			IParser parser = CreateParser("test3.yaml");
+			var parser = CreateParser("test3.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, false));
@@ -152,7 +91,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample4()
 		{
-			IParser parser = CreateParser("test4.yaml");
+			var parser = CreateParser("test4.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -171,7 +110,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample5()
 		{
-			IParser parser = CreateParser("test5.yaml");
+			var parser = CreateParser("test5.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -186,7 +125,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample6()
 		{
-			IParser parser = CreateParser("test6.yaml");
+			var parser = CreateParser("test6.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -199,7 +138,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample7()
 		{
-			IParser parser = CreateParser("test7.yaml");
+			var parser = CreateParser("test7.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, false));
@@ -227,7 +166,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample8()
 		{
-			IParser parser = CreateParser("test8.yaml");
+			var parser = CreateParser("test8.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -244,7 +183,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample9()
 		{
-			IParser parser = CreateParser("test9.yaml");
+			var parser = CreateParser("test9.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -262,7 +201,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample10()
 		{
-			IParser parser = CreateParser("test10.yaml");
+			var parser = CreateParser("test10.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -288,7 +227,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample11()
 		{
-			IParser parser = CreateParser("test11.yaml");
+			var parser = CreateParser("test11.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -318,7 +257,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample12()
 		{
-			IParser parser = CreateParser("test12.yaml");
+			var parser = CreateParser("test12.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -346,7 +285,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample13()
 		{
-			IParser parser = CreateParser("test13.yaml");
+			var parser = CreateParser("test13.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -372,7 +311,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokensOnExample14()
 		{
-			IParser parser = CreateParser("test14.yaml");
+			var parser = CreateParser("test14.yaml");
 			
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, true));
@@ -391,7 +330,7 @@ namespace YamlDotNet.Core.Test
 		[Fact]
 		public void VerifyTokenWithLocalTags()
 		{
-			IParser parser = CreateParser("local-tags.yaml");
+			var parser = CreateParser("local-tags.yaml");
 
 			AssertNext(parser, new StreamStart());
 			AssertNext(parser, new DocumentStart(null, defaultDirectives, false));
@@ -406,6 +345,67 @@ namespace YamlDotNet.Core.Test
 			AssertNext(parser, new DocumentEnd(true));
 			AssertNext(parser, new StreamEnd());
 			AssertDoesNotHaveNext(parser);
+		}
+
+		private IParser CreateParser(string name)
+		{
+			return new Parser(YamlFile(name));
+		}
+
+		private void AssertNext(IParser parser, ParsingEvent expected) {
+			AssertHasNext(parser);
+			AssertCurrent(parser, expected);
+		}
+
+		private void AssertHasNext(IParser parser) {
+			Assert.True(parser.MoveNext());
+		}
+
+		private void AssertDoesNotHaveNext(IParser parser) {
+			Assert.False(parser.MoveNext());
+		}
+
+		private void AssertCurrent(IParser parser, ParsingEvent expected) {
+			Dump.WriteLine(expected.GetType().Name);
+			Assert.True(expected.GetType().IsAssignableFrom(parser.Current.GetType()),
+				string.Format("The event is not of the expected type. Exprected: {0}, Actual: {1}", expected.GetType().Name, parser.Current.GetType().Name));
+
+			foreach (var property in expected.GetType().GetProperties()) {
+				if (property.PropertyType != typeof(Mark) && property.CanRead) {
+					var value = property.GetValue(parser.Current, null);
+					var expectedValue = property.GetValue(expected, null);
+					// Todo: what does GetTypeCode do and is it necessary?
+					if (expectedValue != null && Type.GetTypeCode(expectedValue.GetType()) == TypeCode.Object && expectedValue is IEnumerable) {
+						Dump.Write("\t{0} = {{", property.Name);
+						var isFirst = true;
+						foreach (var item in (IEnumerable)value) {
+							if (isFirst) {
+								isFirst = false;
+							} else {
+								Dump.Write(", ");
+							}
+							Dump.Write(item);
+						}
+						Dump.WriteLine("}");
+
+						if (expectedValue is ICollection && value is ICollection) {
+							Assert.Equal(((ICollection)expectedValue).Count, ((ICollection)value).Count);
+						}
+
+						var values = ((IEnumerable)value).GetEnumerator();
+						var expectedValues = ((IEnumerable)expectedValue).GetEnumerator();
+						while (expectedValues.MoveNext()) {
+							Assert.True(values.MoveNext());
+							Assert.Equal(expectedValues.Current, values.Current);
+						}
+
+						Assert.False(values.MoveNext());
+					} else {
+						Dump.WriteLine("\t{0} = {1}", property.Name, value);
+						Assert.Equal(expectedValue, value);
+					}
+				}
+			}
 		}
 	}
 }

--- a/YamlDotNet.Core.Test/ScannerTests.cs
+++ b/YamlDotNet.Core.Test/ScannerTests.cs
@@ -20,55 +20,20 @@
 //  SOFTWARE.
 
 using System;
-using System.IO;
-using System.Reflection;
-using System.Text;
 using Xunit;
-using YamlDotNet.Core;
 using YamlDotNet.Core.Tokens;
 
 namespace YamlDotNet.Core.Test
 {
 	public class ScannerTests : YamlTest
 	{
-		private static Scanner CreateScanner(string name) {
-			return new Scanner(YamlFile(name));
-		}
-		
-		private void AssertHasNext(Scanner scanner) {
-			Assert.True(scanner.MoveNext());
-		}
-		
-		private void AssertDoesNotHaveNext(Scanner scanner) {
-			Assert.False(scanner.MoveNext());
-		}
-
-		private void AssertCurrent(Scanner scanner, Token expected) {
-			Console.WriteLine(expected.GetType().Name);
-			Assert.NotNull(scanner.Current);
-			Assert.True(expected.GetType().IsAssignableFrom(scanner.Current.GetType()));
-			
-			foreach (var property in expected.GetType().GetProperties()) {
-				if(property.PropertyType != typeof(Mark) && property.CanRead) {
-					object value = property.GetValue(scanner.Current, null);
-					Console.WriteLine("\t{0} = {1}", property.Name, value);
-					Assert.Equal(property.GetValue(expected, null), value);
-				}
-			}
-		}
-		
-		private void AssertNext(Scanner scanner, Token expected) {
-			AssertHasNext(scanner);
-			AssertCurrent(scanner, expected);
-		}
-		
 		[Fact]
 		public void VerifyTokensOnExample1()
 		{
 			Scanner scanner = CreateScanner("test1.yaml");
 			
 			AssertNext(scanner, new StreamStart());
-			AssertNext(scanner, new VersionDirective(new Core.Version(1, 1)));
+			AssertNext(scanner, new VersionDirective(new Version(1, 1)));
 			AssertNext(scanner, new TagDirective("!", "!foo"));
 			AssertNext(scanner, new TagDirective("!yaml!", "tag:yaml.org,2002:"));
 			AssertNext(scanner, new DocumentStart());
@@ -365,6 +330,37 @@ namespace YamlDotNet.Core.Test
 			AssertNext(scanner, new BlockEnd());
 			AssertNext(scanner, new StreamEnd());
 			AssertDoesNotHaveNext(scanner);
+		}
+
+		private static Scanner CreateScanner(string name) {
+			return new Scanner(YamlFile(name));
+		}
+
+		private void AssertNext(Scanner scanner, Token expected) {
+			AssertHasNext(scanner);
+			AssertCurrent(scanner, expected);
+		}
+
+		private void AssertHasNext(Scanner scanner) {
+			Assert.True(scanner.MoveNext());
+		}
+
+		private void AssertDoesNotHaveNext(Scanner scanner) {
+			Assert.False(scanner.MoveNext());
+		}
+
+		private void AssertCurrent(Scanner scanner, Token expected) {
+			Dump.WriteLine(expected.GetType().Name);
+			Assert.NotNull(scanner.Current);
+			Assert.True(expected.GetType().IsAssignableFrom(scanner.Current.GetType()));
+
+			foreach (var property in expected.GetType().GetProperties()) {
+				if (property.PropertyType != typeof(Mark) && property.CanRead) {
+					var value = property.GetValue(scanner.Current, null);
+					Dump.WriteLine("\t{0} = {1}", property.Name, value);
+					Assert.Equal(property.GetValue(expected, null), value);
+				}
+			}
 		}
 	}
 }

--- a/YamlDotNet.Core.Test/YamlDotNet.Core.Test.csproj
+++ b/YamlDotNet.Core.Test/YamlDotNet.Core.Test.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;TEST_DUMP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -47,6 +47,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Dump.cs" />
     <Compile Include="EmitterTests.cs" />
     <Compile Include="InsertionQueueTests.cs" />
     <Compile Include="LookAheadBufferTests.cs" />

--- a/YamlDotNet.RepresentationModel.Test/ExceptionWithNestedSerialization.cs
+++ b/YamlDotNet.RepresentationModel.Test/ExceptionWithNestedSerialization.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 using Xunit;
+using YamlDotNet.Core.Test;
 using YamlDotNet.RepresentationModel.Serialization;
 
 namespace YamlDotNet.RepresentationModel.Test
@@ -18,25 +15,27 @@ namespace YamlDotNet.RepresentationModel.Test
 
 			// serialize AMessage
 			var tw = new StringWriter();
-			s.Serialize(tw, new AMessage() { Payload = new PayloadA() { X = 5, Y = 6 } });
-			Console.WriteLine(tw.ToString());
+			s.Serialize(tw, new AMessage { Payload = new PayloadA { X = 5, Y = 6 } });
+			Dump.WriteLine(tw);
 
 			// stick serialized AMessage in envelope and serialize it
-			var e = new Env() { Type = "some-type", Payload = tw.ToString() };
+			var e = new Env { Type = "some-type", Payload = tw.ToString() };
 
 			tw = new StringWriter();
 			s.Serialize(tw, e);
-			Console.WriteLine(tw.ToString());
+			Dump.WriteLine(tw);
 
-			Console.WriteLine("${0}$", e.Payload);
+			Dump.WriteLine("${0}$", e.Payload);
 
 			// deserialize envelope
 			var e2 = ds.Deserialize<Env>(new StringReader(tw.ToString()));
 
-			Console.WriteLine("${0}$", e2.Payload);
+			Dump.WriteLine("${0}$", e2.Payload);
 
 			// deserialize payload - fails if EmitDefaults is set
 			ds.Deserialize<AMessage>(new StringReader(e2.Payload));
+
+			// Todo: proper assert
 		}
 
 		public class Env

--- a/YamlDotNet.RepresentationModel.Test/YamlDotNet.RepresentationModel.Test.csproj
+++ b/YamlDotNet.RepresentationModel.Test/YamlDotNet.RepresentationModel.Test.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;TEST_DUMP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/YamlDotNet.RepresentationModel.Test/YamlStreamTests.cs
+++ b/YamlDotNet.RepresentationModel.Test/YamlStreamTests.cs
@@ -19,14 +19,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 using YamlDotNet.Core.Test;
-using YamlDotNet.RepresentationModel;
 using System.Text;
 using System.IO;
-using System.Diagnostics;
 
 namespace YamlDotNet.RepresentationModel.Test
 {
@@ -35,7 +32,7 @@ namespace YamlDotNet.RepresentationModel.Test
 
 		[Fact]
 		public void LoadSimpleDocument() {
-			YamlStream stream = new YamlStream();
+			var stream = new YamlStream();
 			stream.Load(YamlFile("test2.yaml"));
 			
 			Assert.Equal(1, stream.Documents.Count);
@@ -45,13 +42,13 @@ namespace YamlDotNet.RepresentationModel.Test
 		
 		[Fact]
 		public void BackwardAliasReferenceWorks() {
-			YamlStream stream = new YamlStream();
+			var stream = new YamlStream();
 			stream.Load(YamlFile("backwardsAlias.yaml"));
 			
 			Assert.Equal(1, stream.Documents.Count);
 			Assert.IsType<YamlSequenceNode>(stream.Documents[0].RootNode);
 
-			YamlSequenceNode sequence = (YamlSequenceNode)stream.Documents[0].RootNode;
+			var sequence = (YamlSequenceNode)stream.Documents[0].RootNode;
 			Assert.Equal(3, sequence.Children.Count);
 
 			Assert.Equal("a scalar", ((YamlScalarNode)sequence.Children[0]).Value);
@@ -62,136 +59,19 @@ namespace YamlDotNet.RepresentationModel.Test
 		
 		[Fact]
 		public void ForwardAliasReferenceWorks() {
-			YamlStream stream = new YamlStream();
+			var stream = new YamlStream();
 			stream.Load(YamlFile("forwardAlias.yaml"));
 			
 			Assert.Equal(1, stream.Documents.Count);
 			Assert.IsType<YamlSequenceNode>(stream.Documents[0].RootNode);
 
-			YamlSequenceNode sequence = (YamlSequenceNode)stream.Documents[0].RootNode;
+			var sequence = (YamlSequenceNode)stream.Documents[0].RootNode;
 			Assert.Equal(3, sequence.Children.Count);
 
 			Assert.Equal("a scalar", ((YamlScalarNode)sequence.Children[0]).Value);
 			Assert.Equal("another scalar", ((YamlScalarNode)sequence.Children[1]).Value);
 			Assert.Equal("a scalar", ((YamlScalarNode)sequence.Children[2]).Value);
 			Assert.Same(sequence.Children[0], sequence.Children[2]);
-		}
-
-		private enum YamlNodeEventType
-		{
-			SequenceStart,
-			SequenceEnd,
-			MappingStart,
-			MappingEnd,
-			Scalar,
-		}
-
-		private class YamlNodeEvent
-		{
-			public YamlNodeEventType Type
-			{
-				get;
-				private set;
-			}
-
-			public string Anchor
-			{
-				get;
-				private set;
-			}
-
-			public string Tag
-			{
-				get;
-				private set;
-			}
-
-			public string Value
-			{
-				get;
-				private set;
-			}
-
-			public YamlNodeEvent(YamlNodeEventType type, string anchor, string tag, string value)
-			{
-				Type = type;
-				Anchor = anchor;
-				Tag = tag;
-				Value = value;
-			}
-		}
-
-		private class YamlDocumentStructureBuilder : YamlVisitor
-		{
-			private readonly List<YamlNodeEvent> events = new List<YamlNodeEvent>();
-
-			public IList<YamlNodeEvent> Events
-			{
-				get
-				{
-					return events;
-				}
-			}
-
-			protected override void Visit(YamlScalarNode scalar)
-			{
-				events.Add(new YamlNodeEvent(YamlNodeEventType.Scalar, scalar.Anchor, scalar.Tag, scalar.Value));
-			}
-
-			protected override void Visit(YamlSequenceNode sequence)
-			{
-				events.Add(new YamlNodeEvent(YamlNodeEventType.SequenceStart, sequence.Anchor, sequence.Tag, null));
-			}
-
-			protected override void Visited(YamlSequenceNode sequence)
-			{
-				events.Add(new YamlNodeEvent(YamlNodeEventType.SequenceEnd, sequence.Anchor, sequence.Tag, null));
-			}
-
-			protected override void Visit(YamlMappingNode mapping)
-			{
-				events.Add(new YamlNodeEvent(YamlNodeEventType.MappingStart, mapping.Anchor, mapping.Tag, null));
-			}
-
-			protected override void Visited(YamlMappingNode mapping)
-			{
-				events.Add(new YamlNodeEvent(YamlNodeEventType.MappingEnd, mapping.Anchor, mapping.Tag, null));
-			}
-		}
-
-		private void RoundtripTest(string yamlFileName)
-		{
-			YamlStream original = new YamlStream();
-			original.Load(YamlFile(yamlFileName));
-
-			StringBuilder buffer = new StringBuilder();
-			original.Save(new StringWriter(buffer));
-
-			Console.WriteLine(buffer.ToString());
-
-			YamlStream final = new YamlStream();
-			final.Load(new StringReader(buffer.ToString()));
-
-			YamlDocumentStructureBuilder originalBuilder = new YamlDocumentStructureBuilder();
-			original.Accept(originalBuilder);
-
-			YamlDocumentStructureBuilder finalBuilder = new YamlDocumentStructureBuilder();
-			final.Accept(finalBuilder);
-
-			Console.WriteLine("The original document produced {0} events.", originalBuilder.Events.Count);
-			Console.WriteLine("The final document produced {0} events.", finalBuilder.Events.Count);
-			Assert.Equal(originalBuilder.Events.Count, finalBuilder.Events.Count);
-
-			for (int i = 0; i < originalBuilder.Events.Count; ++i)
-			{
-				YamlNodeEvent originalEvent = originalBuilder.Events[i];
-				YamlNodeEvent finalEvent = finalBuilder.Events[i];
-
-				Assert.Equal(originalEvent.Type, finalEvent.Type);
-				//Assert.Equal(originalEvent.Tag, finalEvent.Tag);
-				//Assert.Equal(originalEvent.Anchor, finalEvent.Anchor);
-				Assert.Equal(originalEvent.Value, finalEvent.Value);
-			}
 		}
 
 		[Fact]
@@ -285,29 +165,119 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void RoundtripSample()
-		{
-			YamlStream original = new YamlStream();
-			original.Load(YamlFile("sample.yaml"));
-
-			original.Accept(new TracingVisitor());
-			
-			//RoundtripTest("sample.yaml");
-		}
-
-		[Fact]
 		public void FailBackreference()
 		{
-			//YamlStream original = new YamlStream();
-			//original.Load(YamlFile("fail-backreference.yaml"));
 			RoundtripTest("fail-backreference.yaml");
 		}
 
 		[Fact]
 		public void AllAliasesMustBeResolved()
 		{
-			YamlStream original = new YamlStream();
+			var original = new YamlStream();
 			Assert.Throws<AnchorNotFoundException>(() => original.Load(YamlFile("invalid-reference.yaml")));
+		}
+
+		private void RoundtripTest(string yamlFileName)
+		{
+			var original = new YamlStream();
+			original.Load(YamlFile(yamlFileName));
+
+			var buffer = new StringBuilder();
+			original.Save(new StringWriter(buffer));
+
+			Dump.WriteLine(buffer);
+
+			var final = new YamlStream();
+			final.Load(new StringReader(buffer.ToString()));
+
+			var originalBuilder = new YamlDocumentStructureBuilder();
+			original.Accept(originalBuilder);
+
+			var finalBuilder = new YamlDocumentStructureBuilder();
+			final.Accept(finalBuilder);
+
+			Dump.WriteLine("The original document produced {0} events.", originalBuilder.Events.Count);
+			Dump.WriteLine("The final document produced {0} events.", finalBuilder.Events.Count);
+			Assert.Equal(originalBuilder.Events.Count, finalBuilder.Events.Count);
+
+			for (var i = 0; i < originalBuilder.Events.Count; ++i)
+			{
+				var originalEvent = originalBuilder.Events[i];
+				var finalEvent = finalBuilder.Events[i];
+
+				Assert.Equal(originalEvent.Type, finalEvent.Type);
+				Assert.Equal(originalEvent.Value, finalEvent.Value);
+			}
+		}
+
+		private class YamlDocumentStructureBuilder : YamlVisitor
+		{
+			private readonly List<YamlNodeEvent> events = new List<YamlNodeEvent>();
+
+			public IList<YamlNodeEvent> Events
+			{
+				get {
+					return events;
+				}
+			}
+
+			protected override void Visit(YamlScalarNode scalar)
+			{
+				events.Add(new YamlNodeEvent(YamlNodeEventType.Scalar, scalar.Anchor, scalar.Tag, scalar.Value));
+			}
+
+			protected override void Visit(YamlSequenceNode sequence)
+			{
+				events.Add(new YamlNodeEvent(YamlNodeEventType.SequenceStart, sequence.Anchor, sequence.Tag, null));
+			}
+
+			protected override void Visited(YamlSequenceNode sequence)
+			{
+				events.Add(new YamlNodeEvent(YamlNodeEventType.SequenceEnd, sequence.Anchor, sequence.Tag, null));
+			}
+
+			protected override void Visit(YamlMappingNode mapping)
+			{
+				events.Add(new YamlNodeEvent(YamlNodeEventType.MappingStart, mapping.Anchor, mapping.Tag, null));
+			}
+
+			protected override void Visited(YamlMappingNode mapping)
+			{
+				events.Add(new YamlNodeEvent(YamlNodeEventType.MappingEnd, mapping.Anchor, mapping.Tag, null));
+			}
+		}
+
+		private class YamlNodeEvent
+		{
+			public YamlNodeEventType Type { get; private set; }
+			public string Anchor { get; private set; }
+			public string Tag { get; private set; }
+			public string Value { get; private set; }
+
+			public YamlNodeEvent(YamlNodeEventType type, string anchor, string tag, string value) {
+				Type = type;
+				Anchor = anchor;
+				Tag = tag;
+				Value = value;
+			}
+		}
+
+		private enum YamlNodeEventType
+		{
+			SequenceStart,
+			SequenceEnd,
+			MappingStart,
+			MappingEnd,
+			Scalar,
+		}
+
+		// Todo: Sample.. belongs elsewhere?
+		[Fact]
+		public void RoundtripSample()
+		{
+			var original = new YamlStream();
+			original.Load(YamlFile("sample.yaml"));
+			original.Accept(new TracingVisitor());
 		}
 	}
 }


### PR DESCRIPTION
I suggest this change as a step toward fully automated tests. The text dumping can be disabled with the conditional symbol TEST_DUMP so I can skip it while refactoring, while others can still view it.
