### PR TITLE
Why is that null char here in the first place ?

### DIFF
--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -1702,7 +1702,7 @@ namespace YamlDotNet.Core
 
             if (analyzer.IsSpace() || analyzer.IsBreak())
             {
-                var indentHint = string.Format(CultureInfo.InvariantCulture, "{0}\0", bestIndent);
+                var indentHint = string.Format(CultureInfo.InvariantCulture, "{0}", bestIndent);
                 WriteIndicator(indentHint, false, false, false);
             }
 


### PR DESCRIPTION
Here is my pull request to try to fix the problem exposed in http://stackoverflow.com/questions/35681811/null-char-in-output-yaml-in-yamldotnet-serialization

(Unexpected `'\0'` char in yaml output when a scalar starts with a new line)

Here is a `dotnetfiddle.net` that shows the problem: https://dotnetfiddle.net/jqVcL3 

I don't understand the presence of the \0 in the source, so I assume it was a typo.