### PR TITLE
Update TypeNameInTagNodeTypeResolver.cs

### DIFF
--- a/YamlDotNet/Serialization/NodeTypeResolvers/TypeNameInTagNodeTypeResolver.cs
+++ b/YamlDotNet/Serialization/NodeTypeResolvers/TypeNameInTagNodeTypeResolver.cs
@@ -30,8 +30,14 @@ namespace YamlDotNet.Serialization.NodeTypeResolvers
 		{
 			if (!string.IsNullOrEmpty(nodeEvent.Tag))
 			{
-				currentType = Type.GetType(nodeEvent.Tag.Substring(1), true);
-				return true;
+				// If type could not be loaded, make sure to return false
+				// to pass resolving to the next resolver
+				try
+				{
+					currentType = Type.GetType(nodeEvent.Tag.Substring(1), true);
+					return true;
+				}
+				catch {	}
 			}
 			return false;
 		}


### PR DESCRIPTION
If the type could not be loaded, because it fails with an exception, make sure to return false to pass resolving to the next resolver in the list.