### PR TITLE
Parser: Add support for multi-document tag directives

### DIFF
--- a/YamlDotNet.Test/Core/ParserTests.cs
+++ b/YamlDotNet.Test/Core/ParserTests.cs
@@ -310,6 +310,29 @@ namespace YamlDotNet.Test.Core
 				StreamEnd);
 		}
 
+		[Fact]
+		public void VerifyTokenWithMultiDocTag()
+		{
+			AssertSequenceOfEventsFrom(ParserFor("multi-doc-tag.yaml"),
+				StreamStart,
+				DocumentStart(Explicit, Version(1, 1),
+					TagDirective("!x!", "tag:example.com,2014:"),
+					TagDirective("!", "!"),
+					TagDirective("!!", TagYaml)),
+				BlockMappingStart.T("tag:example.com,2014:foo").Explicit,
+				PlainScalar("x"),
+				PlainScalar("0"),
+				MappingEnd,
+				DocumentEnd(Implicit),
+				DocumentStart(Explicit),
+				BlockMappingStart.T("tag:example.com,2014:bar").Explicit,
+				PlainScalar("x"),
+				PlainScalar("1"),
+				MappingEnd,
+				DocumentEnd(Implicit),
+				StreamEnd);
+		}
+
 		private IParser ParserForEmptyContent()
 		{
 			return new Parser(new StringReader(string.Empty));

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -98,6 +98,7 @@
     <EmbeddedResource Include="files\list-explicit.yaml" />
     <EmbeddedResource Include="files\list-of-dictionaries.yaml" />
     <EmbeddedResource Include="files\local-tags.yaml" />
+    <EmbeddedResource Include="files\multi-doc-tag.yaml" />
     <EmbeddedResource Include="files\tags.yaml" />
     <EmbeddedResource Include="files\01-directives.yaml" />
     <EmbeddedResource Include="files\10-mixed-nodes-in-sequence.yaml" />

--- a/YamlDotNet.Test/files/multi-doc-tag.yaml
+++ b/YamlDotNet.Test/files/multi-doc-tag.yaml
@@ -1,0 +1,6 @@
+%YAML 1.1
+%TAG !x! tag:example.com,2014:
+--- !x!foo
+x: 0
+--- !x!bar
+x: 1

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -318,15 +318,15 @@ namespace YamlDotNet.Core
 				Skip();
 			}
 
-			AddDefaultTagDirectives(tags);
-			AddDefaultTagDirectives(tagDirectives);
+			AddTagDirectives(tags, Constants.DefaultTagDirectives);
+			AddTagDirectives(tagDirectives, Constants.DefaultTagDirectives);
 
 			return version;
 		}
 
-		private static void AddDefaultTagDirectives(TagDirectiveCollection directives)
+		private static void AddTagDirectives(TagDirectiveCollection directives, IEnumerable<TagDirective> source)
 		{
-			foreach(var directive in Constants.DefaultTagDirectives)
+			foreach(var directive in source)
 			{
 				if (!directives.Contains(directive))
 				{

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -281,6 +281,7 @@ namespace YamlDotNet.Core
 		private VersionDirective ProcessDirectives(TagDirectiveCollection tags)
 		{
 			VersionDirective version = null;
+			bool hasOwnDirectives = false;
 
 			while (true)
 			{
@@ -300,6 +301,7 @@ namespace YamlDotNet.Core
 					}
 
 					version = currentVersion;
+					hasOwnDirectives = true;
 				}
 				else if ((tag = GetCurrentToken() as TagDirective) != null)
 				{
@@ -308,6 +310,7 @@ namespace YamlDotNet.Core
 						throw new SemanticErrorException(tag.Start, tag.End, "Found duplicate %TAG directive.");
 					}
 					tags.Add(tag);
+					hasOwnDirectives = true;
 				}
 				else
 				{
@@ -318,6 +321,11 @@ namespace YamlDotNet.Core
 			}
 
 			AddTagDirectives(tags, Constants.DefaultTagDirectives);
+
+			if (hasOwnDirectives)
+			{
+				tagDirectives.Clear();
+			}
 			AddTagDirectives(tagDirectives, tags);
 
 			return version;
@@ -550,8 +558,6 @@ namespace YamlDotNet.Core
 				Skip();
 				isImplicit = false;
 			}
-
-			tagDirectives.Clear();
 
 			state = ParserState.DocumentStart;
 			return new Events.DocumentEnd(isImplicit, start, end);

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -303,11 +303,10 @@ namespace YamlDotNet.Core
 				}
 				else if ((tag = GetCurrentToken() as TagDirective) != null)
 				{
-					if (tagDirectives.Contains(tag.Handle))
+					if (tags.Contains(tag.Handle))
 					{
 						throw new SemanticErrorException(tag.Start, tag.End, "Found duplicate %TAG directive.");
 					}
-					tagDirectives.Add(tag);
 					tags.Add(tag);
 				}
 				else
@@ -319,7 +318,7 @@ namespace YamlDotNet.Core
 			}
 
 			AddTagDirectives(tags, Constants.DefaultTagDirectives);
-			AddTagDirectives(tagDirectives, Constants.DefaultTagDirectives);
+			AddTagDirectives(tagDirectives, tags);
 
 			return version;
 		}

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -308,10 +308,7 @@ namespace YamlDotNet.Core
 						throw new SemanticErrorException(tag.Start, tag.End, "Found duplicate %TAG directive.");
 					}
 					tagDirectives.Add(tag);
-					if (tags != null)
-					{
-						tags.Add(tag);
-					}
+					tags.Add(tag);
 				}
 				else
 				{
@@ -321,10 +318,7 @@ namespace YamlDotNet.Core
 				Skip();
 			}
 
-			if (tags != null)
-			{
-				AddDefaultTagDirectives(tags);
-			}
+			AddDefaultTagDirectives(tags);
 			AddDefaultTagDirectives(tagDirectives);
 
 			return version;


### PR DESCRIPTION
The spec at <http://yaml.org/spec/1.1/#l-first-document> says:
    
> If the document specifies no directives, it is parsed using the same settings as the previous document.

Without this change, `ParseDocumentEnd()` unconditionally clears the collection of tag directives, which causes the following `SemanticError`:

> While parsing a node, find undefined tag handle.

when parsing a multi-document stream such as:

    %YAML 1.1
    %TAG !x! tag:example.com,2014:
    --- !x!foo
    x: 0
    --- !x!bar
    x: 1

where both instances of `!x!` stand for for `tag:example.com,2014`.

The main patch postpones the clearing of `tagDirectives` until a new set of directives is encountered at the start of a document.