### PR TITLE
Made Mark exclusive to the external API, Cursor exclusively internal

### DIFF
--- a/YamlDotNet.Test/Core/MarkCursorTests.cs
+++ b/YamlDotNet.Test/Core/MarkCursorTests.cs
@@ -1,0 +1,20 @@
+﻿using FluentAssertions;
+using Xunit;
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Test.Core
+{
+	class MarkCursorTests
+	{
+		[Fact]
+		public void ShouldProvideAnOneIndexedMark()
+		{
+			var cursor = new Cursor();
+
+			var result = cursor.Mark();
+
+			result.Line.Should().Be(1, "the mark should be at line 1");
+			result.Column.Should().Be(1, "the mark should be at column 1");
+		}
+	}
+}

--- a/YamlDotNet.Test/Core/ParserTests.cs
+++ b/YamlDotNet.Test/Core/ParserTests.cs
@@ -310,18 +310,6 @@ namespace YamlDotNet.Test.Core
 				StreamEnd);
 		}
 
-		[Fact]
-		public void LineAndColumnNumbersAreCorrectlyCalculated()
-		{
-			var reader = new EventReader(ParserFor("list.yaml"));
-			reader.Expect<StreamStart>();
-			reader.Expect<DocumentStart>();
-			var sut = reader.Expect<SequenceStart>();
-
-			sut.Start.Line.Should().Be(1, "The sequence should start on line 1");
-			sut.Start.Column.Should().Be(1, "The sequence should start on column 1");
-		}
-
 		private IParser ParserForEmptyContent()
 		{
 			return new Parser(new StringReader(string.Empty));

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -38,6 +38,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\YamlDotNet.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="FakeItEasy">
       <HintPath>..\packages\FakeItEasy.1.13.1\lib\net40\FakeItEasy.dll</HintPath>
@@ -65,6 +71,7 @@
     <Compile Include="Core\InsertionQueueTests.cs" />
     <Compile Include="Core\LookAheadBufferTests.cs" />
     <Compile Include="Core\EventsHelper.cs" />
+    <Compile Include="Core\MarkCursorTests.cs" />
     <Compile Include="Core\ParserTests.cs" />
     <Compile Include="Core\TokenHelper.cs" />
     <Compile Include="Core\ScannerTests.cs" />

--- a/YamlDotNet/Core/Cursor.cs
+++ b/YamlDotNet/Core/Cursor.cs
@@ -29,12 +29,19 @@ namespace YamlDotNet.Core
 
 		public Cursor()
 		{
-			Line = YamlDotNet.Core.Mark.InitialLineNumber;
+			Line = 1;
+		}
+
+		public Cursor(Cursor cursor)
+		{
+			Index = cursor.Index;
+			Line = cursor.Line;
+			LineOffset = cursor.LineOffset;
 		}
 
 		public Mark Mark()
 		{
-			return new Mark(Index, Line, LineOffset + YamlDotNet.Core.Mark.InitialColumnNumber);
+			return new Mark(Index, Line, LineOffset + 1);
 		}
 
 		public void Skip()

--- a/YamlDotNet/Core/EventReader.cs
+++ b/YamlDotNet/Core/EventReader.cs
@@ -69,8 +69,7 @@ namespace YamlDotNet.Core
 				// TODO: Throw a better exception
 				var @event = parser.Current;
 				throw new YamlException(@event.Start, @event.End, string.Format(CultureInfo.InvariantCulture,
-				        "Expected '{0}', got '{1}' (at line {2}, character {3}).",
-				        typeof(T).Name, @event.GetType().Name, @event.Start.Line, @event.Start.Column));
+				        "Expected '{0}', got '{1}' (at {2}).", typeof(T).Name, @event.GetType().Name, @event.Start));
 			}
 			return expectedEvent;
 		}

--- a/YamlDotNet/Core/Mark.cs
+++ b/YamlDotNet/Core/Mark.cs
@@ -29,9 +29,6 @@ namespace YamlDotNet.Core
 	[Serializable]
 	public class Mark
 	{
-		public const int InitialLineNumber = 1;
-		public const int InitialColumnNumber = 1;
-
 		/// <summary>
 		/// Gets a <see cref="Mark"/> with empty values.
 		/// </summary>
@@ -54,8 +51,8 @@ namespace YamlDotNet.Core
 
 		public Mark()
 		{
-			Line = InitialLineNumber;
-			Column = InitialColumnNumber;
+			Line = 1;
+			Column = 1;
 		}
 
 		public Mark(int index, int line, int column)
@@ -64,13 +61,13 @@ namespace YamlDotNet.Core
 			{
 				throw new ArgumentOutOfRangeException("index", "Index must be greater than or equal to zero.");
 			}
-			if (line < InitialLineNumber)
+			if (line < 1)
 			{
-				throw new ArgumentOutOfRangeException("line", string.Format("Line must be greater than or equal to {0}.", InitialLineNumber));
+				throw new ArgumentOutOfRangeException("line", "Line must be greater than or equal to 1.");
 			}
-			if (column < InitialColumnNumber)
+			if (column < 1)
 			{
-				throw new ArgumentOutOfRangeException("column", string.Format("Column must be greater than or equal to {0}.", InitialColumnNumber));
+				throw new ArgumentOutOfRangeException("column", "Column must be greater than or equal to 1.");
 			}
 
 			Index = index;

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -243,7 +243,7 @@ namespace YamlDotNet.Core
 				//  - is shorter than 1024 characters.
 
 
-				if (key.IsPossible && (key.Mark.Line < cursor.Line || key.Mark.Index + 1024 < cursor.Index))
+				if (key.IsPossible && (key.Line < cursor.Line || key.Index + 1024 < cursor.Index))
 				{
 
 					// Check if the potential simple key to be removed is required.
@@ -1015,7 +1015,7 @@ namespace YamlDotNet.Core
 
 				// In the block context, we may need to add the BLOCK-MAPPING-START token.
 
-				RollIndent(simpleKey.Mark.Column - 1, simpleKey.TokenNumber, false, simpleKey.Mark);
+				RollIndent(simpleKey.LineOffset, simpleKey.TokenNumber, false, simpleKey.Mark);
 
 				// Remove the simple key.
 
@@ -2333,7 +2333,7 @@ namespace YamlDotNet.Core
 
 			if (simpleKeyAllowed)
 			{
-				var key = new SimpleKey(true, isRequired, tokensParsed + tokens.Count, cursor.Mark());
+				var key = new SimpleKey(true, isRequired, tokensParsed + tokens.Count, cursor);
 
 				RemoveSimpleKey();
 

--- a/YamlDotNet/Core/SimpleKey.cs
+++ b/YamlDotNet/Core/SimpleKey.cs
@@ -23,23 +23,29 @@ namespace YamlDotNet.Core
 {
 	internal class SimpleKey
 	{
+		private readonly Cursor cursor;
+
 		public bool IsPossible { get; set; }
 
 		public bool IsRequired { get; private set; }
 		public int TokenNumber { get; private set; }
-		public Mark Mark { get; private set; }
+		public int Index { get { return cursor.Index; } }
+		public int Line { get { return cursor.Line; } }
+		public int LineOffset { get { return cursor.LineOffset; } }
+
+		public Mark Mark { get { return cursor.Mark(); } }
 
 		public SimpleKey()
 		{
-			Mark = Mark.Empty;
+			cursor = new Cursor();
 		}
 
-		public SimpleKey(bool isPossible, bool isRequired, int tokenNumber, Mark mark)
+		public SimpleKey(bool isPossible, bool isRequired, int tokenNumber, Cursor cursor)
 		{
 			IsPossible = isPossible;
 			IsRequired = isRequired;
 			TokenNumber = tokenNumber;
-			Mark = mark;
+			this.cursor = new Cursor(cursor);
 		}
 	}
 }

--- a/YamlDotNet/Properties/AssemblyInfo.cs
+++ b/YamlDotNet/Properties/AssemblyInfo.cs
@@ -20,6 +20,9 @@
 //  SOFTWARE.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("YamlDotNet.Core")]
 [assembly: AssemblyDescription("The core YamlDotNet library, which contains the implementation of the parser and the emitter.")]
+
+[assembly: InternalsVisibleTo("YamlDotNet.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c1b7cb58b05e52f6a5ac5c594b0290ef81ce4f9ac8d9f6acd735ed305e11cfb95b5fce69ed1dc3d21522f252fab128f812eb213be599ac502bf8fb2527b08c3f7fe9b36ca001fe8b916b0bea8782ff924e36a240aebca712c87a10e8fbffc5a3d79cc62cb9217d527b77a16875ddafb3ddb3ffa9ec74ea9eb8dd641322c395be")]


### PR DESCRIPTION
There were two problems with the Mark class. Its Initial{Line/Column}Number constants were setting up an unnecessary physical dependency with Cursor (because the Mark ctor already checks the constraints). It were also used in both the setting of zero and one based indexing.

I've simplified the Mark and Cursor classes and also identified the SimpleKey class as the one "holding Mark hostage". SimpleKey can instead hold a copy of the cursor and generate Mark instances from it.
