### PR TITLE
Fix a wrong return type

### DIFF
--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -229,7 +229,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 					return (sbyte)result;
 
 				case TypeCode.UInt16:
-					return (uint)result;
+					return (ushort)result;
 
 				case TypeCode.UInt32:
 					return (uint)result;


### PR DESCRIPTION
I accidentally made it return uint instead of ushort for the UInt16 case.