### PR TITLE
Allow the style of scalar properties to be specified.

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -400,6 +400,22 @@ namespace YamlDotNet.Test.Serialization
 		}
 	}
 
+	public class ScalarStyleExample
+	{
+		public ScalarStyleExample()
+		{
+			var content = "Test";
+			this.LiteralString = content;
+			this.DoubleQuotedString = content;
+		}
+
+		[YamlMember(ScalarStyle = ScalarStyle.Literal)]
+		public String LiteralString { get; set; }
+
+		[YamlMember(ScalarStyle = ScalarStyle.DoubleQuoted)]
+		public String DoubleQuotedString { get; set; }
+	}
+
 	public class DefaultsExample
 	{
 		public const string DefaultValue = "myDefault";

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -628,6 +628,20 @@ namespace YamlDotNet.Test.Serialization
 		}
 
 		[Fact]
+		public void SerializationRespectsScalarStyle()
+		{
+			var writer = new StringWriter();
+			var obj = new ScalarStyleExample();
+
+			Serializer.Serialize(writer, obj);
+			var serialized = writer.ToString();
+			Dump.WriteLine(serialized);
+
+			serialized.Should()
+				.Be("LiteralString: |-\r\n  Test\r\nDoubleQuotedString: \"Test\"\r\n", "the properties should be specifically styled");
+		}
+
+		[Fact]
 		public void SerializationSkipsPropertyWhenUsingDefaultValueAttribute()
 		{
 			var writer = new StringWriter();

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -811,6 +811,12 @@ namespace YamlDotNet.Core
 		{
 			var scalar = (Scalar)evt;
 
+			if (scalar.IsAlreadyStyled)
+			{
+				scalarData.style = scalar.Style;
+				return;
+			}
+
 			var style = scalar.Style;
 			var noTag = tagData.handle == null && tagData.suffix == null;
 

--- a/YamlDotNet/Core/Events/Scalar.cs
+++ b/YamlDotNet/Core/Events/Scalar.cs
@@ -91,6 +91,19 @@ namespace YamlDotNet.Core.Events
 			}
 		}
 
+		private bool isAlreadyStyled { get; set; }
+
+		/// <summary>
+		/// Gets a value indicating whether the scalar has already been styled.
+		/// </summary>
+		public bool IsAlreadyStyled
+		{
+			get
+			{
+				return isAlreadyStyled;
+			}
+		}
+
 		/// <summary>
 		/// Gets a value indicating whether this instance is canonical.
 		/// </summary>
@@ -119,6 +132,22 @@ namespace YamlDotNet.Core.Events
 			this.style = style;
 			this.isPlainImplicit = isPlainImplicit;
 			this.isQuotedImplicit = isQuotedImplicit;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Scalar"/> class.
+		/// </summary>
+		/// <param name="anchor">The anchor.</param>
+		/// <param name="tag">The tag.</param>
+		/// <param name="value">The value.</param>
+		/// <param name="style">The style.</param>
+		/// <param name="isPlainImplicit">.</param>
+		/// <param name="isQuotedImplicit">.</param>
+		/// <param name="isStyleable">Indicates if this scalar's style can be changed</param>
+		public Scalar(string anchor, string tag, string value, ScalarStyle style, bool isPlainImplicit, bool isQuotedImplicit, bool isAlreadyStyled)
+			: this(anchor, tag, value, style, isPlainImplicit, isQuotedImplicit)
+		{
+			this.isAlreadyStyled = isAlreadyStyled;
 		}
 
 		/// <summary>

--- a/YamlDotNet/Core/Events/Scalar.cs
+++ b/YamlDotNet/Core/Events/Scalar.cs
@@ -143,7 +143,7 @@ namespace YamlDotNet.Core.Events
 		/// <param name="style">The style.</param>
 		/// <param name="isPlainImplicit">.</param>
 		/// <param name="isQuotedImplicit">.</param>
-		/// <param name="isStyleable">Indicates if this scalar's style can be changed</param>
+        /// <param name="isAlreadyStyled">Indicates if this scalar's style can be changed</param>
 		public Scalar(string anchor, string tag, string value, ScalarStyle style, bool isPlainImplicit, bool isQuotedImplicit, bool isAlreadyStyled)
 			: this(anchor, tag, value, style, isPlainImplicit, isQuotedImplicit)
 		{

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -37,8 +37,7 @@ namespace YamlDotNet.Serialization.EventEmitters
 
 		public override void Emit(ScalarEventInfo eventInfo)
 		{
-			eventInfo.IsPlainImplicit = true;
-			eventInfo.Style = ScalarStyle.Plain;
+			var style = ScalarStyle.Plain;
 
 			var typeCode = eventInfo.Source.Value != null
 				? eventInfo.Source.Type.GetTypeCode()
@@ -74,7 +73,7 @@ namespace YamlDotNet.Serialization.EventEmitters
 				case TypeCode.Char:
 					eventInfo.Tag = "tag:yaml.org,2002:str";
 					eventInfo.RenderedValue = eventInfo.Source.Value.ToString();
-					eventInfo.Style = ScalarStyle.Any;
+					style = ScalarStyle.Any;
 					break;
 
 				case TypeCode.DateTime:
@@ -95,6 +94,12 @@ namespace YamlDotNet.Serialization.EventEmitters
 					}
 
 					throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "TypeCode.{0} is not supported.", typeCode));
+			}
+
+			eventInfo.IsPlainImplicit = true;
+			if (!eventInfo.IsAlreadyStyled)
+			{
+				eventInfo.Style = style;
 			}
 
 			base.Emit(eventInfo);

--- a/YamlDotNet/Serialization/EventEmitters/WriterEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/WriterEventEmitter.cs
@@ -40,7 +40,7 @@ namespace YamlDotNet.Serialization.EventEmitters
 
 		void IEventEmitter.Emit(ScalarEventInfo eventInfo)
 		{
-			emitter.Emit(new Scalar(eventInfo.Anchor, eventInfo.Tag, eventInfo.RenderedValue, eventInfo.Style, eventInfo.IsPlainImplicit, eventInfo.IsQuotedImplicit));
+			emitter.Emit(new Scalar(eventInfo.Anchor, eventInfo.Tag, eventInfo.RenderedValue, eventInfo.Style, eventInfo.IsPlainImplicit, eventInfo.IsQuotedImplicit, eventInfo.IsAlreadyStyled));
 		}
 
 		void IEventEmitter.Emit(MappingStartEventInfo eventInfo)

--- a/YamlDotNet/Serialization/EventInfo.cs
+++ b/YamlDotNet/Serialization/EventInfo.cs
@@ -57,15 +57,21 @@ namespace YamlDotNet.Serialization
 
 	public sealed class ScalarEventInfo : ObjectEventInfo
 	{
-		public ScalarEventInfo(IObjectDescriptor source)
+		public ScalarEventInfo(IObjectDescriptor source, ScalarStyle style)
 			: base(source)
 		{
+			if (style != ScalarStyle.Any)
+			{
+				Style = style;
+				IsAlreadyStyled = true;
+			}
 		}
 
 		public string RenderedValue { get; set; }
 		public ScalarStyle Style { get; set; }
 		public bool IsPlainImplicit { get; set; }
 		public bool IsQuotedImplicit { get; set; }
+		public bool IsAlreadyStyled { get; set; }
 	}
 
 	public sealed class MappingStartEventInfo : ObjectEventInfo

--- a/YamlDotNet/Serialization/IObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/IObjectGraphVisitor.cs
@@ -20,6 +20,7 @@
 //  SOFTWARE.
 
 using System;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization
 {
@@ -59,7 +60,8 @@ namespace YamlDotNet.Serialization
 		/// Notifies the visitor that a scalar value has been encountered.
 		/// </summary>
 		/// <param name="scalar">The value of the scalar.</param>
-		void VisitScalar(IObjectDescriptor scalar);
+		/// <param name="scalarStyle">The desired style of the scalar.</param>
+		void VisitScalar(IObjectDescriptor scalar, ScalarStyle scalarStyle);
 
 		/// <summary>
 		/// Notifies the visitor that the traversal of a mapping is about to begin.

--- a/YamlDotNet/Serialization/IPropertyDescriptor.cs
+++ b/YamlDotNet/Serialization/IPropertyDescriptor.cs
@@ -20,6 +20,7 @@
 //  SOFTWARE.
 
 using System;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization
 {
@@ -30,6 +31,7 @@ namespace YamlDotNet.Serialization
 		Type Type { get; }
 		Type TypeOverride { get; set; }
         int Order { get; set; }
+		ScalarStyle ScalarStyle { get; set; }
 
 		T GetCustomAttribute<T>() where T : Attribute;
 

--- a/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Serialization.Utilities;
 
@@ -72,7 +73,7 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
 			Traverse(graph, visitor, 0);
 		}
 
-		protected virtual void Traverse(IObjectDescriptor value, IObjectGraphVisitor visitor, int currentDepth)
+		protected virtual void Traverse(IObjectDescriptor value, IObjectGraphVisitor visitor, int currentDepth, ScalarStyle scalarStyle = ScalarStyle.Any)
 		{
 			if (++currentDepth > maxRecursion)
 			{
@@ -102,11 +103,11 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
 				case TypeCode.String:
 				case TypeCode.Char:
 				case TypeCode.DateTime:
-					visitor.VisitScalar(value);
+					visitor.VisitScalar(value, scalarStyle);
 					break;
 
 				case TypeCode.DBNull:
-					visitor.VisitScalar(new ObjectDescriptor(null, typeof(object), typeof(object)));
+					visitor.VisitScalar(new ObjectDescriptor(null, typeof(object), typeof(object)), scalarStyle);
 					break;
 
 				case TypeCode.Empty:
@@ -115,7 +116,7 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
 				default:
 					if (value.Value == null || value.Type == typeof(TimeSpan))
 					{
-						visitor.VisitScalar(value);
+						visitor.VisitScalar(value, scalarStyle);
 						break;
 					}
 
@@ -124,7 +125,7 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
 					{
 						// This is a nullable type, recursively handle it with its underlying type.
 						// Note that if it contains null, the condition above already took care of it
-						Traverse(new ObjectDescriptor(value.Value, underlyingType, value.Type), visitor, currentDepth);
+						Traverse(new ObjectDescriptor(value.Value, underlyingType, value.Type), visitor, currentDepth, scalarStyle);
 					}
 					else
 					{
@@ -238,7 +239,7 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
 				if (visitor.EnterMapping(propertyDescriptor, propertyValue))
 				{
 					Traverse(new ObjectDescriptor(propertyDescriptor.Name, typeof(string), typeof(string)), visitor, currentDepth);
-					Traverse(propertyValue, visitor, currentDepth);
+					Traverse(propertyValue, visitor, currentDepth, propertyDescriptor.ScalarStyle);
 				}
 			}
 

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigner.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigner.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization.ObjectGraphVisitors
 {
@@ -70,7 +71,7 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
 			return true;
 		}
 
-		void IObjectGraphVisitor.VisitScalar(IObjectDescriptor scalar) { }
+		void IObjectGraphVisitor.VisitScalar(IObjectDescriptor scalar, ScalarStyle scalarStyle) { }
 		void IObjectGraphVisitor.VisitMappingStart(IObjectDescriptor mapping, Type keyType, Type valueType) { }
 		void IObjectGraphVisitor.VisitMappingEnd(IObjectDescriptor mapping) { }
 		void IObjectGraphVisitor.VisitSequenceStart(IObjectDescriptor sequence, Type elementType) { }

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigningObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigningObjectGraphVisitor.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization.ObjectGraphVisitors
 {
@@ -59,9 +60,9 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
 			eventEmitter.Emit(new SequenceStartEventInfo(sequence) { Anchor = aliasProvider.GetAlias(sequence.Value) });
 		}
 
-		public override void VisitScalar(IObjectDescriptor scalar)
+		public override void VisitScalar(IObjectDescriptor scalar, ScalarStyle scalarStyle)
 		{
-			eventEmitter.Emit(new ScalarEventInfo(scalar) { Anchor = aliasProvider.GetAlias(scalar.Value) });
+			eventEmitter.Emit(new ScalarEventInfo(scalar, scalarStyle) { Anchor = aliasProvider.GetAlias(scalar.Value) });
 		}
 	}
 }

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/ChainedObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/ChainedObjectGraphVisitor.cs
@@ -20,6 +20,7 @@
 //  SOFTWARE.
 
 using System;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization.ObjectGraphVisitors
 {
@@ -47,9 +48,9 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
 			return nextVisitor.EnterMapping(key, value);
 		}
 
-		public virtual void VisitScalar(IObjectDescriptor scalar)
+		public virtual void VisitScalar(IObjectDescriptor scalar, ScalarStyle scalarStyle)
 		{
-			nextVisitor.VisitScalar(scalar);
+			nextVisitor.VisitScalar(scalar, scalarStyle);
 		}
 
 		public virtual void VisitMappingStart(IObjectDescriptor mapping, Type keyType, Type valueType)

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/EmittingObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/EmittingObjectGraphVisitor.cs
@@ -20,6 +20,7 @@
 //  SOFTWARE.
 
 using System;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization.ObjectGraphVisitors
 {
@@ -47,9 +48,9 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
 			return true;
 		}
 
-		void IObjectGraphVisitor.VisitScalar(IObjectDescriptor scalar)
+		void IObjectGraphVisitor.VisitScalar(IObjectDescriptor scalar, ScalarStyle scalarStyle)
 		{
-			eventEmitter.Emit(new ScalarEventInfo(scalar));
+			eventEmitter.Emit(new ScalarEventInfo(scalar, scalarStyle));
 		}
 
 		void IObjectGraphVisitor.VisitMappingStart(IObjectDescriptor mapping, Type keyType, Type valueType)

--- a/YamlDotNet/Serialization/PropertyDescriptor.cs
+++ b/YamlDotNet/Serialization/PropertyDescriptor.cs
@@ -20,6 +20,7 @@
 //  SOFTWARE.
 
 using System;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization
 {
@@ -31,6 +32,7 @@ namespace YamlDotNet.Serialization
 		{
 			this.baseDescriptor = baseDescriptor;
 			Name = baseDescriptor.Name;
+			ScalarStyle = ScalarStyle.Any;
 		}
 
 		public string Name { get; set; }
@@ -44,6 +46,8 @@ namespace YamlDotNet.Serialization
 		}
 
 	    public int Order { get; set; }
+
+		public ScalarStyle ScalarStyle { get; set; }
 
 	    public bool CanWrite
 		{

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization.TypeInspectors
 {
@@ -66,6 +67,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
 			{
 				_propertyInfo = propertyInfo;
 				_typeResolver = typeResolver;
+				ScalarStyle = ScalarStyle.Any;
 			}
 
 			public string Name { get { return _propertyInfo.Name; } }
@@ -73,6 +75,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
 			public Type TypeOverride { get; set; }
 		    public int Order { get; set; }
 		    public bool CanWrite { get { return _propertyInfo.CanWrite; } }
+			public ScalarStyle ScalarStyle { get; set; }
 
 			public void Write(object target, object value)
 			{

--- a/YamlDotNet/Serialization/YamlAttributesTypeInspector.cs
+++ b/YamlDotNet/Serialization/YamlAttributesTypeInspector.cs
@@ -63,6 +63,7 @@ namespace YamlDotNet.Serialization
 						}
 
 						descriptor.Order = member.Order;
+						descriptor.ScalarStyle = member.ScalarStyle;
 
 						if (member.Alias != null)
 						{

--- a/YamlDotNet/Serialization/YamlMember.cs
+++ b/YamlDotNet/Serialization/YamlMember.cs
@@ -20,6 +20,7 @@
 //  SOFTWARE.
 
 using System;
+using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization
 {
@@ -45,17 +46,23 @@ namespace YamlDotNet.Serialization
 		public string Alias { get; set; }
 
         /// <summary>
+        /// Specifies the scalar style of the property when serialized. This will only affect the serialization of scalar properties.
+        /// </summary>
+        public ScalarStyle ScalarStyle { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="YamlMemberAttribute" /> class.
         /// </summary>
         public YamlMemberAttribute()
         {
+            ScalarStyle = ScalarStyle.Any;
         }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="YamlMemberAttribute" /> class.
 		/// </summary>
 		/// <param name="serializeAs">Specifies that this property should be serialized as the given type, rather than using the actual runtime value's type.</param>
-		public YamlMemberAttribute(Type serializeAs)
+		public YamlMemberAttribute(Type serializeAs) : this()
 		{
 			SerializeAs = serializeAs;
 		}


### PR DESCRIPTION
Hi

As discussed in #122 these changes add a new property to the YamlMemberAttribute allowing the style of scalar values to specified.

This completely bypasses Emitter.SelectScalarStyle and does not check that the value is appropriate for the provided scalar style, leaving it up to the user to choose an appropriate style or ensure the the values are valid for the style. Is this suitable, or do you think we should check the values and scalar style to ensure  invalid YAML is not produced?