### PR TITLE
Fixed #121: Finding properties in parent interfaces

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -320,12 +320,27 @@ namespace YamlDotNet.Test.Serialization
 		public Base BaseWithSerializeAs { get; set; }
 	}
 
-	public class Base
+	public class InterfaceExample
+	{
+		public IDerived Derived { get; set; }
+	}
+
+	public interface IBase
+	{
+		string BaseProperty { get; set; }
+	}
+
+	public interface IDerived : IBase
+	{
+		string DerivedProperty { get; set; }
+	}
+
+	public class Base : IBase
 	{
 		public string BaseProperty { get; set; }
 	}
 
-	public class Derived : Base
+	public class Derived : Base, IDerived
 	{
 		public string DerivedProperty { get; set; }
 	}

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -36,6 +36,7 @@ using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using YamlDotNet.Serialization.ObjectFactories;
 
 namespace YamlDotNet.Test.Serialization
 {
@@ -235,6 +236,27 @@ namespace YamlDotNet.Test.Serialization
 
 			result.BaseWithSerializeAs.Should().BeOfType<Base>().And
 				.Subject.As<Base>().ShouldHave().SharedProperties().EqualTo(new { ParentProp = "foo" });
+		}
+
+		[Fact]
+		public void RoundtripInterfaceProperties()
+		{
+			AssumingDeserializerWith(new LambdaObjectFactory(t =>
+			{
+				if (t == typeof(InterfaceExample)) { return new InterfaceExample(); }
+				else if (t == typeof(IDerived)) { return new Derived(); }
+				return null;
+			}));
+
+			var obj = new InterfaceExample
+			{
+				Derived = new Derived { BaseProperty = "foo", DerivedProperty = "bar" }
+			};
+
+			var result = DoRoundtripFromObjectTo<InterfaceExample>(obj);
+
+			result.Derived.Should().BeOfType<Derived>().And
+				.Subject.As<IDerived>().ShouldHave().SharedProperties().EqualTo(new { BaseProperty = "foo", DerivedProperty = "bar" });
 		}
 
 		[Fact]

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -161,8 +161,13 @@ namespace YamlDotNet
 
 		public static IEnumerable<PropertyInfo> GetPublicProperties(this Type type)
 		{
-			return type.GetRuntimeProperties()
-				.Where(p => p.GetMethod.IsPublic && !p.GetMethod.IsStatic);
+			var instancePublic = new Func<PropertyInfo, bool>(
+				p => !p.GetMethod.IsStatic && p.GetMethod.IsPublic);
+			return type.IsInterface
+				? (new Type[] { type })
+					.Concat(type.GetInterfaces())
+					.SelectMany(i => i.GetRuntimeProperties().Where(instancePublic))
+				: type.GetRuntimeProperties().Where(instancePublic);
 		}
 
 		public static IEnumerable<MethodInfo> GetPublicMethods(this Type type)
@@ -292,7 +297,12 @@ namespace YamlDotNet
  
 		public static IEnumerable<PropertyInfo> GetPublicProperties(this Type type)
 		{
-			return type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+			var instancePublic = BindingFlags.Instance | BindingFlags.Public;
+			return type.IsInterface
+				? (new Type[] { type })
+					.Concat(type.GetInterfaces())
+					.SelectMany(i => i.GetProperties(instancePublic))
+				: type.GetProperties(instancePublic);
 		}
 
 		public static IEnumerable<MethodInfo> GetPublicMethods(this Type type)

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -163,7 +163,7 @@ namespace YamlDotNet
 		{
 			var instancePublic = new Func<PropertyInfo, bool>(
 				p => !p.GetMethod.IsStatic && p.GetMethod.IsPublic);
-			return type.IsInterface
+			return type.IsInterface()
 				? (new Type[] { type })
 					.Concat(type.GetInterfaces())
 					.SelectMany(i => i.GetRuntimeProperties().Where(instancePublic))


### PR DESCRIPTION
I included a test that fails with the existing code but then succeeds with my changes. I modified the "portable" version of GetPublicProperties() as well, although I was not able to test it.