### PR TITLE
Yaml Attribute overrides

### DIFF
--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -270,6 +270,11 @@ namespace YamlDotNet
         {
             return ex.InnerException;
         }
+        
+        public static bool IsInstanceOf(this Type type, object o)
+        {
+        	return o.GetType() == type || o.GetType().GetTypeInfo().IsSubclassOf(type)
+        }
     }
 
     internal enum TypeCode
@@ -396,6 +401,11 @@ namespace YamlDotNet
                 remoteStackTraceField.SetValue(ex.InnerException, ex.InnerException.StackTrace + "\r\n");
             }
             return result;
+        }
+        
+        public static bool IsInstanceOf(this Type type, object o)
+        {
+        	return type.IsInstanceOfType(o);
         }
     }
 

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -273,7 +273,7 @@ namespace YamlDotNet
         
         public static bool IsInstanceOf(this Type type, object o)
         {
-        	return o.GetType() == type || o.GetType().GetTypeInfo().IsSubclassOf(type)
+        	return o.GetType() == type || o.GetType().GetTypeInfo().IsSubclassOf(type);
         }
     }
 

--- a/YamlDotNet/Serialization/Deserializer.cs
+++ b/YamlDotNet/Serialization/Deserializer.cs
@@ -85,17 +85,17 @@ namespace YamlDotNet.Serialization
             typeDescriptor.TypeDescriptor =
                 new CachedTypeInspector(
                     new YamlAttributesTypeInspector(
-            			new YamlAttributeOverridesInspector(
-	                        new NamingConventionTypeInspector(
-	                            new ReadableAndWritablePropertiesTypeInspector(
-	                                new ReadablePropertiesTypeInspector(
-	                                    new StaticTypeResolver()
-	                                )
-	                            ),
-	                            namingConvention
-	                        ),
-            				overrides
-            			)
+                        new YamlAttributeOverridesInspector(
+                            new NamingConventionTypeInspector(
+                                new ReadableAndWritablePropertiesTypeInspector(
+                                    new ReadablePropertiesTypeInspector(
+                                        new StaticTypeResolver()
+                                    )
+                                ),
+                                namingConvention
+                            ),
+                            overrides
+                        )
                     )
                 );
 

--- a/YamlDotNet/Serialization/Deserializer.cs
+++ b/YamlDotNet/Serialization/Deserializer.cs
@@ -76,7 +76,8 @@ namespace YamlDotNet.Serialization
         public Deserializer(
             IObjectFactory objectFactory = null,
             INamingConvention namingConvention = null,
-            bool ignoreUnmatched = false)
+            bool ignoreUnmatched = false,
+            YamlAttributeOverrides overrides = null)
         {
             objectFactory = objectFactory ?? new DefaultObjectFactory();
             namingConvention = namingConvention ?? new NullNamingConvention();
@@ -84,14 +85,17 @@ namespace YamlDotNet.Serialization
             typeDescriptor.TypeDescriptor =
                 new CachedTypeInspector(
                     new YamlAttributesTypeInspector(
-                        new NamingConventionTypeInspector(
-                            new ReadableAndWritablePropertiesTypeInspector(
-                                new ReadablePropertiesTypeInspector(
-                                    new StaticTypeResolver()
-                                )
-                            ),
-                            namingConvention
-                        )
+            			new YamlAttributeOverridesInspector(
+	                        new NamingConventionTypeInspector(
+	                            new ReadableAndWritablePropertiesTypeInspector(
+	                                new ReadablePropertiesTypeInspector(
+	                                    new StaticTypeResolver()
+	                                )
+	                            ),
+	                            namingConvention
+	                        ),
+            				overrides
+            			)
                     )
                 );
 

--- a/YamlDotNet/Serialization/Serializer.cs
+++ b/YamlDotNet/Serialization/Serializer.cs
@@ -43,16 +43,19 @@ namespace YamlDotNet.Serialization
         private readonly SerializationOptions options;
         private readonly INamingConvention namingConvention;
         private readonly ITypeResolver typeResolver;
+        private readonly YamlAttributeOverrides overrides;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="options">Options that control how the serialization is to be performed.</param>
         /// <param name="namingConvention">Naming strategy to use for serialized property names</param>
-        public Serializer(SerializationOptions options = SerializationOptions.None, INamingConvention namingConvention = null)
+        /// <param name="overrides">Yaml attribute overrides</param>
+        public Serializer(SerializationOptions options = SerializationOptions.None, INamingConvention namingConvention = null, YamlAttributeOverrides overrides = null)
         {
             this.options = options;
             this.namingConvention = namingConvention ?? new NullNamingConvention();
+            this.overrides = overrides;
 
             Converters = new List<IYamlTypeConverter>();
             foreach (IYamlTypeConverter yamlTypeConverter in Utilities.YamlTypeConverters.GetBuiltInConverters(IsOptionSet(SerializationOptions.JsonCompatible)))
@@ -195,6 +198,9 @@ namespace YamlDotNet.Serialization
             }
 
             typeDescriptor = new NamingConventionTypeInspector(typeDescriptor, namingConvention);
+
+            typeDescriptor = new YamlAttributeOverridesInspector(typeDescriptor, overrides);
+
             typeDescriptor = new YamlAttributesTypeInspector(typeDescriptor);
             if (IsOptionSet(SerializationOptions.DefaultToStaticType))
             {

--- a/YamlDotNet/Serialization/YamlAttributeOverrides.cs
+++ b/YamlDotNet/Serialization/YamlAttributeOverrides.cs
@@ -1,0 +1,93 @@
+﻿//  This file is part of YamlDotNet - A .NET library for YAML.
+//  Copyright (c) Antoine Aubry and contributors
+    
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//  of the Software, and to permit persons to whom the Software is furnished to do
+//  so, subject to the following conditions:
+    
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+    
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Globalization;
+using System.Collections.Generic;
+
+namespace YamlDotNet.Serialization
+{
+    /// <summary>
+    /// Define a collection of YamlAttribute Overrides for pre-defined object types.
+    /// </summary>
+    public sealed class YamlAttributeOverrides
+    {
+        private readonly Dictionary<Type, Dictionary<string, List<Attribute>>> overrides = new Dictionary<Type, Dictionary<string, List<Attribute>>>();
+        
+        public ICollection<Attribute> this[Type type, string member]
+        {
+        	get
+        	{
+        		Dictionary<string, List<Attribute>> dict;
+	            if (!overrides.TryGetValue(type, out dict))
+	            	return null;
+	            
+	            List<Attribute> list;
+	            if (!dict.TryGetValue(member, out list))
+	            	return null;
+	            
+	            return list;
+        	}
+        }
+        
+        public T GetAttribute<T>(Type type, string member) where T : Attribute
+        {
+       		var list = this[type, member];
+       		return list == null ? null : list.OfType<T>().FirstOrDefault();
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YamlAttributeOverrides"/> class.
+        /// </summary>
+        public YamlAttributeOverrides()
+        {
+        }
+        
+        /// <summary>
+        /// Add a Member Attribute Override
+        /// </summary>
+        /// <param name="type">Type</param>
+        /// <param name="member">Class Member</param>
+        /// <param name="attribute">Overriding Attribute</param>
+        public void Add(Type type, string member, Attribute attribute)
+        {
+            Dictionary<string, List<Attribute>> dict;
+            if (!overrides.TryGetValue(type, out dict))
+            {
+                dict = new Dictionary<string, List<Attribute>>();
+                overrides.Add(type, dict);
+            }
+            
+            List<Attribute> list;
+            if (!dict.TryGetValue(member, out list))
+            {
+            	list = new List<Attribute>();
+            	dict.Add(member, list);
+            }
+            
+            if (list.Any(attr => attr.GetType().IsInstanceOfType(attribute)))
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Attribute ({3}) already set for Type {0}, Member {1}", type.FullName, member, attribute));
+
+            list.Add(attribute);
+        }        
+    }
+}

--- a/YamlDotNet/Serialization/YamlAttributeOverrides.cs
+++ b/YamlDotNet/Serialization/YamlAttributeOverrides.cs
@@ -84,7 +84,7 @@ namespace YamlDotNet.Serialization
             	dict.Add(member, list);
             }
             
-            if (list.Any(attr => attr.GetType().IsInstanceOfType(attribute)))
+            if (list.Any(attr => attr.GetType().IsInstanceOf(attribute)))
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Attribute ({3}) already set for Type {0}, Member {1}", type.FullName, member, attribute));
 
             list.Add(attribute);

--- a/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
+++ b/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
@@ -43,65 +43,74 @@ namespace YamlDotNet.Serialization
         
         public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)
         {
-        	if (overrides == null)
-        		return innerTypeDescriptor.GetProperties(type, container);
-        	
+            if (overrides == null)
+                return innerTypeDescriptor.GetProperties(type, container);
+            
             return innerTypeDescriptor.GetProperties(type, container)
-            	.Select(p => (IPropertyDescriptor)new OverridePropertyDescriptor(p, overrides, type));
+                .Select(p => (IPropertyDescriptor)new OverridePropertyDescriptor(p, overrides, type));
         }
         
         public sealed class OverridePropertyDescriptor : IPropertyDescriptor
-	    {
-	        private readonly IPropertyDescriptor baseDescriptor;
-	        private readonly YamlAttributeOverrides overrides;
-	        private readonly Type classType;
-	
-	        public OverridePropertyDescriptor(IPropertyDescriptor baseDescriptor, YamlAttributeOverrides overrides, Type classType)
-	        {
-	            this.baseDescriptor = baseDescriptor;
-	            this.overrides = overrides;
-	            this.classType = classType;
-	        }
-	
-	        public string Name { get { return baseDescriptor.Name; } }
-	
-	        public bool CanWrite { get { return baseDescriptor.CanWrite; } }
+        {
+            private readonly IPropertyDescriptor baseDescriptor;
+            private readonly YamlAttributeOverrides overrides;
+            private readonly Type classType;
+    
+            public OverridePropertyDescriptor(IPropertyDescriptor baseDescriptor, YamlAttributeOverrides overrides, Type classType)
+            {
+                this.baseDescriptor = baseDescriptor;
+                this.overrides = overrides;
+                this.classType = classType;
+            }
+    
+            public string Name { get { return baseDescriptor.Name; } }
+    
+            public bool CanWrite { get { return baseDescriptor.CanWrite; } }
 
-	        public Type Type { get { return baseDescriptor.Type; } }
-	
-	        public Type TypeOverride
-	        {
-	            get { return baseDescriptor.TypeOverride; }
-	            set { baseDescriptor.TypeOverride = value; }
-	        }
-	
-	        public int Order
-	        {
-	            get { return baseDescriptor.Order; }
-	            set { baseDescriptor.Order = value; }
-	        }
-	
-	        public ScalarStyle ScalarStyle
-	        {
-	            get { return baseDescriptor.ScalarStyle; }
-	            set { baseDescriptor.ScalarStyle = value; }
-	        }
-		
-	        public void Write(object target, object value)
-	        {
-	            baseDescriptor.Write(target, value);
-	        }
-	
-	        public T GetCustomAttribute<T>() where T : Attribute
-	        {
-	        	var attr = overrides.GetAttribute<T>(classType, Name);
-	        	return attr ?? baseDescriptor.GetCustomAttribute<T>();
-	        }
-	
-	        public IObjectDescriptor Read(object target)
-	        {
-	            return baseDescriptor.Read(target);
-	        }
-	    }
+            public Type Type { get { return baseDescriptor.Type; } }
+    
+            public Type TypeOverride
+            {
+                get { return baseDescriptor.TypeOverride; }
+                set { baseDescriptor.TypeOverride = value; }
+            }
+    
+            public int Order
+            {
+                get { return baseDescriptor.Order; }
+                set { baseDescriptor.Order = value; }
+            }
+    
+            public ScalarStyle ScalarStyle
+            {
+                get { return baseDescriptor.ScalarStyle; }
+                set { baseDescriptor.ScalarStyle = value; }
+            }
+        
+            public void Write(object target, object value)
+            {
+                baseDescriptor.Write(target, value);
+            }
+    
+            public T GetCustomAttribute<T>() where T : Attribute
+            {
+                // Check for a Property
+                var prop = classType.GetProperty(Name);
+                if (prop != null)
+                {
+                    var attr = overrides.GetAttribute<T>(prop.DeclaringType, Name);
+                    if (attr != null)
+                        return attr;
+                }
+                
+                // Default to base behavior
+                return baseDescriptor.GetCustomAttribute<T>();
+            }
+    
+            public IObjectDescriptor Read(object target)
+            {
+                return baseDescriptor.Read(target);
+            }
+        }
     }
 }

--- a/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
+++ b/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
@@ -1,0 +1,107 @@
+﻿//  This file is part of YamlDotNet - A .NET library for YAML.
+//  Copyright (c) Antoine Aubry and contributors
+
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//  of the Software, and to permit persons to whom the Software is furnished to do
+//  so, subject to the following conditions:
+
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization.TypeInspectors;
+
+namespace YamlDotNet.Serialization
+{
+    /// <summary>
+    /// Applies the Yaml attribute overrides to another <see cref="ITypeInspector"/>.
+    /// </summary>
+    public sealed class YamlAttributeOverridesInspector : TypeInspectorSkeleton
+    {
+        private readonly ITypeInspector innerTypeDescriptor;
+        private readonly YamlAttributeOverrides overrides;
+
+        public YamlAttributeOverridesInspector(ITypeInspector innerTypeDescriptor, YamlAttributeOverrides overrides)
+        {
+            this.innerTypeDescriptor = innerTypeDescriptor;
+            this.overrides = overrides;
+        }
+        
+        public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)
+        {
+        	if (overrides == null)
+        		return innerTypeDescriptor.GetProperties(type, container);
+        	
+            return innerTypeDescriptor.GetProperties(type, container)
+            	.Select(p => (IPropertyDescriptor)new OverridePropertyDescriptor(p, overrides, type));
+        }
+        
+        public sealed class OverridePropertyDescriptor : IPropertyDescriptor
+	    {
+	        private readonly IPropertyDescriptor baseDescriptor;
+	        private readonly YamlAttributeOverrides overrides;
+	        private readonly Type classType;
+	
+	        public OverridePropertyDescriptor(IPropertyDescriptor baseDescriptor, YamlAttributeOverrides overrides, Type classType)
+	        {
+	            this.baseDescriptor = baseDescriptor;
+	            this.overrides = overrides;
+	            this.classType = classType;
+	        }
+	
+	        public string Name { get { return baseDescriptor.Name; } }
+	
+	        public bool CanWrite { get { return baseDescriptor.CanWrite; } }
+
+	        public Type Type { get { return baseDescriptor.Type; } }
+	
+	        public Type TypeOverride
+	        {
+	            get { return baseDescriptor.TypeOverride; }
+	            set { baseDescriptor.TypeOverride = value; }
+	        }
+	
+	        public int Order
+	        {
+	            get { return baseDescriptor.Order; }
+	            set { baseDescriptor.Order = value; }
+	        }
+	
+	        public ScalarStyle ScalarStyle
+	        {
+	            get { return baseDescriptor.ScalarStyle; }
+	            set { baseDescriptor.ScalarStyle = value; }
+	        }
+		
+	        public void Write(object target, object value)
+	        {
+	            baseDescriptor.Write(target, value);
+	        }
+	
+	        public T GetCustomAttribute<T>() where T : Attribute
+	        {
+	        	var attr = overrides.GetAttribute<T>(classType, Name);
+	        	return attr ?? baseDescriptor.GetCustomAttribute<T>();
+	        }
+	
+	        public IObjectDescriptor Read(object target)
+	        {
+	            return baseDescriptor.Read(target);
+	        }
+	    }
+    }
+}

--- a/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
+++ b/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
@@ -95,7 +95,7 @@ namespace YamlDotNet.Serialization
             public T GetCustomAttribute<T>() where T : Attribute
             {
                 // Check for a Property
-                var prop = classType.GetProperty(Name);
+                var prop = classType.GetPublicProperty(Name);
                 if (prop != null)
                 {
                     var attr = overrides.GetAttribute<T>(prop.DeclaringType, Name);

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -303,6 +303,8 @@
     <Compile Include="Serialization\ValueDeserializers\AliasValueDeserializer.cs" />
     <Compile Include="Serialization\ValueDeserializers\NodeValueDeserializer.cs" />
     <Compile Include="Serialization\YamlAliasAttribute.cs" />
+    <Compile Include="Serialization\YamlAttributeOverrides.cs" />
+    <Compile Include="Serialization\YamlAttributeOverridesInspector.cs" />
     <Compile Include="Serialization\YamlAttributesTypeInspector.cs" />
     <Compile Include="Serialization\YamlFormatter.cs" />
     <Compile Include="Serialization\YamlIgnoreAttribute.cs" />


### PR DESCRIPTION
Implementation of Serializer Attribute Overriding Feature.

I wanted to switch from .NET XML Serializer to YamlDotNet Serializer but there is a lack of Seralizer customization...

I was using intensively XML Attribute Overrides with the XML Serializer to map classes that didn't implement specific attributes, this is useful to serialize class by reflection and have format agnostic importer/exporter !

In this PR I tried to rely as most as possible on existing inner behavior of YamlDotNet to rely on existing ```YamlAttributesTypeInspector``` and provide overriding for any current or future Yaml Attribute.

I provided a few Unit Tests.