### PR TITLE
Re-implementing Parser: Add support for multi-document tag directives

### DIFF
--- a/YamlDotNet.Test/Core/ParserTests.cs
+++ b/YamlDotNet.Test/Core/ParserTests.cs
@@ -423,5 +423,28 @@ namespace YamlDotNet.Test.Core
 				}
 			}
 		}
+
+        [Fact]
+        public void VerifyTokenWithMultiDocTag()
+        {
+            AssertSequenceOfEventsFrom(Yaml.ParserForResource("multi-doc-tag.yaml"),
+                StreamStart,
+                DocumentStart(Explicit, Version(1, 1),
+                    TagDirective("!x!", "tag:example.com,2014:"),
+                    TagDirective("!", "!"),
+                    TagDirective("!!", TagYaml)),
+                BlockMappingStart.T("tag:example.com,2014:foo").Explicit,
+                PlainScalar("x"),
+                PlainScalar("0"),
+                MappingEnd,
+                DocumentEnd(Implicit),
+                DocumentStart(Explicit),
+                BlockMappingStart.T("tag:example.com,2014:bar").Explicit,
+                PlainScalar("x"),
+                PlainScalar("1"),
+                MappingEnd,
+                DocumentEnd(Implicit),
+                StreamEnd);
+        }
 	}
 }

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -131,6 +131,7 @@
     <EmbeddedResource Include="files\explicit-type.template" />
     <EmbeddedResource Include="files\guid.yaml" />
     <EmbeddedResource Include="files\ordered-properties.yaml" />
+    <EmbeddedResource Include="files\multi-doc-tag.yaml" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/YamlDotNet.Test/files/multi-doc-tag.yaml
+++ b/YamlDotNet.Test/files/multi-doc-tag.yaml
@@ -1,0 +1,6 @@
+﻿%YAML 1.1
+%TAG !x! tag:example.com,2014:
+--- !x!foo
+x: 0
+--- !x!bar
+x: 1

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -303,6 +303,7 @@ namespace YamlDotNet.Core
 		private VersionDirective ProcessDirectives(TagDirectiveCollection tags)
 		{
 			VersionDirective version = null;
+            bool hasOwnDirectives = false;
 
 			while (true)
 			{
@@ -322,18 +323,16 @@ namespace YamlDotNet.Core
 					}
 
 					version = currentVersion;
+                    hasOwnDirectives = true;
 				}
 				else if ((tag = GetCurrentToken() as TagDirective) != null)
 				{
-					if (tagDirectives.Contains(tag.Handle))
+                    if (tags.Contains(tag.Handle))
 					{
 						throw new SemanticErrorException(tag.Start, tag.End, "Found duplicate %TAG directive.");
 					}
-					tagDirectives.Add(tag);
-					if (tags != null)
-					{
-						tags.Add(tag);
-					}
+                    tags.Add(tag);
+                    hasOwnDirectives = true;
 				}
 				else
 				{
@@ -343,18 +342,21 @@ namespace YamlDotNet.Core
 				Skip();
 			}
 
-			if (tags != null)
+            AddTagDirectives(tags, Constants.DefaultTagDirectives);
+
+            if (hasOwnDirectives)
 			{
-				AddDefaultTagDirectives(tags);
+				tagDirectives.Clear();
 			}
-			AddDefaultTagDirectives(tagDirectives);
+
+            AddTagDirectives(tagDirectives, tags);
 
 			return version;
 		}
 
-		private static void AddDefaultTagDirectives(TagDirectiveCollection directives)
+        private static void AddTagDirectives(TagDirectiveCollection directives, IEnumerable<TagDirective> source)
 		{
-			foreach(var directive in Constants.DefaultTagDirectives)
+            foreach (var directive in source)
 			{
 				if (!directives.Contains(directive))
 				{
@@ -579,8 +581,6 @@ namespace YamlDotNet.Core
 				Skip();
 				isImplicit = false;
 			}
-
-			tagDirectives.Clear();
 
 			state = ParserState.DocumentStart;
 			return new Events.DocumentEnd(isImplicit, start, end);

--- a/YamlDotNet/Serialization/NodeTypeResolvers/TypeNameInTagNodeTypeResolver.cs
+++ b/YamlDotNet/Serialization/NodeTypeResolvers/TypeNameInTagNodeTypeResolver.cs
@@ -30,8 +30,14 @@ namespace YamlDotNet.Serialization.NodeTypeResolvers
 		{
 			if (!string.IsNullOrEmpty(nodeEvent.Tag))
 			{
-				currentType = Type.GetType(nodeEvent.Tag.Substring(1), true);
-				return true;
+                // If type could not be loaded, make sure to pass resolving
+                // to the next resolver
+			    try
+			    {
+			        currentType = Type.GetType(nodeEvent.Tag.Substring(1), true);
+                    return true;
+			    }
+			    catch { }
 			}
 			return false;
 		}


### PR DESCRIPTION
Especially to aid reading Unity scene files
Original PR https://github.com/aaubry/YamlDotNet/pull/102
