### PR TITLE
Mutable Cursor, immutable Mark

### DIFF
--- a/YamlDotNet/Core/Cursor.cs
+++ b/YamlDotNet/Core/Cursor.cs
@@ -1,0 +1,57 @@
+﻿//  This file is part of YamlDotNet - A .NET library for YAML.
+//  Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013 Antoine Aubry
+
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//  of the Software, and to permit persons to whom the Software is furnished to do
+//  so, subject to the following conditions:
+
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+namespace YamlDotNet.Core
+{
+	internal class Cursor
+	{
+		public int Index { get; set; }
+		public int Line { get; set; }
+		public int Column { get; set; }
+
+		public Mark Mark()
+		{
+			return new Mark(Index, Line, Column);
+		}
+
+		public void Skip()
+		{
+			Index++;
+			Column++;
+		}
+		
+		public void SkipLineByOffset(int offset)
+		{
+			Index += offset;
+			Line++;
+			Column = 0;
+		}
+
+		public void ForceSkipLineAfterNonBreak()
+		{
+			if (Column != 0)
+			{
+				Line++;
+				Column = 0;
+			}
+		}
+	}
+}

--- a/YamlDotNet/Core/Mark.cs
+++ b/YamlDotNet/Core/Mark.cs
@@ -27,73 +27,51 @@ namespace YamlDotNet.Core
 	/// Represents a location inside a file
 	/// </summary>
 	[Serializable]
-	public struct Mark
+	public class Mark
 	{
-		private int index;
-		private int line;
-		private int column;
+		/// <summary>
+		/// Gets a <see cref="Mark"/> with empty values.
+		/// </summary>
+		public static readonly Mark Empty = new Mark();
 
 		/// <summary>
 		/// Gets / sets the absolute offset in the file
 		/// </summary>
-		public int Index
-		{
-			get
-			{
-				return index;
-			}
-			set
-			{
-				if (value < 0)
-				{
-					throw new ArgumentOutOfRangeException("value", "Index must be greater than or equal to zero.");
-				}
-				index = value;
-			}
-		}
+		public int Index { get; private set; }
 
 		/// <summary>
 		/// Gets / sets the number of the line
 		/// </summary>
-		public int Line
-		{
-			get
-			{
-				return line;
-			}
-			set
-			{
-				if (value < 0)
-				{
-					throw new ArgumentOutOfRangeException("value", "Line must be greater than or equal to zero.");
-				}
-				line = value;
-			}
-		}
+		public int Line { get; private set; }
 
 		/// <summary>
 		/// Gets / sets the index of the column
 		/// </summary>
-		public int Column
+		public int Column { get; private set; }
+
+		public Mark()
 		{
-			get
-			{
-				return column;
-			}
-			set
-			{
-				if (value < 0)
-				{
-					throw new ArgumentOutOfRangeException("value", "Column must be greater than or equal to zero.");
-				}
-				column = value;
-			}
 		}
 
-		/// <summary>
-		/// Gets a <see cref="Mark"/> with empty values.
-		/// </summary>
-		public static readonly Mark Empty;
+		public Mark(int index, int line, int column)
+		{
+			if (index < 0)
+			{
+				throw new ArgumentOutOfRangeException("index", "Index must be greater than or equal to zero.");
+			}
+			if (line < 0)
+			{
+				throw new ArgumentOutOfRangeException("line", "Line must be greater than or equal to zero.");
+			}
+			if (column < 0)
+			{
+				throw new ArgumentOutOfRangeException("column", "Column must be greater than or equal to zero.");
+			}
+
+			Index = index;
+			Line = line;
+			Column = column;
+		}
 
 		/// <summary>
 		/// Returns a <see cref="System.String"/> that represents this instance.
@@ -103,7 +81,7 @@ namespace YamlDotNet.Core
 		/// </returns>
 		public override string ToString()
 		{
-			return string.Format("Lin: {0}, Col: {1}, Chr: {2}", line, column, index);
+			return string.Format("Line: {0}, Col: {1}, Idx: {2}", Line, Column, Index);
 		}
 	}
 }

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Core\AnchorNotFoundException.cs" />
     <Compile Include="Core\CharacterAnalyzer.cs" />
     <Compile Include="Core\Constants.cs" />
+    <Compile Include="Core\Cursor.cs" />
     <Compile Include="Core\DuplicateAnchorException.cs" />
     <Compile Include="Core\Emitter.cs" />
     <Compile Include="Core\EmitterState.cs" />


### PR DESCRIPTION
Beside inside the scanner there is not really a reason to mutate a Mark instance. I've added a Cursor class that holds the current position and that can be told what to do. It can be queried for a Mark instance, a specific immutable position.

Unless there is an actual measured performance gain with having Mark as a struct, and I don't see any "unsafe" unmanaged memory handling where it is especially performant with small structs, class is the way to go.
