### PR TITLE
Improve the usability of YamlDocument et al

### DIFF
--- a/YamlDotNet.Test/Serialization/RepresentationModelSerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/RepresentationModelSerializationTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.Test.Serialization
+{
+    public class RepresentationModelSerializationTests
+    {
+        [Theory]
+        [InlineData("hello", "hello")]
+        [InlineData("'hello'", "hello")]
+        [InlineData("\"hello\"", "hello")]
+        [InlineData("!!int 123", "123")]
+        public void ScalarIsSerializable(string yaml, string expectedValue)
+        {
+            var deserializer = new Deserializer();
+            var node = deserializer.Deserialize<YamlScalarNode>(Yaml.ReaderForText(yaml));
+
+            Assert.NotNull(node);
+            Assert.Equal(expectedValue, node.Value);
+
+            var serializer = new Serializer();
+            var buffer = new StringWriter();
+            serializer.Serialize(buffer, node);
+            Assert.Equal(yaml, buffer.ToString().TrimEnd('\r', '\n', '.'));
+        }
+
+        [Theory]
+        [InlineData("[a]", new[] { "a" })]
+        [InlineData("['a']", new[] { "a" })]
+        [InlineData("- a\r\n- b", new[] { "a", "b" })]
+        public void SequenceIsSerializable(string yaml, string[] expectedValues)
+        {
+            var deserializer = new Deserializer();
+            var node = deserializer.Deserialize<YamlSequenceNode>(Yaml.ReaderForText(yaml));
+
+            Assert.NotNull(node);
+            Assert.Equal(expectedValues.Length, node.Children.Count);
+            for (int i = 0; i < expectedValues.Length; i++)
+            {
+                Assert.Equal(expectedValues[i], ((YamlScalarNode)node.Children[i]).Value);
+            }
+
+            var serializer = new Serializer();
+            var buffer = new StringWriter();
+            serializer.Serialize(buffer, node);
+            Assert.Equal(yaml, buffer.ToString().TrimEnd('\r', '\n', '.'));
+        }
+
+        [Theory]
+        [InlineData("{a: b}", new[] { "a", "b" })]
+        [InlineData("{'a': \"b\"}", new[] { "a", "b" })]
+        [InlineData("a: b\r\nc: d", new[] { "a", "b", "c", "d" })]
+        public void MappingIsSerializable(string yaml, string[] expectedKeysAndValues)
+        {
+            var deserializer = new Deserializer();
+            var node = deserializer.Deserialize<YamlMappingNode>(Yaml.ReaderForText(yaml));
+
+            Assert.NotNull(node);
+            Assert.Equal(expectedKeysAndValues.Length / 2, node.Children.Count);
+            for (int i = 0; i < expectedKeysAndValues.Length; i += 2)
+            {
+                Assert.Equal(expectedKeysAndValues[i + 1], ((YamlScalarNode)node.Children[expectedKeysAndValues[i]]).Value);
+            }
+
+            var serializer = new Serializer();
+            var buffer = new StringWriter();
+            serializer.Serialize(buffer, node);
+            Assert.Equal(yaml, buffer.ToString().TrimEnd('\r', '\n', '.'));
+        }
+    }
+
+    public class ByteArrayConverter : IYamlTypeConverter
+    {
+        public bool Accepts(Type type)
+        {
+            return type == typeof(byte[]);
+        }
+
+        public object ReadYaml(IParser parser, Type type)
+        {
+            var scalar = (YamlDotNet.Core.Events.Scalar)parser.Current;
+            var bytes = Convert.FromBase64String(scalar.Value);
+            parser.MoveNext();
+            return bytes;
+        }
+
+        public void WriteYaml(IEmitter emitter, object value, Type type)
+        {
+            var bytes = (byte[])value;
+            emitter.Emit(new YamlDotNet.Core.Events.Scalar(
+                null,
+                "tag:yaml.org,2002:binary",
+                Convert.ToBase64String(bytes),
+                ScalarStyle.Plain,
+                false,
+                false
+            ));
+        }
+    }
+}

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Serialization\GenericTestList.cs" />
     <Compile Include="Serialization\NamingConventionTests.cs" />
     <Compile Include="Serialization\ObjectFactoryTests.cs" />
+    <Compile Include="Serialization\RepresentationModelSerializationTests.cs" />
     <Compile Include="Serialization\SerializationTestHelper.cs" />
     <Compile Include="Serialization\SerializationTests.cs" />
     <Compile Include="Serialization\CodeValidations.cs" />

--- a/YamlDotNet/RepresentationModel/YamlDocument.cs
+++ b/YamlDotNet/RepresentationModel/YamlDocument.cs
@@ -149,7 +149,7 @@ namespace YamlDotNet.RepresentationModel
 
             protected override void Visit(YamlScalarNode scalar)
             {
-                VisitNode(scalar);
+                // Do not assign anchors to scalars
             }
 
             protected override void Visit(YamlMappingNode mapping)

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -70,6 +70,7 @@ namespace YamlDotNet.RepresentationModel
         {
             MappingStart mapping = events.Expect<MappingStart>();
             base.Load(mapping, state);
+            Style = mapping.Style;
 
             bool hasUnresolvedAliases = false;
             while (!events.Accept<MappingEnd>())

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -415,7 +415,7 @@ namespace YamlDotNet.RepresentationModel
             }
 
             var result = new YamlMappingNode();
-            foreach (var property in mapping.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            foreach (var property in mapping.GetType().GetPublicProperties())
             {
                 if (property.CanRead && property.GetGetMethod().GetParameters().Length == 0)
                 {

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
@@ -400,6 +401,29 @@ namespace YamlDotNet.RepresentationModel
         void IYamlConvertible.Write(IEmitter emitter)
         {
             Emit(emitter, new EmitterState());
+        }
+
+        /// <summary>
+        /// Creates a <see cref="YamlMappingNode" /> containing a key-value pair for each property of the specified object.
+        /// </summary>
+        public static YamlMappingNode FromObject(object mapping)
+        {
+            if (mapping == null)
+            {
+                throw new ArgumentNullException("mapping");
+            }
+
+            var result = new YamlMappingNode();
+            foreach (var property in mapping.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                if (property.CanRead && property.GetGetMethod().GetParameters().Length == 0)
+                {
+                    var value = property.GetValue(mapping, null);
+                    var valueNode = (value as YamlNode) ?? (Convert.ToString(value));
+                    result.Add(property.Name, valueNode);
+                }
+            }
+            return result;
         }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -212,5 +212,15 @@ namespace YamlDotNet.RepresentationModel
         {
             get;
         }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="System.String"/> to <see cref="YamlDotNet.RepresentationModel.YamlNode"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator YamlNode(string value)
+        {
+            return new YamlScalarNode(value);
+        }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -1,16 +1,16 @@
 //  This file is part of YamlDotNet - A .NET library for YAML.
 //  Copyright (c) Antoine Aubry and contributors
-    
+
 //  Permission is hereby granted, free of charge, to any person obtaining a copy of
 //  this software and associated documentation files (the "Software"), to deal in
 //  the Software without restriction, including without limitation the rights to
 //  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 //  of the Software, and to permit persons to whom the Software is furnished to do
 //  so, subject to the following conditions:
-    
+
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
-    
+
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,6 +20,7 @@
 //  SOFTWARE.
 
 using System;
+using System.Linq;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using System.Collections.Generic;
@@ -221,6 +222,46 @@ namespace YamlDotNet.RepresentationModel
         public static implicit operator YamlNode(string value)
         {
             return new YamlScalarNode(value);
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from string[] to <see cref="YamlDotNet.RepresentationModel.YamlNode"/>.
+        /// </summary>
+        /// <param name="sequence">The value.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator YamlNode(string[] sequence)
+        {
+            return new YamlSequenceNode(sequence.Select(i => (YamlNode)i));
+        }
+
+        /// <summary>
+        /// Converts a <see cref="YamlScalarNode" /> to a string by returning its value.
+        /// </summary>
+        public static explicit operator string(YamlNode scalar)
+        {
+            return ((YamlScalarNode)scalar).Value;
+        }
+
+        /// <summary>
+        /// Gets the nth element in a <see cref="YamlSequenceNode" />.
+        /// </summary>
+        public YamlNode this[int index]
+        {
+            get
+            {
+                return ((YamlSequenceNode)this).Children[index];
+            }
+        }
+
+        /// <summary>
+        /// Gets the value associated with a key in a <see cref="YamlMappingNode" />.
+        /// </summary>
+        public YamlNode this[YamlNode key]
+        {
+            get
+            {
+                return ((YamlMappingNode)this).Children[key];
+            }
         }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlScalarNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlScalarNode.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
 
 namespace YamlDotNet.RepresentationModel
 {
@@ -33,7 +34,7 @@ namespace YamlDotNet.RepresentationModel
     /// </summary>
     [DebuggerDisplay("{Value}")]
     [Serializable]
-    public class YamlScalarNode : YamlNode
+    public class YamlScalarNode : YamlNode, IYamlConvertible
     {
         /// <summary>
         /// Gets or sets the value of the node.
@@ -54,8 +55,13 @@ namespace YamlDotNet.RepresentationModel
         /// <param name="state">The state.</param>
         internal YamlScalarNode(EventReader events, DocumentLoadingState state)
         {
+            Load(events, state);
+        }
+
+        private void Load(EventReader events, DocumentLoadingState state)
+        {
             Scalar scalar = events.Expect<Scalar>();
-            Load(scalar, state);
+            base.Load(scalar, state);
             Value = scalar.Value;
             Style = scalar.Style;
         }
@@ -92,7 +98,7 @@ namespace YamlDotNet.RepresentationModel
         /// <param name="state">The state.</param>
         internal override void Emit(IEmitter emitter, EmitterState state)
         {
-            emitter.Emit(new Scalar(Anchor, Tag, Value, Style, true, false));
+            emitter.Emit(new Scalar(Anchor, Tag, Value, Style, Tag == null, false));
         }
         
         /// <summary>
@@ -171,6 +177,16 @@ namespace YamlDotNet.RepresentationModel
         public override YamlNodeType NodeType
         {
             get { return YamlNodeType.Scalar; }
+        }
+
+        void IYamlConvertible.Read(EventReader reader, Type expectedType, Func<EventReader, Type, object> nestedObjectDeserializer)
+        {
+            Load(reader, new DocumentLoadingState());
+        }
+
+        void IYamlConvertible.Write(IEmitter emitter)
+        {
+            Emit(emitter, new EmitterState());
         }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlScalarNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlScalarNode.cs
@@ -133,16 +133,6 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="System.String"/> to <see cref="YamlDotNet.RepresentationModel.YamlScalarNode"/>.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        /// <returns>The result of the conversion.</returns>
-        public static implicit operator YamlScalarNode(string value)
-        {
-            return new YamlScalarNode(value);
-        }
-
-        /// <summary>
         /// Performs an explicit conversion from <see cref="YamlDotNet.RepresentationModel.YamlScalarNode"/> to <see cref="System.String"/>.
         /// </summary>
         /// <param name="value">The value.</param>

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -72,6 +72,7 @@ namespace YamlDotNet.RepresentationModel
         {
             SequenceStart sequence = events.Expect<SequenceStart>();
             base.Load(sequence, state);
+            Style = sequence.Style;
 
             bool hasUnresolvedAliases = false;
             while (!events.Accept<SequenceEnd>())

--- a/YamlDotNet/Serialization/Deserializer.cs
+++ b/YamlDotNet/Serialization/Deserializer.cs
@@ -106,6 +106,8 @@ namespace YamlDotNet.Serialization
             }
 
             NodeDeserializers = new List<INodeDeserializer>();
+            NodeDeserializers.Add(new YamlConvertibleNodeDeserializer(objectFactory));
+            NodeDeserializers.Add(new YamlSerializableNodeDeserializer(objectFactory));
             NodeDeserializers.Add(new TypeConverterNodeDeserializer(converters));
             NodeDeserializers.Add(new NullNodeDeserializer());
             NodeDeserializers.Add(new ScalarNodeDeserializer());
@@ -117,6 +119,8 @@ namespace YamlDotNet.Serialization
 
             tagMappings = new Dictionary<string, Type>(predefinedTagMappings);
             TypeResolvers = new List<INodeTypeResolver>();
+            TypeResolvers.Add(new YamlConvertibleTypeResolver());
+            TypeResolvers.Add(new YamlSerializableTypeResolver());
             TypeResolvers.Add(new TagNodeTypeResolver(tagMappings));
             TypeResolvers.Add(new TypeNameInTagNodeTypeResolver());
             TypeResolvers.Add(new DefaultContainersNodeTypeResolver());

--- a/YamlDotNet/Serialization/IYamlConvertible.cs
+++ b/YamlDotNet/Serialization/IYamlConvertible.cs
@@ -1,16 +1,16 @@
 //  This file is part of YamlDotNet - A .NET library for YAML.
 //  Copyright (c) Antoine Aubry and contributors
-    
+
 //  Permission is hereby granted, free of charge, to any person obtaining a copy of
 //  this software and associated documentation files (the "Software"), to deal in
 //  the Software without restriction, including without limitation the rights to
 //  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 //  of the Software, and to permit persons to whom the Software is furnished to do
 //  so, subject to the following conditions:
-    
+
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
-    
+
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,17 +27,16 @@ namespace YamlDotNet.Serialization
     /// <summary>
     /// Allows an object to customize how it is serialized and deserialized.
     /// </summary>
-    [Obsolete("Please use IYamlConvertible instead")]
-    public interface IYamlSerializable
+    public interface IYamlConvertible
     {
         /// <summary>
         /// Reads this object's state from a YAML parser.
         /// </summary>
-        void ReadYaml(IParser parser);
+        void Read(EventReader reader, Type expectedType, Func<EventReader, Type, object> nestedObjectDeserializer);
 
         /// <summary>
         /// Writes this object's state to a YAML emitter.
         /// </summary>
-        void WriteYaml(IEmitter emitter);
+        void Write(IEmitter emitter);
     }
 }

--- a/YamlDotNet/Serialization/NodeDeserializers/CollectionNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/CollectionNodeDeserializer.cs
@@ -67,7 +67,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             }
             else
             {
-                value = false;
+                value = null;
                 return false;
             }
 

--- a/YamlDotNet/Serialization/NodeDeserializers/YamlConvertibleNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/YamlConvertibleNodeDeserializer.cs
@@ -1,0 +1,50 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Serialization.NodeDeserializers
+{
+    public sealed class YamlConvertibleNodeDeserializer : INodeDeserializer
+    {
+        private readonly IObjectFactory objectFactory;
+
+        public YamlConvertibleNodeDeserializer(IObjectFactory objectFactory)
+        {
+			this.objectFactory = objectFactory;
+        }
+    
+        public bool Deserialize(EventReader reader, Type expectedType, Func<EventReader, Type, object> nestedObjectDeserializer, out object value)
+        {
+            if (typeof(IYamlConvertible).IsAssignableFrom(expectedType))
+            {
+                var convertible = (IYamlConvertible)objectFactory.Create(expectedType);
+                convertible.Read(reader, expectedType, nestedObjectDeserializer);
+                value = convertible;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/YamlDotNet/Serialization/NodeDeserializers/YamlSerializableNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/YamlSerializableNodeDeserializer.cs
@@ -1,0 +1,52 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Serialization.NodeDeserializers
+{
+    public sealed class YamlSerializableNodeDeserializer : INodeDeserializer
+    {
+        private readonly IObjectFactory objectFactory;
+
+        public YamlSerializableNodeDeserializer(IObjectFactory objectFactory)
+        {
+			this.objectFactory = objectFactory;
+        }
+    
+        public bool Deserialize(EventReader reader, Type expectedType, Func<EventReader, Type, object> nestedObjectDeserializer, out object value)
+        {
+#pragma warning disable 0618 // IYamlSerializable is obsolete
+            if (typeof(IYamlSerializable).IsAssignableFrom(expectedType))
+            {
+                var serializable = (IYamlSerializable)objectFactory.Create(expectedType);
+                serializable.ReadYaml(reader.Parser);
+                value = serializable;
+                return true;
+            }
+#pragma warning restore
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/YamlDotNet/Serialization/NodeTypeResolvers/YamlConvertibleTypeResolver.cs
+++ b/YamlDotNet/Serialization/NodeTypeResolvers/YamlConvertibleTypeResolver.cs
@@ -1,0 +1,34 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using YamlDotNet.Core.Events;
+
+namespace YamlDotNet.Serialization.NodeTypeResolvers
+{
+    public sealed class YamlConvertibleTypeResolver : INodeTypeResolver
+    {
+        public bool Resolve(NodeEvent nodeEvent, ref Type currentType)
+        {
+            return typeof(IYamlConvertible).IsAssignableFrom(currentType);
+        }
+    }
+}

--- a/YamlDotNet/Serialization/NodeTypeResolvers/YamlSerializableTypeResolver.cs
+++ b/YamlDotNet/Serialization/NodeTypeResolvers/YamlSerializableTypeResolver.cs
@@ -1,0 +1,36 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using YamlDotNet.Core.Events;
+
+namespace YamlDotNet.Serialization.NodeTypeResolvers
+{
+    public sealed class YamlSerializableTypeResolver : INodeTypeResolver
+    {
+        public bool Resolve(NodeEvent nodeEvent, ref Type currentType)
+        {
+#pragma warning disable 0618 // IYamlSerializable is obsolete
+            return typeof(IYamlSerializable).IsAssignableFrom(currentType);
+#pragma warning restore 0618
+        }
+    }
+}

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/CustomSerializationObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/CustomSerializationObjectGraphVisitor.cs
@@ -48,12 +48,21 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
                 return false;
             }
 
-            var serializable = value as IYamlSerializable;
+            var convertible = value.Value as IYamlConvertible;
+            if (convertible != null)
+            {
+                convertible.Write(emitter);
+                return false;
+            }
+
+#pragma warning disable 0618 // IYamlSerializable is obsolete
+            var serializable = value.Value as IYamlSerializable;
             if (serializable != null)
             {
                 serializable.WriteYaml(emitter);
                 return false;
             }
+#pragma warning restore
 
             return base.Enter(value);
         }

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -251,6 +251,7 @@
     <Compile Include="Serialization\ITypeResolver.cs" />
     <Compile Include="Serialization\IValueDeserializer.cs" />
     <Compile Include="Serialization\IValuePromise.cs" />
+    <Compile Include="Serialization\IYamlConvertible.cs" />
     <Compile Include="Serialization\IYamlSerializable.cs" />
     <Compile Include="Serialization\IYamlTypeConverter.cs" />
     <Compile Include="Serialization\NamingConventions\CamelCaseNamingConvention.cs" />
@@ -259,6 +260,7 @@
     <Compile Include="Serialization\NamingConventions\PascalCaseNamingConvention.cs" />
     <Compile Include="Serialization\NamingConventions\UnderscoredNamingConvention.cs" />
     <Compile Include="Serialization\NodeDeserializers\ArrayNodeDeserializer.cs" />
+    <Compile Include="Serialization\NodeDeserializers\YamlConvertibleNodeDeserializer.cs" />
     <Compile Include="Serialization\NodeDeserializers\EnumerableNodeDeserializer.cs" />
     <Compile Include="Serialization\NodeDeserializers\CollectionNodeDeserializer.cs" />
     <Compile Include="Serialization\NodeDeserializers\DictionaryNodeDeserializer.cs" />
@@ -268,9 +270,12 @@
     <Compile Include="Serialization\NodeDeserializers\ObjectNodeDeserializer.cs" />
     <Compile Include="Serialization\NodeDeserializers\ScalarNodeDeserializer.cs" />
     <Compile Include="Serialization\NodeDeserializers\TypeConverterNodeDeserializer.cs" />
+    <Compile Include="Serialization\NodeDeserializers\YamlSerializableNodeDeserializer.cs" />
+    <Compile Include="Serialization\NodeTypeResolvers\YamlConvertibleTypeResolver.cs" />
     <Compile Include="Serialization\NodeTypeResolvers\DefaultContainersNodeTypeResolver.cs" />
     <Compile Include="Serialization\NodeTypeResolvers\TagNodeTypeResolver.cs" />
     <Compile Include="Serialization\NodeTypeResolvers\TypeNameInTagNodeTypeResolver.cs" />
+    <Compile Include="Serialization\NodeTypeResolvers\YamlSerializableTypeResolver.cs" />
     <Compile Include="Serialization\ObjectDescriptor.cs" />
     <Compile Include="Serialization\ObjectFactories\DefaultObjectFactory.cs" />
     <Compile Include="Serialization\ObjectFactories\LambdaObjectFactory.cs" />


### PR DESCRIPTION
* YamlScalarNode, YamlSequenceNode and YamlMappingNode can now be serialized and deserialized when they appear inside an object graph.
* The IYamlSerializable interface has been improved and is now called IYamlConvertible.
* Add conversion operators to make it easier to construct YAML YamlDocuments.
* Add conversion operators and indexers to make it easier to access the nodes in a YamlDocument.

[Example code to build and access a YamlDocument](https://dotnetfiddle.net/nPq3Zl)