### PR TITLE
Refactor of the serialization tests

### DIFF
--- a/YamlDotNet.RepresentationModel.Test/SerializationTests.cs
+++ b/YamlDotNet.RepresentationModel.Test/SerializationTests.cs
@@ -42,35 +42,66 @@ namespace YamlDotNet.RepresentationModel.Test
 	public class SerializationTests : YamlTest
 	{
 		[Fact]
-		public void Roundtrip()
+		public void DeserializeEmptyDocument()
 		{
-			ShouldRountripWithOptions(SerializationOptions.Roundtrip);
-		}
-
-		[Fact]
-		public void RoundtripWithDefaults()
-		{
-			ShouldRountripWithOptions(SerializationOptions.Roundtrip | SerializationOptions.EmitDefaults);
-		}
-
-		private void ShouldRountripWithOptions(SerializationOptions options)
-		{
-			var buffer = new StringWriter();
-			var serializer = new Serializer(options);
-
-			var original = new X();
-			serializer.Serialize(buffer, original);
-
-			Dump.WriteLine(buffer);
-
 			var deserializer = new Deserializer();
-			var copy = deserializer.Deserialize<X>(UsingReaderFor(buffer));
 
-			copy.ShouldHave().AllProperties().EqualTo(original);
+			var array = deserializer.Deserialize<int[]>(UsingReaderFor(""));
+
+			array.Should().BeNull();
 		}
 
 		[Fact]
-		public void CircularReference()
+		public void DeserializeScalar()
+		{
+			var deserializer = new Deserializer();
+
+			var result = deserializer.Deserialize(YamlFile("test2.yaml"));
+
+			result.Should().Be("a scalar");
+		}
+
+		[Fact]
+		public void RoundtripEnums()
+		{
+			var serializer = new Serializer();
+			var deserializer = new Deserializer();
+			var buffer = new StringWriter();
+			var flags = EnumFlags.One | EnumFlags.Two;
+
+			serializer.Serialize(buffer, flags);
+			var result = deserializer.Deserialize<EnumFlags>(UsingReaderFor(buffer));
+
+			result.Should().Be(flags);
+		}
+
+		[Flags]
+		public enum EnumFlags
+		{
+			None,
+			One,
+			Two
+		}
+
+		[Fact]
+		public void SerializeAnonymousType()
+		{
+			var serializer = new Serializer();
+			var deserializer = new Deserializer();
+			var buffer = new StringWriter();
+			var data = new { Key = 3 };
+
+			serializer.Serialize(buffer, data);
+			Dump.WriteLine(buffer);
+			var result = deserializer.Deserialize<Dictionary<string, string>>(UsingReaderFor(buffer));
+
+			result.Should().Equal(new Dictionary<string, string> {
+				{ "Key", "3" }
+			});
+		}
+
+		[Fact]
+		public void SerializeCircularReference()
 		{
 			var serializer = new Serializer(SerializationOptions.Roundtrip);
 			var buffer = new StringWriter();
@@ -92,13 +123,16 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void DeserializeScalar()
+		public void DeserializeCustomTags()
 		{
 			var deserializer = new Deserializer();
 
-			var result = deserializer.Deserialize(YamlFile("test2.yaml"));
+			deserializer.RegisterTagMapping("tag:yaml.org,2002:point", typeof(Point));
+			var result = deserializer.Deserialize(YamlFile("tags.yaml"));
 
-			result.Should().Be("a scalar");
+			result.Should().BeOfType<Point>().And
+				.Subject.As<Point>().ShouldHave()
+				.SharedProperties().EqualTo(new { X = 10, Y = 20 });
 		}
 
 		[Fact]
@@ -109,140 +143,6 @@ namespace YamlDotNet.RepresentationModel.Test
 			var result = deserializer.Deserialize<Z>(YamlFile("explicitType.yaml"));
 
 			result.aaa.Should().Be("bbb");
-		}
-
-		[Fact]
-		public void DeserializeDictionary()
-		{
-			var deserializer = new Deserializer();
-
-			var result = deserializer.Deserialize(YamlFile("dictionary.yaml"));
-
-			result.Should().BeAssignableTo<IDictionary<object, object>>().And.Subject
-				.As<IDictionary<object, object>>().Should().Equal(new Dictionary<object, object> {
-					{ "key1", "value1" },
-					{ "key2", "value2" }
-				});
-		}
-
-		[Fact]
-		public void DeserializeExplicitDictionary()
-		{
-			var deserializer = new Deserializer();
-
-			var result = deserializer.Deserialize(YamlFile("dictionaryExplicit.yaml"));
-
-			result.Should().BeAssignableTo<IDictionary<string, int>>().And.Subject
-				.As<IDictionary<string, int>>().Should().Equal(new Dictionary<string, int> {
-					{ "key1", 1 },
-					{ "key2", 2 }
-				});
-		}
-
-		[Fact]
-		public void DeserializeListOfDictionaries()
-		{
-			var deserializer = new Deserializer();
-
-			var result = deserializer.Deserialize<List<Dictionary<string, string>>>(YamlFile("listOfDictionaries.yaml"));
-
-			result.ShouldBeEquivalentTo(new [] {
-				new Dictionary<string, string> {
-					{ "connection", "conn1" },
-					{ "path", "path1" }
-				},
-				new Dictionary<string, string> {
-					{ "connection", "conn2" },
-					{ "path", "path2" }
-				}}, opt => opt.WithStrictOrderingFor(root => root));
-		}
-
-		[Fact]
-		public void DeserializeList()
-		{
-			var deserializer = new Deserializer();
-			
-			var result = deserializer.Deserialize(YamlFile("list.yaml"));
-
-			result.Should().BeAssignableTo<IList>().And
-				.Subject.As<IList>().Should().Equal(new[] { "one", "two", "three" });
-		}
-
-		[Fact]
-		public void DeserializeExplicitList()
-		{
-			var deserializer = new Deserializer();
-
-			var result = deserializer.Deserialize(YamlFile("listExplicit.yaml"));
-
-			result.Should().BeAssignableTo<IList<int>>().And
-				.Subject.As<IList<int>>().Should().Equal(3, 4, 5);
-		}
-
-		[Fact]
-		public void DeserializeEnumerable()
-		{
-			var serializer = new Serializer();
-			var deserializer = new Deserializer();
-			var buffer = new StringWriter();
-			var z = new[] { new Z { aaa = "Yo" }};
-
-			serializer.Serialize(buffer, z);
-			var result = deserializer.Deserialize<IEnumerable<Z>>(UsingReaderFor(buffer));
-
-			result.Should().ContainSingle(item => "Yo".Equals(item.aaa));
-		}
-
-		[Fact]
-		public void RoundtripList()
-		{
-			var serializer = new Serializer(SerializationOptions.Roundtrip);
-			var deserializer = new Deserializer();
-			var buffer = new StringWriter();
-			var original = new List<int> { 2, 4, 6 };
-
-			serializer.Serialize(buffer, original, typeof(List<int>));
-			Dump.WriteLine(buffer);
-			var copy = deserializer.Deserialize<List<int>>(UsingReaderFor(buffer));
-
-			copy.Should().Equal(original);
-		}
-
-		[Fact]
-		public void DeserializeArray()
-		{
-			var deserializer = new Deserializer();
-
-			var result = deserializer.Deserialize<String[]>(YamlFile("list.yaml"));
-
-			result.Should().Equal(new[] { "one", "two", "three" });
-		}
-
-		[Fact]
-		public void Enums()
-		{
-			var serializer = new Serializer();
-			var deserializer = new Deserializer();
-			var buffer = new StringWriter();
-			var flags = StringFormatFlags.NoClip | StringFormatFlags.NoFontFallback;
-
-			serializer.Serialize(buffer, flags);
-			var result = deserializer.Deserialize<StringFormatFlags>(UsingReaderFor(buffer));
-
-			result.Should().Be(flags);
-		}
-
-		[Fact]
-		public void CustomTags()
-		{
-			var deserializer = new Deserializer();
-
-			deserializer.RegisterTagMapping("tag:yaml.org,2002:point", typeof(Point));
-			var result = deserializer.Deserialize(YamlFile("tags.yaml"));
-
-			result.Should().BeOfType<Point>().And
-				.Subject.As<Point>().ShouldHave()
-				.SharedProperties().EqualTo(new { X = 10, Y = 20 });
 		}
 
 		[Fact]
@@ -272,8 +172,7 @@ namespace YamlDotNet.RepresentationModel.Test
 				if (!(value is string))
 					throw new InvalidOperationException();
 				var parts = (value as string).Split(' ');
-				return new Convertible
-				{
+				return new Convertible {
 					Left = parts[0],
 					Right = parts[1]
 				};
@@ -379,7 +278,62 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void RoundtripWithTypeConverter()
+		public void DeserializationOfObjectsHandlesForwardReferences()
+		{
+			var deserializer = new Deserializer();
+			var text = Lines(
+				"Nothing: *forward",
+				"MyString: &forward ForwardReference");
+
+			var result = deserializer.Deserialize<X>(UsingReaderFor(text));
+
+			result.ShouldHave().SharedProperties().EqualTo(
+				new { Nothing = "ForwardReference", MyString = "ForwardReference" });
+		}
+
+		[Fact]
+		public void DeserializationFailsForUndefinedForwardReferences()
+		{
+			var deserializer = new Deserializer();
+			var text = Lines(
+				"Nothing: *forward",
+				"MyString: ForwardReference");
+
+			Action action = () => deserializer.Deserialize<X>(UsingReaderFor(text));
+
+			action.ShouldThrow<AnchorNotFoundException>();
+		}
+
+		[Fact]
+		public void RoundtripObject()
+		{
+			ShouldRountripWithOptions(SerializationOptions.Roundtrip);
+		}
+
+		[Fact]
+		public void RoundtripObjectWithDefaults()
+		{
+			ShouldRountripWithOptions(SerializationOptions.Roundtrip | SerializationOptions.EmitDefaults);
+		}
+
+		private void ShouldRountripWithOptions(SerializationOptions options)
+		{
+			var buffer = new StringWriter();
+			var serializer = new Serializer(options);
+
+			var original = new X();
+			serializer.Serialize(buffer, original);
+
+			Dump.WriteLine(buffer);
+
+			var deserializer = new Deserializer();
+			var copy = deserializer.Deserialize<X>(UsingReaderFor(buffer));
+
+			copy.ShouldHave().AllProperties().EqualTo(original);
+		}
+
+		[Fact]
+		public void RoundtripWithYamlTypeConverter()
 		{
 			var serializer = new Serializer(SerializationOptions.Roundtrip);
 			var deserializer = new Deserializer();
@@ -396,10 +350,10 @@ namespace YamlDotNet.RepresentationModel.Test
 			copy.Value.Should().Be("Yo");
 		}
 
-		// Fails in serialization unless a type converter is specified
-		class ParameterizedCtor
+		public class ParameterizedCtor
 		{
 			public string Value;
+			// Fails in serialization unless a type converter is specified
 			public ParameterizedCtor(string value) { Value = value; }
 		}
 
@@ -412,146 +366,39 @@ namespace YamlDotNet.RepresentationModel.Test
 
 			public object ReadYaml(IParser parser, Type type)
 			{
-				var value = ((Scalar) parser.Current).Value;
+				var value = ((Scalar)parser.Current).Value;
 				parser.MoveNext();
 				return new ParameterizedCtor(value);
 			}
 
 			public void WriteYaml(IEmitter emitter, object value, Type type)
 			{
-				emitter.Emit(new Scalar(((ParameterizedCtor) value).Value));
+				emitter.Emit(new Scalar(((ParameterizedCtor)value).Value));
 			}
 		}
 
 		[Fact]
-		public void RoundtripDictionary()
+		public void RoundtripAlias()
 		{
 			var serializer = new Serializer();
 			var deserializer = new Deserializer();
-			var buffer = new StringWriter();
-			var entries = new Dictionary<string, string> {
-				{ "key1", "value1" },
-				{ "key2", "value2" },
-				{ "key3", "value3" },
-			};
+			var writer = new StringWriter();
+			var input = new ConventionTest { AliasTest = "Fourth" };
 
-			serializer.Serialize(buffer, entries);
-			Dump.WriteLine(buffer);
-			var result = deserializer.Deserialize<Dictionary<string, string>>(UsingReaderFor(buffer));
+			serializer.Serialize(writer, input, input.GetType());
+			var text = writer.ToString();
 
-			result.Should().Equal(entries);
+			// Todo: use RegEx once FluentAssertions 2.2 is released
+			text.TrimEnd('\r', '\n').Should().Be("fourthTest: Fourth");
+
+			var output = deserializer.Deserialize<ConventionTest>(UsingReaderFor(text));
+
+			output.AliasTest.Should().Be(input.AliasTest);
 		}
 
 		[Fact]
-		public void SerializeAnonymousType()
-		{
-			var serializer = new Serializer();
-			var deserializer = new Deserializer();
-			var buffer = new StringWriter();
-			var data = new { Key = 3 };
-
-			serializer.Serialize(buffer, data);
-			Dump.WriteLine(buffer);
-			var result = deserializer.Deserialize<Dictionary<string, string>>(UsingReaderFor(buffer));
-
-			result.Should().Equal(new Dictionary<string, string> {
-				{ "Key", "3" }
-			});
-		}
-
-		[Fact]
-		public void SerializationIncludesNullWhenAsked()
-		{
-			var serializer = new Serializer(SerializationOptions.EmitDefaults);
-			var buffer = new StringWriter();
-			var original = new X { MyString = null };
-
-			serializer.Serialize(buffer, original, typeof(X));
-			Dump.WriteLine(buffer);
-
-			buffer.ToString().Should().Contain("MyString");
-		}
-
-		[Fact]
-		[Trait("Motive", "Bug fix")]
-		public void SerializationIncludesNullWhenAskedAboutAnonymousType()
-		{
-			var serializer = new Serializer(SerializationOptions.EmitDefaults);
-			var buffer = new StringWriter();
-			var original = new { MyString = (string) null };
-			
-			serializer.Serialize(buffer, original, original.GetType());
-			Dump.WriteLine(buffer);
-
-			buffer.ToString().Should().Contain("MyString");
-		}
-
-		[Fact]
-		public void SerializationDoesNotIncludeNullWhenNotAsked()
-		{
-			var serializer = new Serializer();
-			var buffer = new StringWriter();
-			var original = new X { MyString = null };
-
-			serializer.Serialize(buffer, original, typeof(X));
-			Dump.WriteLine(buffer);
-
-			buffer.ToString().Should().NotContain("MyString");
-		}
-
-		[Fact]
-		public void SerializationOfNullWorksInJson()
-		{
-			var serializer = new Serializer(SerializationOptions.EmitDefaults | SerializationOptions.JsonCompatible);
-			var buffer = new StringWriter();
-			var original = new X { MyString = null };
-
-			serializer.Serialize(buffer, original, typeof(X));
-			Dump.WriteLine(buffer);
-
-			buffer.ToString().Should().Contain("MyString");
-		}
-
-		[Fact]
-		public void DeserializationOfNullWorksInJson()
-		{
-			var options = SerializationOptions.EmitDefaults | SerializationOptions.JsonCompatible | SerializationOptions.Roundtrip;
-			var serializer = new Serializer(options);
-			var deserializer = new Deserializer();
-			var buffer = new StringWriter();
-			var original = new X { MyString = null };
-
-			serializer.Serialize(buffer, original, typeof(X));
-			Dump.WriteLine(buffer);
-			var copy = deserializer.Deserialize<X>(UsingReaderFor(buffer));
-
-			copy.MyString.Should().BeNull();
-		}
-
-		[Fact]
-		public void SerializationRespectsYamlIgnoreAttribute()
-		{
-			var serializer = new Serializer();
-			var deserializer = new Deserializer();
-			var buffer = new StringWriter();
-			var original = new ContainsIgnore { IgnoreMe = "Some Text" };
-
-			serializer.Serialize(buffer, original);
-			Dump.WriteLine(buffer);
-			var copy = deserializer.Deserialize<ContainsIgnore>(UsingReaderFor(buffer));
-
-			copy.IgnoreMe.Should().BeNull();
-		}
-
-		public class ContainsIgnore
-		{
-			[YamlIgnore]
-			public String IgnoreMe { get; set; }
-		}
-
 		// Todo: is the assert on the string necessary?
-		[Fact]
-		public void RoundtripWithPolymorphism()
+		public void RoundtripDerivedClass()
 		{
 			var serializer = new Serializer(SerializationOptions.Roundtrip);
 			var deserializer = new Deserializer();
@@ -570,14 +417,13 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void RoundtripWithSerializeAs()
+		public void RoundtripDerivedClassWithSerializeAs()
 		{
 			var serializer = new Serializer(SerializationOptions.Roundtrip);
 			var deserializer = new Deserializer();
 
 			var buffer = new StringWriter();
-			serializer.Serialize(buffer, new ParentChildContainer
-			{
+			serializer.Serialize(buffer, new ParentChildContainer {
 				SomeScalar = "Hello",
 				ParentWithSerializeAs = new Child { ParentProp = "foo", ChildProp = "bar" },
 			});
@@ -607,37 +453,100 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void SerializeArrayOfIdenticalObjects()
-		{
-			var z = new Z { aaa = "abc" };
-			var objects = new[] { z, z, z };
-
-			var result = SerializeThenDeserialize(objects);
-
-			result.Should().HaveCount(3).And.OnlyContain(x => z.aaa.Equals(x.aaa));
-			result[0].Should().BeSameAs(result[1]).And.BeSameAs(result[2]);
-		}
-
-		private T SerializeThenDeserialize<T>(T input)
+		public void DeserializeEnumerable()
 		{
 			var serializer = new Serializer();
-			var writer = new StringWriter();
-			serializer.Serialize(writer, input, typeof(T));
-
-			Dump.WriteLine("serialized =\n-----\n{0}", writer);
-
 			var deserializer = new Deserializer();
-			return deserializer.Deserialize<T>(UsingReaderFor(writer));
+			var buffer = new StringWriter();
+			var z = new[] { new Z { aaa = "bbb" }};
+
+			serializer.Serialize(buffer, z);
+			var result = deserializer.Deserialize<IEnumerable<Z>>(UsingReaderFor(buffer));
+
+			result.Should().ContainSingle(item => "bbb".Equals(item.aaa));
 		}
 
 		[Fact]
-		public void BoxedArray()
+		public void DeserializeArray()
+		{
+			var deserializer = new Deserializer();
+
+			var result = deserializer.Deserialize<String[]>(YamlFile("list.yaml"));
+
+			result.Should().Equal(new[] { "one", "two", "three" });
+		}
+
+		[Fact]
+		public void DeserializeList()
+		{
+			var deserializer = new Deserializer();
+			
+			var result = deserializer.Deserialize(YamlFile("list.yaml"));
+
+			result.Should().BeAssignableTo<IList>().And
+				.Subject.As<IList>().Should().Equal(new[] { "one", "two", "three" });
+		}
+
+		[Fact]
+		public void DeserializeExplicitList()
+		{
+			var deserializer = new Deserializer();
+
+			var result = deserializer.Deserialize(YamlFile("listExplicit.yaml"));
+
+			result.Should().BeAssignableTo<IList<int>>().And
+				.Subject.As<IList<int>>().Should().Equal(3, 4, 5);
+		}
+
+		[Fact]
+		public void DeserializationOfGenericListsHandlesForwardReferences()
+		{
+			var deserializer = new Deserializer();
+			var text = Lines(
+				"- *forward",
+				"- &forward ForwardReference");
+
+			var result = deserializer.Deserialize<string[]>(UsingReaderFor(text));
+
+			result.Should().Equal(new[] { "ForwardReference", "ForwardReference" });
+		}
+
+		[Fact]
+		public void DeserializationOfNonGenericListsHandlesForwardReferences()
+		{
+			var deserializer = new Deserializer();
+			var text = Lines(
+				"- *forward",
+				"- &forward ForwardReference");
+
+			var result = deserializer.Deserialize<ArrayList>(UsingReaderFor(text));
+
+			result.Should().Equal(new[] { "ForwardReference", "ForwardReference" });
+		}
+
+		[Fact]
+		public void RoundtripList()
+		{
+			var serializer = new Serializer(SerializationOptions.Roundtrip);
+			var deserializer = new Deserializer();
+			var buffer = new StringWriter();
+			var original = new List<int> { 2, 4, 6 };
+
+			serializer.Serialize(buffer, original, typeof(List<int>));
+			Dump.WriteLine(buffer);
+			var copy = deserializer.Deserialize<List<int>>(UsingReaderFor(buffer));
+
+			copy.Should().Equal(original);
+		}
+
+		[Fact]
+		public void RoundtripArrayWithTypeConversion()
 		{
 			var serializer = new Serializer();
 			var deserializer = new Deserializer();
 			var buffer = new StringWriter();
 
-			serializer.Serialize(buffer, new object[] {1, 2, "3"});
+			serializer.Serialize(buffer, new object[] { 1, 2, "3" });
 			Dump.WriteLine(buffer);
 			var result = deserializer.Deserialize<int[]>(UsingReaderFor(buffer));
 
@@ -645,60 +554,20 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void SerializeUsingCamelCaseNaming()
+		public void RoundtripArrayOfIdenticalObjects()
 		{
-			var obj = new { foo = "bar", moreFoo = "More bar", evenMoreFoo = "Awesome" };
+			var serializer = new Serializer();
+			var deserializer = new Deserializer();
+			var buffer = new StringWriter();
+			var z = new Z { aaa = "abc" };
+			var objects = new[] { z, z, z };
 
-			var result = SerializeWithNaming(obj, new CamelCaseNamingConvention());
+			serializer.Serialize(buffer, objects, typeof(Z[]));
+			Dump.WriteLine(buffer);
+			var result = deserializer.Deserialize<Z[]>(UsingReaderFor(buffer));
 
-			result.Should().Contain("foo: bar").And
-				.Contain("moreFoo: More bar").And
-				.Contain("evenMoreFoo: Awesome");
-		}
-
-		[Fact]
-		public void SerializeUsingPascalCaseNaming()
-		{
-			var obj = new { foo = "bar", moreFoo = "More bar", evenMoreFoo = "Awesome" };
-
-			var result = SerializeWithNaming(obj, new PascalCaseNamingConvention());
-			Dump.WriteLine(result);
-
-			result.Should().Contain("Foo: bar").And
-				.Contain("MoreFoo: More bar").And
-				.Contain("EvenMoreFoo: Awesome");
-		}
-
-		[Fact]
-		public void SerializeUsingHyphenationNaming()
-		{
-			var obj = new { foo = "bar", moreFoo = "More bar", EvenMoreFoo = "Awesome" };
-
-			var result = SerializeWithNaming(obj, new HyphenatedNamingConvention());
-
-			result.Should().Contain("foo: bar").And
-				.Contain("more-foo: More bar").And
-				.Contain("even-more-foo: Awesome");
-		}
-
-		[Fact]
-		public void SerializeUsingUnderscoreNaming()
-		{
-			var obj = new { foo = "bar", moreFoo = "More bar", EvenMoreFoo = "Awsome" };
-
-			var result = SerializeWithNaming(obj, new UnderscoredNamingConvention());
-
-			result.Should().Contain("foo: bar").And
-				.Contain("more_foo: More bar").And
-				.Contain("even_more_foo: Awsome");
-		}
-
-		private string SerializeWithNaming<T>(T input, INamingConvention naming)
-		{
-			var serializer = new Serializer(namingConvention: naming);
-			var writer = new StringWriter();
-			serializer.Serialize(writer, input, typeof(T));
-			return writer.ToString();
+			result.Should().HaveCount(3).And.OnlyContain(x => z.aaa.Equals(x.aaa));
+			result[0].Should().BeSameAs(result[1]).And.BeSameAs(result[2]);
 		}
 
 		public class Z
@@ -706,93 +575,317 @@ namespace YamlDotNet.RepresentationModel.Test
 			public string aaa { get; set; }
 		}
 
-		// Todo: are these needed? Naming convention classes are tested elsewhere
 		[Fact]
-		public void DeserializeUsingCamelCaseNamingConvention()
+		public void DeserializeDictionary()
 		{
-			DeserializeUsing(new CamelCaseNamingConvention(),
-				"firstTest: First",
-				"secondTest: Second",
-				"thirdTest: Third",
-				"fourthTest: Fourth");
+			var deserializer = new Deserializer();
+
+			var result = deserializer.Deserialize(YamlFile("dictionary.yaml"));
+
+			result.Should().BeAssignableTo<IDictionary<object, object>>().And.Subject
+				.As<IDictionary<object, object>>().Should().Equal(new Dictionary<object, object> {
+					{ "key1", "value1" },
+					{ "key2", "value2" }
+				});
 		}
 
 		[Fact]
-		public void DeserializeUsingHyphenatedNamingConvention()
+		public void DeserializeExplicitDictionary()
 		{
-			DeserializeUsing(new HyphenatedNamingConvention(),
-				"first-test: First",
-				"second-test: Second",
-				"third-test: Third",
-				"fourthTest: Fourth");
+			var deserializer = new Deserializer();
+
+			var result = deserializer.Deserialize(YamlFile("dictionaryExplicit.yaml"));
+
+			result.Should().BeAssignableTo<IDictionary<string, int>>().And.Subject
+				.As<IDictionary<string, int>>().Should().Equal(new Dictionary<string, int> {
+					{ "key1", 1 },
+					{ "key2", 2 }
+				});
 		}
 
 		[Fact]
-		public void DeserializeUsingPascalCaseNamingConvention()
+		public void RoundtripDictionary()
 		{
-			DeserializeUsing(new PascalCaseNamingConvention(),
-				"FirstTest: First",
-				"SecondTest: Second",
-				"ThirdTest: Third",
-				"fourthTest: Fourth");
+			var serializer = new Serializer();
+			var deserializer = new Deserializer();
+			var buffer = new StringWriter();
+			var entries = new Dictionary<string, string> {
+				{ "key1", "value1" },
+				{ "key2", "value2" },
+				{ "key3", "value3" },
+			};
+
+			serializer.Serialize(buffer, entries);
+			Dump.WriteLine(buffer);
+			var result = deserializer.Deserialize<Dictionary<string, string>>(UsingReaderFor(buffer));
+
+			result.Should().Equal(entries);
 		}
 
 		[Fact]
-		public void DeserializeUsingUnderscoredNamingConvention()
+		public void DeserializationOfGenericDictionariesHandlesForwardReferences()
 		{
-			DeserializeUsing(new UnderscoredNamingConvention(),
-				"first_test: First",
-				"second_test: Second",
-				"third_test: Third",
-				"fourthTest: Fourth");
-		}
+			var deserializer = new Deserializer();
+			var text = Lines(
+				"key1: *forward",
+				"*forwardKey: ForwardKeyValue",
+				"*forward: *forward",
+				"key2: &forward ForwardReference",
+				"key3: &forwardKey key4");
 
-		private void DeserializeUsing(INamingConvention convention, params string[] yaml)
-		{
-			var deserializer = new Deserializer(namingConvention: convention);
+			var result = deserializer.Deserialize<Dictionary<string, string>>(UsingReaderFor(text));
 
-			var result = deserializer.Deserialize<ConventionTest>(UsingReaderFor(Lines(yaml)));
-
-			result.ShouldHave().SharedProperties().EqualTo(new {
-				FirstTest = "First",
-				SecondTest = "Second",
-				ThirdTest = "Third",
-				AliasTest = "Fourth"
+			result.Should().Equal(new Dictionary<string, string> {
+				{ "ForwardReference", "ForwardReference" },
+				{ "key1", "ForwardReference" },
+				{ "key2", "ForwardReference" },
+				{ "key4", "ForwardKeyValue" },
+				{ "key3", "key4" }
 			});
 		}
 
 		[Fact]
-		public void RoundtripAlias()
+		public void DeserializationOfNonGenericDictionariesHandlesForwardReferences()
 		{
-			var serializer = new Serializer();
 			var deserializer = new Deserializer();
-			var writer = new StringWriter();
-			var input = new ConventionTest { AliasTest = "Fourth" };
+			var text = Lines(
+				"key1: *forward",
+				"*forwardKey: ForwardKeyValue",
+				"*forward: *forward",
+				"key2: &forward ForwardReference",
+				"key3: &forwardKey key4");
 
-			serializer.Serialize(writer, input, input.GetType());
-			var text = writer.ToString();
+			var result = deserializer.Deserialize<Hashtable>(UsingReaderFor(text));
 
-			// Todo: use RegEx once FluentAssertions 2.2 is released
-			text.TrimEnd('\r', '\n').Should().Be("fourthTest: Fourth");
-
-			var output = deserializer.Deserialize<ConventionTest>(UsingReaderFor(text));
-
-			output.AliasTest.Should().Be(input.AliasTest);
+			result.Should().BeEquivalentTo(
+				Entry("ForwardReference", "ForwardReference"),
+				Entry("key1", "ForwardReference"),
+				Entry("key2", "ForwardReference"),
+				Entry("key4", "ForwardKeyValue"),
+				Entry("key3", "key4"));
 		}
 
-		public class ConventionTest
+		private object Entry(string key, string value)
 		{
-			public string FirstTest { get; set; }
-			public string SecondTest { get; set; }
-			public string ThirdTest { get; set; }
-			[YamlAlias("fourthTest")]
-			public string AliasTest { get; set; }
-			[YamlIgnore]
-			public string fourthTest { get; set; }
+			return new DictionaryEntry(key, value);
 		}
 
 		[Fact]
-		public void DefaultValueAttributeIsUsedWhenPresentWithoutEmitDefaults()
+		public void DeserializeListOfDictionaries()
+		{
+			var deserializer = new Deserializer();
+
+			var result = deserializer.Deserialize<List<Dictionary<string, string>>>(YamlFile("listOfDictionaries.yaml"));
+
+			result.ShouldBeEquivalentTo(new[] {
+				new Dictionary<string, string> {
+					{ "connection", "conn1" },
+					{ "path", "path1" }
+				},
+				new Dictionary<string, string> {
+					{ "connection", "conn2" },
+					{ "path", "path2" }
+				}}, opt => opt.WithStrictOrderingFor(root => root));
+		}
+
+		[Fact]
+		public void DeserializeTwoDocuments()
+		{
+			var deserializer = new Deserializer();
+			var reader = EventReaderFor(Lines(
+				"---",
+				"Name: Andy",
+				"---",
+				"Name: Brad",
+				"..."));
+
+			reader.Expect<StreamStart>();
+			var andy = deserializer.Deserialize<Person>(reader);
+			var brad = deserializer.Deserialize<Person>(reader);
+
+			andy.ShouldHave().AllProperties().EqualTo(new { Name = "Andy" });
+			brad.ShouldHave().AllProperties().EqualTo(new { Name = "Brad" });
+		}
+
+		[Fact]
+		public void DeserializeThreeDocuments()
+		{
+			var deserializer = new Deserializer();
+			var reader = EventReaderFor(Lines(
+				"---",
+				"Name: Andy",
+				"---",
+				"Name: Brad",
+				"---",
+				"Name: Charles",
+				"..."));
+
+			reader.Expect<StreamStart>();
+			var andy = deserializer.Deserialize<Person>(reader);
+			var brad = deserializer.Deserialize<Person>(reader);
+			var charles = deserializer.Deserialize<Person>(reader);
+
+			reader.Accept<StreamEnd>().Should().BeTrue("reader should have reach the end of stream");
+			andy.ShouldHave().AllProperties().EqualTo(new { Name = "Andy" });
+			brad.ShouldHave().AllProperties().EqualTo(new { Name = "Brad" });
+			charles.ShouldHave().AllProperties().EqualTo(new { Name = "Charles" });
+		}
+
+		private static EventReader EventReaderFor(string yaml)
+		{
+			return new EventReader(new Parser(new StringReader(yaml)));
+		}
+
+		public class Person
+		{
+			public string Name { get; set; }
+		}
+
+		[Fact]
+		public void SerializationOfNullInListsAreAlwaysEmittedWithoutUsingEmitDefaults()
+		{
+			var serializer = new Serializer();
+			var writer = new StringWriter();
+			var input = new[] { "foo", null, "bar" };
+
+			serializer.Serialize(writer, input);
+			var serialized = writer.ToString();
+			Dump.WriteLine(serialized);
+
+			Regex.Matches(serialized, "-").Count.Should().Be(3, "there should have been 3 elements");
+		}
+
+		[Fact]
+		public void SerializationOfNullInListsAreAlwaysEmittedWhenUsingEmitDefaults()
+		{
+			var serializer = new Serializer(SerializationOptions.EmitDefaults);
+			var writer = new StringWriter();
+			var input = new[] { "foo", null, "bar" };
+
+			serializer.Serialize(writer, input);
+			var serialized = writer.ToString();
+			Dump.WriteLine(serialized);
+
+			Regex.Matches(serialized, "-").Count.Should().Be(3, "there should have been 3 elements");
+		}
+
+		[Fact]
+		public void SerializationIncludesKeyWhenEmittingDefaults()
+		{
+			var serializer = new Serializer(SerializationOptions.EmitDefaults);
+			var buffer = new StringWriter();
+			var original = new X { MyString = null };
+
+			serializer.Serialize(buffer, original, typeof(X));
+			Dump.WriteLine(buffer);
+
+			buffer.ToString().Should().Contain("MyString");
+		}
+
+		[Fact]
+		[Trait("Motive", "Bug fix")]
+		public void SerializationIncludesKeyFromAnonymousTypeWhenEmittingDefaults()
+		{
+			var serializer = new Serializer(SerializationOptions.EmitDefaults);
+			var buffer = new StringWriter();
+			var original = new { MyString = (string) null };
+			
+			serializer.Serialize(buffer, original, original.GetType());
+			Dump.WriteLine(buffer);
+
+			buffer.ToString().Should().Contain("MyString");
+		}
+
+		[Fact]
+		public void SerializationDoesNotIncludeKeyWhenDisregardingDefaults()
+		{
+			var serializer = new Serializer();
+			var buffer = new StringWriter();
+			var original = new X { MyString = null };
+
+			serializer.Serialize(buffer, original, typeof(X));
+			Dump.WriteLine(buffer);
+
+			buffer.ToString().Should().NotContain("MyString");
+		}
+
+		[Fact]
+		public void SerializationOfDefaultsWorkInJson()
+		{
+			var serializer = new Serializer(SerializationOptions.EmitDefaults | SerializationOptions.JsonCompatible);
+			var buffer = new StringWriter();
+			var original = new X { MyString = null };
+
+			serializer.Serialize(buffer, original, typeof(X));
+			Dump.WriteLine(buffer);
+
+			buffer.ToString().Should().Contain("MyString");
+		}
+
+		[Fact]
+		public void DeserializationOfDefaultsWorkInJson()
+		{
+			var options = SerializationOptions.EmitDefaults | SerializationOptions.JsonCompatible | SerializationOptions.Roundtrip;
+			var serializer = new Serializer(options);
+			var deserializer = new Deserializer();
+			var buffer = new StringWriter();
+			var original = new X { MyString = null };
+
+			serializer.Serialize(buffer, original, typeof(X));
+			Dump.WriteLine(buffer);
+			var copy = deserializer.Deserialize<X>(UsingReaderFor(buffer));
+
+			copy.MyString.Should().BeNull();
+		}
+
+		public class X
+		{
+			public bool MyFlag { get; set; }
+			public string Nothing { get; set; }
+			public int MyInt { get; set; }
+			public double MyDouble { get; set; }
+			public string MyString { get; set; }
+			public DateTime MyDate { get; set; }
+			public TimeSpan MyTimeSpan { get; set; }
+			public Point MyPoint { get; set; }
+			public int? MyNullableWithValue { get; set; }
+			public int? MyNullableWithoutValue { get; set; }
+
+			public X()
+			{
+				MyInt = 1234;
+				MyDouble = 6789.1011;
+				MyString = "Hello world";
+				MyDate = DateTime.Now;
+				MyTimeSpan = TimeSpan.FromHours(1);
+				MyPoint = new Point(100, 200);
+				MyNullableWithValue = 8;
+			}
+		}
+
+		[Fact]
+		public void SerializationRespectsYamlIgnoreAttribute()
+		{
+			var serializer = new Serializer();
+			var deserializer = new Deserializer();
+			var buffer = new StringWriter();
+			var original = new ContainsIgnore { IgnoreMe = "Some Text" };
+
+			serializer.Serialize(buffer, original);
+			Dump.WriteLine(buffer);
+			var copy = deserializer.Deserialize<ContainsIgnore>(UsingReaderFor(buffer));
+
+			copy.IgnoreMe.Should().BeNull();
+		}
+
+		public class ContainsIgnore
+		{
+			[YamlIgnore]
+			public String IgnoreMe { get; set; }
+		}
+
+		[Fact]
+		public void SerializationSkipsPropertyWhenUsingDefaultValueAttribute()
 		{
 			var serializer = new Serializer();
 			var writer = new StringWriter();
@@ -806,7 +899,7 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void DefaultValueAttributeIsIgnoredWhenPresentWithEmitDefaults()
+		public void SerializationEmitsPropertyWhenUsingEmitDefaultsAndDefaultValueAttribute()
 		{
 			var serializer = new Serializer(SerializationOptions.EmitDefaults);
 			var writer = new StringWriter();
@@ -820,7 +913,7 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void DefaultValueAttributeIsIgnoredWhenValueIsDifferent()
+		public void SerializationEmitsPropertyWhenValueDifferFromDefaultValueAttribute()
 		{
 			var serializer = new Serializer();
 			var writer = new StringWriter();
@@ -842,107 +935,7 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void NullValuesInListsAreAlwaysEmittedWithoutEmitDefaults()
-		{
-			var serializer = new Serializer();
-			var writer = new StringWriter();
-			var input = new[] { "foo", null, "bar" };
-
-			serializer.Serialize(writer, input);
-			var serialized = writer.ToString();
-			Dump.WriteLine(serialized);
-
-			Regex.Matches(serialized, "-").Count.Should().Be(3, "there should have been 3 elements");
-		}
-
-		[Fact]
-		public void NullValuesInListsAreAlwaysEmittedWithEmitDefaults()
-		{
-			var serializer = new Serializer(SerializationOptions.EmitDefaults);
-			var writer = new StringWriter();
-			var input = new[] { "foo", null, "bar" };
-
-			serializer.Serialize(writer, input);
-			var serialized = writer.ToString();
-			Dump.WriteLine(serialized);
-
-			Regex.Matches(serialized, "-").Count.Should().Be(3, "there should have been 3 elements");
-		}
-
-		[Fact]
-		public void DeserializeTwoDocuments()
-		{
-			var deserializer = new Deserializer();
-			var reader = EventReaderForYaml(Lines(
-				"---",
-				"Name: Andy",
-				"---",
-				"Name: Brad",
-				"..."));
-
-			reader.Expect<StreamStart>();
-			var andy = deserializer.Deserialize<Person>(reader);
-			var brad = deserializer.Deserialize<Person>(reader);
-
-			andy.ShouldHave().AllProperties().EqualTo(new { Name = "Andy" });
-			brad.ShouldHave().AllProperties().EqualTo(new { Name = "Brad" });
-		}
-
-		[Fact]
-		public void DeserializeManyDocuments()
-		{
-			var deserializer = new Deserializer();
-			var reader = EventReaderForYaml(Lines(
-				"---",
-				"Name: Andy",
-				"---",
-				"Name: Brad",
-				"---",
-				"Name: Charles",
-				"..."));
-
-			reader.Allow<StreamStart>();
-
-			var people = new List<Person>();
-			while (!reader.Accept<StreamEnd>())
-			{
-				var person = deserializer.Deserialize<Person>(reader);
-				people.Add(person);
-			}
-
-			people.Should().HaveCount(3);
-			people[0].ShouldHave().AllProperties().EqualTo(new { Name = "Andy" });
-			people[1].ShouldHave().AllProperties().EqualTo(new { Name = "Brad" });
-			people[2].ShouldHave().AllProperties().EqualTo(new { Name = "Charles" });
-		}
-
-		private static EventReader EventReaderForYaml(string yaml)
-		{
-			return new EventReader(new Parser(new StringReader(yaml)));
-		}
-
-		private string Lines(params string[] lines)
-		{
-			return string.Join(Environment.NewLine, lines);
-		}
-
-		public class Person
-		{
-			public string Name { get; set; }
-		}
-
-		[Fact]
-		public void DeserializeEmptyDocument()
-		{
-			var deserializer = new Deserializer();
-
-			var array = deserializer.Deserialize<int[]>(UsingReaderFor(""));
-
-			array.Should().BeNull();
-		}
-
-		[Fact]
-		public void SerializeGenericDictionaryShouldNotThrowTargetException()
+		public void SerializingAGenericDictionaryShouldNotThrowTargetException()
 		{
 			var serializer = new Serializer();
 			var buffer = new StringWriter();
@@ -954,7 +947,7 @@ namespace YamlDotNet.RepresentationModel.Test
 			action.ShouldNotThrow<TargetException>();
 		}
 
-		private class OnlyGenericDictionary : IDictionary<string, string>
+		public class OnlyGenericDictionary : IDictionary<string, string>
 		{
 			private readonly Dictionary<string, string> dictionary = new Dictionary<string, string>();
 
@@ -1045,129 +1038,126 @@ namespace YamlDotNet.RepresentationModel.Test
 		}
 
 		[Fact]
-		public void ForwardReferencesWorkInGenericLists()
+		// Todo: are these needed? Naming convention classes are tested elsewhere
+		public void SerializeUsingCamelCaseNamingConvention()
 		{
-			var deserializer = new Deserializer();
-			var text = Lines(
-				"- *forward",
-				"- &forward ForwardReference");
+			var obj = new { foo = "bar", moreFoo = "More bar", evenMoreFoo = "Awesome" };
 
-			var result = deserializer.Deserialize<string[]>(UsingReaderFor(text));
+			var result = SerializeWithNaming(obj, new CamelCaseNamingConvention());
 
-			result.Should().Equal(new[] { "ForwardReference", "ForwardReference" });
+			result.Should().Contain("foo: bar").And
+				.Contain("moreFoo: More bar").And
+				.Contain("evenMoreFoo: Awesome");
 		}
 
 		[Fact]
-		public void ForwardReferencesWorkInNonGenericLists()
+		public void DeserializeUsingCamelCaseNamingConvention()
 		{
-			var deserializer = new Deserializer();
-			var text = Lines(
-				"- *forward",
-				"- &forward ForwardReference");
-
-			var result = deserializer.Deserialize<ArrayList>(UsingReaderFor(text));
-
-			result.Should().Equal(new[] { "ForwardReference", "ForwardReference" });
+			DeserializeUsing(new CamelCaseNamingConvention(),
+				"firstTest: First",
+				"secondTest: Second",
+				"thirdTest: Third",
+				"fourthTest: Fourth");
 		}
 
 		[Fact]
-		public void ForwardReferencesWorkInGenericDictionaries()
+		public void SerializeUsingPascalCaseNamingConvention()
 		{
-			var deserializer = new Deserializer();
-			var text = Lines(
-				"key1: *forward",
-				"*forwardKey: ForwardKeyValue",
-				"*forward: *forward",
-				"key2: &forward ForwardReference",
-				"key3: &forwardKey key4");
+			var obj = new { foo = "bar", moreFoo = "More bar", evenMoreFoo = "Awesome" };
 
-			var result = deserializer.Deserialize<Dictionary<string, string>>(UsingReaderFor(text));
+			var result = SerializeWithNaming(obj, new PascalCaseNamingConvention());
+			Dump.WriteLine(result);
 
-			result.Should().Equal(new Dictionary<string, string> {
-				{ "ForwardReference", "ForwardReference" },
-				{ "key1", "ForwardReference" },
-				{ "key2", "ForwardReference" },
-				{ "key4", "ForwardKeyValue" },
-				{ "key3", "key4" }
+			result.Should().Contain("Foo: bar").And
+				.Contain("MoreFoo: More bar").And
+				.Contain("EvenMoreFoo: Awesome");
+		}
+
+		[Fact]
+		public void DeserializeUsingPascalCaseNamingConvention()
+		{
+			DeserializeUsing(new PascalCaseNamingConvention(),
+				"FirstTest: First",
+				"SecondTest: Second",
+				"ThirdTest: Third",
+				"fourthTest: Fourth");
+		}
+
+		[Fact]
+		public void SerializeUsingHyphenationNamingConvention()
+		{
+			var obj = new { foo = "bar", moreFoo = "More bar", EvenMoreFoo = "Awesome" };
+
+			var result = SerializeWithNaming(obj, new HyphenatedNamingConvention());
+
+			result.Should().Contain("foo: bar").And
+				.Contain("more-foo: More bar").And
+				.Contain("even-more-foo: Awesome");
+		}
+
+		[Fact]
+		public void DeserializeUsingHyphenatedNamingConvention()
+		{
+			DeserializeUsing(new HyphenatedNamingConvention(),
+				"first-test: First",
+				"second-test: Second",
+				"third-test: Third",
+				"fourthTest: Fourth");
+		}
+
+		[Fact]
+		public void SerializeUsingUnderscoredNamingConvention()
+		{
+			var obj = new { foo = "bar", moreFoo = "More bar", EvenMoreFoo = "Awsome" };
+
+			var result = SerializeWithNaming(obj, new UnderscoredNamingConvention());
+
+			result.Should().Contain("foo: bar").And
+				.Contain("more_foo: More bar").And
+				.Contain("even_more_foo: Awsome");
+		}
+
+		[Fact]
+		public void DeserializeUsingUnderscoredNamingConvention()
+		{
+			DeserializeUsing(new UnderscoredNamingConvention(),
+				"first_test: First",
+				"second_test: Second",
+				"third_test: Third",
+				"fourthTest: Fourth");
+		}
+
+		private string SerializeWithNaming<T>(T input, INamingConvention naming)
+		{
+			var serializer = new Serializer(namingConvention: naming);
+			var writer = new StringWriter();
+			serializer.Serialize(writer, input, typeof(T));
+			return writer.ToString();
+		}
+
+		private void DeserializeUsing(INamingConvention convention, params string[] yaml)
+		{
+			var deserializer = new Deserializer(namingConvention: convention);
+
+			var result = deserializer.Deserialize<ConventionTest>(UsingReaderFor(Lines(yaml)));
+
+			result.ShouldHave().SharedProperties().EqualTo(new {
+				FirstTest = "First",
+				SecondTest = "Second",
+				ThirdTest = "Third",
+				AliasTest = "Fourth"
 			});
 		}
 
-		[Fact]
-		public void ForwardReferencesWorkInNonGenericDictionaries()
+		public class ConventionTest
 		{
-			var deserializer = new Deserializer();
-			var text = Lines(
-				"key1: *forward",
-				"*forwardKey: ForwardKeyValue",
-				"*forward: *forward",
-				"key2: &forward ForwardReference",
-				"key3: &forwardKey key4");
-
-			var result = deserializer.Deserialize<Hashtable>(UsingReaderFor(text));
-
-			result.Should().BeEquivalentTo(
-				Entry("ForwardReference", "ForwardReference"),
-				Entry("key1", "ForwardReference"),
-				Entry("key2", "ForwardReference"),
-				Entry("key4", "ForwardKeyValue"),
-				Entry("key3", "key4"));
-		}
-
-		private object Entry(string key, string value)
-		{
-			return new DictionaryEntry(key, value);
-		}
-
-		[Fact]
-		public void ForwardReferencesWorkInObjects()
-		{
-			var deserializer = new Deserializer();
-			var text = Lines(
-				"Nothing: *forward",
-				"MyString: &forward ForwardReference");
-
-			var result = deserializer.Deserialize<X>(UsingReaderFor(text));
-
-			result.ShouldHave().SharedProperties().EqualTo(
-				new { Nothing = "ForwardReference", MyString = "ForwardReference" });
-		}
-
-		[Fact]
-		public void UndefinedForwardReferencesFail()
-		{
-			var deserializer = new Deserializer();
-			var text = Lines(
-				"Nothing: *forward",
-				"MyString: ForwardReference");
-
-			Action action = () => deserializer.Deserialize<X>(UsingReaderFor(text));
-
-			action.ShouldThrow<AnchorNotFoundException>();
-		}
-
-		public class X
-		{
-			public bool MyFlag { get; set; }
-			public string Nothing { get; set; }
-			public int MyInt { get; set; }
-			public double MyDouble { get; set; }
-			public string MyString { get; set; }
-			public DateTime MyDate { get; set; }
-			public TimeSpan MyTimeSpan { get; set; }
-			public Point MyPoint { get; set; }
-			public int? MyNullableWithValue { get; set; }
-			public int? MyNullableWithoutValue { get; set; }
-
-			public X()
-			{
-				MyInt = 1234;
-				MyDouble = 6789.1011;
-				MyString = "Hello world";
-				MyDate = DateTime.Now;
-				MyTimeSpan = TimeSpan.FromHours(1);
-				MyPoint = new Point(100, 200);
-				MyNullableWithValue = 8;
-			}
+			public string FirstTest { get; set; }
+			public string SecondTest { get; set; }
+			public string ThirdTest { get; set; }
+			[YamlAlias("fourthTest")]
+			public string AliasTest { get; set; }
+			[YamlIgnore]
+			public string fourthTest { get; set; }
 		}
 
 		private StringReader UsingReaderFor(StringWriter buffer)
@@ -1178,6 +1168,11 @@ namespace YamlDotNet.RepresentationModel.Test
 		private StringReader UsingReaderFor(string text)
 		{
 			return new StringReader(text);
+		}
+
+		private string Lines(params string[] lines)
+		{
+			return string.Join(Environment.NewLine, lines);
 		}
 	}
 }


### PR DESCRIPTION
Creating a pull request at this point since I took the liberty of a huge method reordering.

The commits have the details, but as a whole I've put in FluentAssertions, added asserts to some methods that were missing it and rearranged the method order to express a focus on behaviors instead of a strict separation between serialization, deserialization and roundtrip tests.
