### PR TITLE
Added double dispatch feature to parsing events

### DIFF
--- a/YamlDotNet/Core/Events/AnchorAlias.cs
+++ b/YamlDotNet/Core/Events/AnchorAlias.cs
@@ -91,12 +91,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/DocumentEnd.cs
+++ b/YamlDotNet/Core/Events/DocumentEnd.cs
@@ -101,12 +101,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/DocumentStart.cs
+++ b/YamlDotNet/Core/Events/DocumentStart.cs
@@ -153,12 +153,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/IParsingEventVisitor.cs
+++ b/YamlDotNet/Core/Events/IParsingEventVisitor.cs
@@ -22,19 +22,19 @@
 namespace YamlDotNet.Core.Events
 {
 	/// <summary>
-	/// Callback interface for external event handler.
+	/// Callback interface for external event Visitr.
 	/// </summary>
-	public interface IParsingEventHandler
+	public interface IParsingEventVisitor
 	{
-		void Handle(AnchorAlias e);
-		void Handle(StreamStart e);
-		void Handle(StreamEnd e);
-		void Handle(DocumentStart e);
-		void Handle(DocumentEnd e);
-		void Handle(Scalar e);
-		void Handle(SequenceStart e);
-		void Handle(SequenceEnd e);
-		void Handle(MappingStart e);
-		void Handle(MappingEnd e);
+		void Visit(AnchorAlias e);
+		void Visit(StreamStart e);
+		void Visit(StreamEnd e);
+		void Visit(DocumentStart e);
+		void Visit(DocumentEnd e);
+		void Visit(Scalar e);
+		void Visit(SequenceStart e);
+		void Visit(SequenceEnd e);
+		void Visit(MappingStart e);
+		void Visit(MappingEnd e);
 	}
 }

--- a/YamlDotNet/Core/Events/MappingEnd.cs
+++ b/YamlDotNet/Core/Events/MappingEnd.cs
@@ -76,12 +76,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/MappingStart.cs
+++ b/YamlDotNet/Core/Events/MappingStart.cs
@@ -142,12 +142,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/ParsingEvent.cs
+++ b/YamlDotNet/Core/Events/ParsingEvent.cs
@@ -69,10 +69,10 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Dispatch event to the specified event handler.
+		/// Accepts the specified visitor.
 		/// </summary>
-		/// <param name="handler"></param>
-		public abstract void Dispatch(IParsingEventHandler handler);
+		/// <param name="visitor">Visitor to accept, may not be null</param>
+		public abstract void Accept(IParsingEventVisitor visitor);
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ParsingEvent"/> class.

--- a/YamlDotNet/Core/Events/Scalar.cs
+++ b/YamlDotNet/Core/Events/Scalar.cs
@@ -183,12 +183,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/SequenceEnd.cs
+++ b/YamlDotNet/Core/Events/SequenceEnd.cs
@@ -76,12 +76,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/SequenceStart.cs
+++ b/YamlDotNet/Core/Events/SequenceStart.cs
@@ -131,12 +131,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/StreamEnd.cs
+++ b/YamlDotNet/Core/Events/StreamEnd.cs
@@ -76,12 +76,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/Core/Events/StreamStart.cs
+++ b/YamlDotNet/Core/Events/StreamStart.cs
@@ -76,12 +76,12 @@ namespace YamlDotNet.Core.Events
 		}
 
 		/// <summary>
-		/// Accepts and invokes event handler for this ParsingEvent.
+		/// Invokes run-time type specific Visit() method of the specified visitor.
 		/// </summary>
-		/// <param name="handler">Event handler</param>
-		public override void Dispatch(IParsingEventHandler handler)
+		/// <param name="visitor">visitor, may not be null.</param>
+		public override void Accept(IParsingEventVisitor visitor)
 		{
-			handler.Handle(this);
+			visitor.Visit(this);
 		}
 	}
 }

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -82,7 +82,7 @@
     <Compile Include="Core\Events\DocumentEnd.cs" />
     <Compile Include="Core\Events\DocumentStart.cs" />
     <Compile Include="Core\Events\EventType.cs" />
-    <Compile Include="Core\Events\IParsingEventHandler.cs" />
+    <Compile Include="Core\Events\IParsingEventVisitor.cs" />
     <Compile Include="Core\Events\MappingStyle.cs" />
     <Compile Include="Core\Events\NodeEvent.cs" />
     <Compile Include="Core\Events\ParsingEvent.cs" />


### PR DESCRIPTION
Hi Antoine,

If you'd be interested to integrate this, I've added the double dispatch to Core.Event classes. The use is simple:

```
event.Dispatch(myHandler);
```

where myHandler implements IParsingEventHandler will pass the event to the corresponding overload of Handle method.

Best regards,

Leon
