### PR TITLE
Equals() rather than == is best practice

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -666,7 +666,7 @@ namespace YamlDotNet.Test.Serialization
 
 			list
 				.Should().NotBeNull()
-				.And.ContainSingle(c => c == "[hello, world]");
+				.And.ContainSingle(c => c.Equals("[hello, world]"));
 		}
 	}
 }


### PR DESCRIPTION
The == operator is implemented with object.ReferenceEquals() and can fail when strings are not interned. One should always using Equals() as a best practice.
