### PR TITLE
Properly handle non-Unicode encodings when emitting scalars.

### DIFF
--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -321,8 +321,7 @@ namespace YamlDotNet.Core
 
 			var lineBreaks = false;
 
-            var valueIsRepresentableInOutputEncoding = outputUsesUnicodeEncoding || output.Encoding.GetString(output.Encoding.GetBytes(value)).Equals(value);
-            var specialCharacters = !valueIsRepresentableInOutputEncoding;
+            var specialCharacters = !ValueIsRepresentableInOutputEncoding(value);
 
 			var isFirst = true;
 			while (!buffer.EndOfInput)
@@ -461,6 +460,29 @@ namespace YamlDotNet.Core
 			if (blockIndicators)
 				scalarData.isBlockPlainAllowed = false;
 		}
+
+        private bool ValueIsRepresentableInOutputEncoding(string value)
+        {
+            if (outputUsesUnicodeEncoding)
+            {
+                return true;
+            }
+
+            try
+            {
+                var encodedBytes = output.Encoding.GetBytes(value);
+                var decodedString = output.Encoding.GetString(encodedBytes, 0, encodedBytes.Length);
+                return decodedString.Equals(value);
+            }
+            catch (EncoderFallbackException)
+            {
+                return false;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return false;
+            }
+        }
 
         private bool IsUnicode(Encoding encoding)
 		{

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -41,6 +41,42 @@ namespace YamlDotNet
 #endif
 
 #if PORTABLE
+ 	/// <summary>
+	/// Mock UTF7Encoding to avoid having to add #if all over the place
+	/// </summary>
+   internal sealed class UTF7Encoding : System.Text.Encoding
+    {
+        public override int GetByteCount(char[] chars, int index, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetCharCount(byte[] bytes, int index, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetMaxByteCount(int charCount)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetMaxCharCount(int byteCount)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
 	/// <summary>
 	/// Mock SerializableAttribute to avoid having to add #if all over the place
 	/// </summary>


### PR DESCRIPTION
Fixes #159