### PR TITLE
Added alternative .yml file extension support.

### DIFF
--- a/YamlDotNetEditor/FileAndContentTypeDefinitions.cs
+++ b/YamlDotNetEditor/FileAndContentTypeDefinitions.cs
@@ -26,8 +26,6 @@ namespace YamlDotNetEditor
 {
 	internal static class FileAndContentTypeDefinitions
 	{
-		public const string FileExtension = ".yaml";
-
 #pragma warning disable 0649	// Field is never assigned
 		[Export]
 		[Name("yaml")]
@@ -35,9 +33,14 @@ namespace YamlDotNetEditor
 		internal static ContentTypeDefinition hidingContentTypeDefinition;
 
 		[Export]
-		[FileExtension(FileExtension)]
+		[FileExtension(".yaml")]
 		[ContentType("yaml")]
-		internal static FileExtensionToContentTypeDefinition hiddenFileExtensionDefinition;
+		internal static FileExtensionToContentTypeDefinition hiddenYAMLFileExtensionDefinition;
+
+		[Export]
+		[FileExtension(".yml")]
+		[ContentType("yaml")]
+		internal static FileExtensionToContentTypeDefinition hiddenYMLFileExtensionDefinition;
 #pragma warning restore 0649
 	}
 }


### PR DESCRIPTION
I've started using Visual Studio for PHP development and I've found YamlDotNetEditor extension really useful. But the problem is that extension only highlights .yaml files, and in Symphony (PHP framework I use) configuration files are using .yml extension by convention.

So this pull request just registers yaml content type with both .yaml and .yml file extensions.
