### PR TITLE
Fix Issue 189 extra '\0' after indentation indicators

### DIFF
--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -174,6 +174,19 @@ namespace YamlDotNet.Test.Core
         }
 
         [Theory]
+        [InlineData("test", ">-\r\n  test\r\n")]    // No indentation indicator when no indent.
+        [InlineData("  test", ">2-\r\n    test\r\n")]
+        public void BlockStyleGeneratesIndentationIndicator(string input, string expected)
+        {
+            var events = StreamOf(
+                DocumentWith(FoldedScalar(input)));
+
+            var yaml = EmittedTextFrom(events);
+
+            yaml.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData("LF hello\nworld")]
         [InlineData("CRLF hello\r\nworld")]
         public void FoldedStyleDoesNotLooseCharacters(string text)

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -1762,7 +1762,7 @@ namespace YamlDotNet.Core
 
             if (analyzer.IsSpace() || analyzer.IsBreak())
             {
-                var indentHint = string.Format(CultureInfo.InvariantCulture, "{0}\0", bestIndent);
+                var indentHint = string.Format(CultureInfo.InvariantCulture, "{0}", bestIndent);
                 WriteIndicator(indentHint, false, false, false);
             }
 


### PR DESCRIPTION
Hi!

This fixes issue #189 by removing extra '\0' after indentation indicators. The extra '\0' which is not allowed here makes resulting YAML text malformed.

Could you take a look? Thanks!

