### PR TITLE
Fixed TypeConverter not finding implicit/explicit cast methods

### DIFF
--- a/YamlDotNet/Serialization/Utilities/TypeConverter.cs
+++ b/YamlDotNet/Serialization/Utilities/TypeConverter.cs
@@ -187,7 +187,7 @@ namespace YamlDotNet.Serialization.Utilities
 			// Try to find a casting operator in the source or destination type
 			foreach (var type in new[] { sourceType, destinationType })
 			{
-				foreach (var method in type.GetPublicMethods())
+				foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
 				{
 					var isCastingOperator =
 						method.IsSpecialName &&


### PR DESCRIPTION
TypeConverter was using Type.GetPublicMethods() which never finds op_Implicit or op_Explicit.