### PR TITLE
Added suport for .NET binary serialization

### DIFF
--- a/YamlDotNet.Test/RepresentationModel/BinarySerlializationTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/BinarySerlializationTests.cs
@@ -1,0 +1,51 @@
+﻿//  This file is part of YamlDotNet - A .NET library for YAML.
+//  Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013 Antoine Aubry and contributors
+
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//  of the Software, and to permit persons to whom the Software is furnished to do
+//  so, subject to the following conditions:
+
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace YamlDotNet.Test.RepresentationModel
+{
+	using System.Runtime.Serialization.Formatters.Binary;
+
+	public class BinarySerlializationTests
+	{
+		[Fact]
+		public void YamlNodeGraphsAreBinarySerializeable()
+		{
+			var stream = new YamlStream();
+			stream.Load(Yaml.StreamFrom("fail-backreference.yaml"));
+
+			
+			var formatter = new BinaryFormatter();
+			var memoryStream = new MemoryStream();
+			formatter.Serialize(memoryStream, stream.Documents[0].RootNode);
+
+			memoryStream.Position = 0;
+			YamlNode result = (YamlNode)formatter.Deserialize(memoryStream);
+			Assert.Equal(stream.Documents[0].RootNode, result);
+		}
+	}
+}

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Dump.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RepresentationModel\BinarySerlializationTests.cs" />
     <Compile Include="RepresentationModel\YamlStreamTests.cs" />
     <Compile Include="Serialization\NamingConventionTests.cs" />
     <Compile Include="Serialization\ObjectFactoryTests.cs" />

--- a/YamlDotNet/RepresentationModel/YamlAliasNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlAliasNode.cs
@@ -28,6 +28,7 @@ namespace YamlDotNet.RepresentationModel
 	/// <summary>
 	/// Represents an alias node in the YAML document.
 	/// </summary>
+	[Serializable]
 	internal class YamlAliasNode : YamlNode
 	{
 		/// <summary>

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -31,6 +31,7 @@ namespace YamlDotNet.RepresentationModel
 	/// <summary>
 	/// Represents a mapping node in the YAML document.
 	/// </summary>
+	[Serializable]
 	public class YamlMappingNode : YamlNode, IEnumerable<KeyValuePair<YamlNode, YamlNode>>
 	{
 		private readonly IDictionary<YamlNode, YamlNode> children = new Dictionary<YamlNode, YamlNode>();

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -29,6 +29,7 @@ namespace YamlDotNet.RepresentationModel
 	/// <summary>
 	/// Represents a single node in the YAML document.
 	/// </summary>
+	[Serializable]
 	public abstract class YamlNode
 	{
 		/// <summary>

--- a/YamlDotNet/RepresentationModel/YamlScalarNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlScalarNode.cs
@@ -32,6 +32,7 @@ namespace YamlDotNet.RepresentationModel
 	/// Represents a scalar node in the YAML document.
 	/// </summary>
 	[DebuggerDisplay("{Value}")]
+	[Serializable]
 	public class YamlScalarNode : YamlNode
 	{
 		/// <summary>

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -33,6 +33,7 @@ namespace YamlDotNet.RepresentationModel
 	/// Represents a sequence node in the YAML document.
 	/// </summary>
 	[DebuggerDisplay("Count = {children.Count}")]
+	[Serializable]
 	public class YamlSequenceNode : YamlNode, IEnumerable<YamlNode>
 	{
 		private readonly IList<YamlNode> children = new List<YamlNode>();


### PR DESCRIPTION
Adding the Serializable attribute to YamlNode allows the YamlNode object graph to be easily deep cloned / marshalled across processes with BinarySerlialization. Deep cloning is particularly useful within parallelized environments.

We have used this change successfully for about a month now.
