### PR TITLE
Fixed a bug with dynamicYaml's ability to find keys.

### DIFF
--- a/YamlDotNet.Dynamic.Test/DynamicYamlTest.cs
+++ b/YamlDotNet.Dynamic.Test/DynamicYamlTest.cs
@@ -206,6 +206,42 @@ namespace YamlDotNet.Dynamic.Test
 			values[3].Should().BeFalse();
 		}
 
+		[Fact]
+		public void TestNamingConventions()
+		{
+			dynamic dynamicYaml = new DynamicYaml(NamingConventionsYaml);
+
+			string snake = dynamicYaml.snake_case;
+			snake.Should().Be("should work", "the key was typed in snake case");
+
+			string pascal = dynamicYaml.PascalCase;
+			pascal.Should().Be("should work as well", "the key was typed in pascal case");
+
+			string camel = dynamicYaml.camelCase;
+			camel.Should().Be("will also work", "the key was typed in camel case");
+
+			string upper = dynamicYaml.UPPER_CASE;
+			upper.Should().Be("works as well", "the key was typed in upper case");
+		}
+
+		[Fact]
+		public void TestNamingConventionsWithFirstLetterCaseInsensitivity()
+		{
+			dynamic dynamicYaml = new DynamicYaml(NamingConventionsYaml);
+
+			string snake = dynamicYaml.Snake_case;
+			snake.Should().Be("should work", "the key was typed in snake case");
+
+			string pascal = dynamicYaml.pascalCase;
+			pascal.Should().Be("should work as well", "the key was typed in pascal case");
+
+			string camel = dynamicYaml.CamelCase;
+			camel.Should().Be("will also work", "the key was typed in camel case");
+
+			string upper = dynamicYaml.uPPER_CASE;
+			upper.Should().Be("works as well", "the key was typed in upper case");
+		}
+
 		private const string EnumYaml = @"---
             - stringComparisonMode: CurrentCultureIgnoreCase
             - stringComparisonMode: Ordinal";
@@ -225,6 +261,12 @@ namespace YamlDotNet.Dynamic.Test
 		private const string NestedSequenceYaml = @"---
             - [1, 2, 3]
             - [4, 5, 6]";
+
+		private const string NamingConventionsYaml = @"---
+            snake_case: should work
+            PascalCase: should work as well
+            camelCase: will also work
+            UPPER_CASE: works as well";
 
 		private const string MappingYaml = @"---
             receipt:    Oz-Ware Purchase Invoice

--- a/YamlDotNet.Dynamic/DynamicYaml.cs
+++ b/YamlDotNet.Dynamic/DynamicYaml.cs
@@ -138,10 +138,21 @@ namespace YamlDotNet.Dynamic
 			{
 				return FailToGetValue(out result);
 			}
-			var yamlKey = new YamlScalarNode(key.Decapitalize());
-			var yamlKey2 = new YamlScalarNode(key.Capitalize());
-			return TryGetValueByYamlKeyAndType(yamlKey, type, out result) ||
-				TryGetValueByYamlKeyAndType(yamlKey2, type, out result);
+
+			// try and get an exact match to the key first
+			if (TryGetValueByYamlKeyAndType(key, type, out result))
+			{
+				return true;
+			}
+
+			// otherwise try and match the key with a different cased first character
+			var yamlKey = new YamlScalarNode(key.InverseFirstCapital());
+			if (TryGetValueByYamlKeyAndType(yamlKey, type, out result))
+			{
+				return true;
+			}
+
+			return IsNullableType(type) ? SuccessfullyGetValue(new DynamicYaml((YamlNode)null), out result) : FailToGetValue(out result);
 		}
 
 		private bool TryGetValueByYamlKeyAndType(YamlScalarNode yamlKey, Type type, out object result)
@@ -154,8 +165,8 @@ namespace YamlDotNet.Dynamic
 					return true;
 				}
 			}
-
-			return IsNullableType(type) ? SuccessfullyGetValue(new DynamicYaml((YamlNode)null), out result) : FailToGetValue(out result);
+			
+			return FailToGetValue(out result);
 		}
 
 		private static bool IsNullableType(Type type)

--- a/YamlDotNet.Dynamic/Extensions.cs
+++ b/YamlDotNet.Dynamic/Extensions.cs
@@ -37,24 +37,17 @@ namespace YamlDotNet.Dynamic
 			return string.IsNullOrEmpty(str);
 		}
 
-		public static string Capitalize(this string str)
+		public static string InverseFirstCapital(this string str)
 		{
 			if (str.IsNullOrEmpty())
 			{
 				return str;
 			}
 
-			return char.ToUpper(str[0]) + str.Substring(1);
-		}
+			char first = str[0];
+			first = char.IsUpper(first) ? char.ToLower(str[0]) : char.ToUpper(first);
 
-		public static string Decapitalize(this string str)
-		{
-			if (str.IsNullOrEmpty())
-			{
-				return str;
-			}
-
-			return char.ToLower(str[0]) + str.Substring(1);
+			return first + str.Substring(1);
 		}
 	}
 }


### PR DESCRIPTION
The yaml document would parse fine but due to a short circuit `||` operator certain valid keys could never be retrieved off a dynamic object.

E.g.:

``` yml

---
SomeProperty: 3.0
```

would always return null when accessed due to the capitalized first character.

I fixed the bug, simplified the code involved (IMHO), and added unit tests for failing (and existing passing) cases.
I preserved the pre-existing behavior that allowed the first character of the key to be case in-sensitive. I think this behavior is a little silly but I did not want to introduce a breaking change.
