### PR TITLE
Add a YamlNodeType enumeration property to nodes

### DIFF
--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -38,6 +38,7 @@ namespace YamlDotNet.Test.RepresentationModel
             Assert.Equal(1, stream.Documents.Count);
             Assert.IsType<YamlScalarNode>(stream.Documents[0].RootNode);
             Assert.Equal("a scalar", ((YamlScalarNode)stream.Documents[0].RootNode).Value);
+            Assert.Equal (YamlNodeType.Scalar, stream.Documents[0].RootNode.NodeType);
         }
         
         [Fact]

--- a/YamlDotNet/RepresentationModel/YamlAliasNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlAliasNode.cs
@@ -106,5 +106,13 @@ namespace YamlDotNet.RepresentationModel
         {
             get { yield return this; }
         }
+
+        /// <summary>
+        /// Gets the type of node.
+        /// </summary>
+        public override YamlNodeType NodeType
+        {
+            get { return YamlNodeType.Alias; }
+        }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -336,6 +336,14 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
+        /// Gets the type of node.
+        /// </summary>
+        public override YamlNodeType NodeType
+        {
+            get { return YamlNodeType.Mapping; }
+        }
+
+        /// <summary>
         /// Returns a <see cref="System.String"/> that represents this instance.
         /// </summary>
         /// <returns>

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -204,5 +204,13 @@ namespace YamlDotNet.RepresentationModel
         {
             get;
         }
+
+        /// <summary>
+        /// Gets the type of node.
+        /// </summary>
+        public abstract YamlNodeType NodeType
+        {
+            get;
+        }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlNodeType.cs
+++ b/YamlDotNet/RepresentationModel/YamlNodeType.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace YamlDotNet.RepresentationModel
+{
+    /// <summary>
+    /// Specifies the type of node in the representation model.
+    /// </summary>
+    public enum YamlNodeType
+    {
+        /// <summary>
+        /// The node is a <see cref="YamlAliasNode"/>.
+        /// </summary>
+        Alias,
+
+        /// <summary>
+        /// The node is a <see cref="YamlMappingNode"/>.
+        /// </summary>
+        Mapping,
+
+        /// <summary>
+        /// The node is a <see cref="YamlScalarNode"/>.
+        /// </summary>
+        Scalar,
+
+        /// <summary>
+        /// The node is a <see cref="YamlSequenceNode"/>.
+        /// </summary>
+        Sequence
+    }
+}

--- a/YamlDotNet/RepresentationModel/YamlScalarNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlScalarNode.cs
@@ -164,5 +164,13 @@ namespace YamlDotNet.RepresentationModel
         {
             get { yield return this; }
         }
+
+        /// <summary>
+        /// Gets the type of node.
+        /// </summary>
+        public override YamlNodeType NodeType
+        {
+            get { return YamlNodeType.Scalar; }
+        }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -236,6 +236,14 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
+        /// Gets the type of node.
+        /// </summary>
+        public override YamlNodeType NodeType
+        {
+            get { return YamlNodeType.Sequence; }
+        }
+
+        /// <summary>
         /// Returns a <see cref="System.String"/> that represents this instance.
         /// </summary>
         /// <returns>

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -225,6 +225,7 @@
     <Compile Include="RepresentationModel\YamlMappingNode.cs" />
     <Compile Include="RepresentationModel\YamlNode.cs" />
     <Compile Include="RepresentationModel\YamlNodeIdentityEqualityComparer.cs" />
+    <Compile Include="RepresentationModel\YamlNodeType.cs" />
     <Compile Include="RepresentationModel\YamlScalarNode.cs" />
     <Compile Include="RepresentationModel\YamlSequenceNode.cs" />
     <Compile Include="RepresentationModel\YamlStream.cs" />


### PR DESCRIPTION
This makes processing easier than just trying to use as/is
all over when processing a doc. This is similar to the way
System.Linq.Expressions namespace does it.