### PR TITLE
Anchor assignment during YamlStream.Save(): ability to opt out

### DIFF
--- a/YamlDotNet/RepresentationModel/YamlDocument.cs
+++ b/YamlDotNet/RepresentationModel/YamlDocument.cs
@@ -169,14 +169,15 @@ namespace YamlDotNet.RepresentationModel
 			visitor.AssignAnchors(this);
 		}
 
-		internal void Save(IEmitter emitter)
-		{
-			AssignAnchors();
+        internal void Save(IEmitter emitter, bool assignAnchors = true)
+        {
+            if (assignAnchors)
+                AssignAnchors();
 
-			emitter.Emit(new DocumentStart());
-			RootNode.Save(emitter, new EmitterState());
-			emitter.Emit(new DocumentEnd(false));
-		}
+            emitter.Emit(new DocumentStart());
+            RootNode.Save(emitter, new EmitterState());
+            emitter.Emit(new DocumentEnd(false));
+        }
 
 		/// <summary>
 		/// Accepts the specified visitor by calling the appropriate Visit method on it.

--- a/YamlDotNet/RepresentationModel/YamlDocument.cs
+++ b/YamlDotNet/RepresentationModel/YamlDocument.cs
@@ -169,15 +169,15 @@ namespace YamlDotNet.RepresentationModel
 			visitor.AssignAnchors(this);
 		}
 
-        internal void Save(IEmitter emitter, bool assignAnchors = true)
-        {
-            if (assignAnchors)
-                AssignAnchors();
+		internal void Save(IEmitter emitter, bool assignAnchors = true)
+		{
+			if (assignAnchors)
+				AssignAnchors();
 
-            emitter.Emit(new DocumentStart());
-            RootNode.Save(emitter, new EmitterState());
-            emitter.Emit(new DocumentEnd(false));
-        }
+			emitter.Emit(new DocumentStart());
+			RootNode.Save(emitter, new EmitterState());
+			emitter.Emit(new DocumentEnd(false));
+		}
 
 		/// <summary>
 		/// Accepts the specified visitor by calling the appropriate Visit method on it.

--- a/YamlDotNet/RepresentationModel/YamlStream.cs
+++ b/YamlDotNet/RepresentationModel/YamlStream.cs
@@ -1,16 +1,16 @@
 //  This file is part of YamlDotNet - A .NET library for YAML.
 //  Copyright (c) Antoine Aubry and contributors
-	
+
 //  Permission is hereby granted, free of charge, to any person obtaining a copy of
 //  this software and associated documentation files (the "Software"), to deal in
 //  the Software without restriction, including without limitation the rights to
 //  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 //  of the Software, and to permit persons to whom the Software is furnished to do
 //  so, subject to the following conditions:
-	
+
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
-	
+
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/YamlDotNet/RepresentationModel/YamlStream.cs
+++ b/YamlDotNet/RepresentationModel/YamlStream.cs
@@ -106,14 +106,15 @@ namespace YamlDotNet.RepresentationModel
 		/// Saves the stream to the specified output.
 		/// </summary>
 		/// <param name="output">The output.</param>
-		public void Save(TextWriter output)
+        /// <param name="assignAnchors">Indicates whether or not to assign node anchors.</param>
+		public void Save(TextWriter output, bool assignAnchors = true)
 		{
 			IEmitter emitter = new Emitter(output);
 			emitter.Emit(new StreamStart());
 
 			foreach (var document in documents)
 			{
-				document.Save(emitter);
+				document.Save(emitter, assignAnchors);
 			}
 
 			emitter.Emit(new StreamEnd());

--- a/YamlDotNet/RepresentationModel/YamlStream.cs
+++ b/YamlDotNet/RepresentationModel/YamlStream.cs
@@ -1,16 +1,16 @@
 //  This file is part of YamlDotNet - A .NET library for YAML.
 //  Copyright (c) Antoine Aubry and contributors
-    
+	
 //  Permission is hereby granted, free of charge, to any person obtaining a copy of
 //  this software and associated documentation files (the "Software"), to deal in
 //  the Software without restriction, including without limitation the rights to
 //  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 //  of the Software, and to permit persons to whom the Software is furnished to do
 //  so, subject to the following conditions:
-    
+	
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
-    
+	
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -106,7 +106,7 @@ namespace YamlDotNet.RepresentationModel
 		/// Saves the stream to the specified output.
 		/// </summary>
 		/// <param name="output">The output.</param>
-        /// <param name="assignAnchors">Indicates whether or not to assign node anchors.</param>
+		/// <param name="assignAnchors">Indicates whether or not to assign node anchors.</param>
 		public void Save(TextWriter output, bool assignAnchors = true)
 		{
 			IEmitter emitter = new Emitter(output);


### PR DESCRIPTION
I noticed that assigning node anchors can be extremely slow for large `YamlDocument`s; for example, writing a ~5.3 MB YAML file takes about 28 minutes, and the vast majority of that time is taken from assigning node anchors. 

If I know ahead of time that my document does not contain any cross-references, then I can safely skip the anchor assignment and the output will be unaffected. This brought the writing time down from 28 minutes to 4 seconds for that 5.3 MB file.

This change adds an overload to `YamlStream.Save()` which allows the user to opt out of anchor assignment. This defaults to `true` (which is the current behaviour and which makes this a non-breaking change), but it can be changed to `false` to skip anchor assignment and consequently save lots of time.

The user would only need to be aware that explicitly using the overload with `false` would cause cross-referenced nodes to be emitted independently, which may or may not be desirable based on their requirements.