### PR TITLE
Create NetCore project for .NET Core RTM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ README.html
 
 samples/dotnet/project.lock.json
 YamlDotNet/Properties/AssemblyInfo.Generated.cs
+project.lock.json

--- a/YamlDotNet.NetCore/YamlDotNet.NetCore.xproj
+++ b/YamlDotNet.NetCore/YamlDotNet.NetCore.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>20c5d482-25ae-4096-a4c1-42a678348cf7</ProjectGuid>
+    <RootNamespace>YamlDotNet.NetCore</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/YamlDotNet.NetCore/project.json
+++ b/YamlDotNet.NetCore/project.json
@@ -1,0 +1,33 @@
+﻿{
+    "version": "1.0.0-*",
+    "buildOptions": {
+        "compile": {
+            "include": "../YamlDotNet/**/*.cs"
+        }
+    },
+
+    "dependencies": {
+    },
+
+    "frameworks": {
+        "netstandard1.0": {
+            "buildOptions": {
+                "define": [ "PORTABLE" ]
+            },
+            "dependencies": {
+                "System.Collections": "4.0.11",
+                "System.Diagnostics.Debug": "4.0.11",
+                "System.Diagnostics.Tools": "4.0.1",
+                "System.Globalization": "4.0.11",
+                "System.Linq": "4.1.0",
+                "System.Linq.Expressions": "4.1.0",
+                "System.Reflection.Extensions": "4.0.1",
+                "System.Runtime.Extensions": "4.1.0",
+                "System.Runtime.Serialization.Primitives": "4.1.1",
+                "System.ObjectModel": "4.0.12",
+                "System.Text.Encoding.Extensions": "4.0.11",
+                "System.Text.RegularExpressions": "4.1.0"
+            }
+        }
+    }
+}

--- a/YamlDotNet.sln
+++ b/YamlDotNet.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{69EE9636-55BA-49C2-827E-D5684221C345}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
@@ -34,12 +36,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.AotTest", "YamlD
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v3.8.0", "PerformanceTests\YamlDotNet.PerformanceTests.v3.8.0\YamlDotNet.PerformanceTests.v3.8.0.csproj", "{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "YamlDotNet.NetCore", "YamlDotNet.NetCore\YamlDotNet.NetCore.xproj", "{20C5D482-25AE-4096-A4C1-42A678348CF7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug-AOT|Any CPU = Debug-AOT|Any CPU
 		Debug-UnitySubset-v35|Any CPU = Debug-UnitySubset-v35|Any CPU
 		PerformanceTests|Any CPU = PerformanceTests|Any CPU
+		Release|Any CPU = Release|Any CPU
 		Release-Portable-Signed|Any CPU = Release-Portable-Signed|Any CPU
 		Release-Portable-Unsigned|Any CPU = Release-Portable-Unsigned|Any CPU
 		Release-Signed|Any CPU = Release-Signed|Any CPU
@@ -49,12 +54,13 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug-AOT|Any CPU.ActiveCfg = Debug-AOT|Any CPU
-		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug-AOT|Any CPU.Build.0 = Debug-AOT|Any CPU
-		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug-UnitySubset-v35|Any CPU
-		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug-UnitySubset-v35|Any CPU.Build.0 = Debug-UnitySubset-v35|Any CPU
-		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.PerformanceTests|Any CPU.ActiveCfg = Release-Unsigned|Any CPU
-		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.PerformanceTests|Any CPU.Build.0 = Release-Unsigned|Any CPU
+		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug-AOT|Any CPU.Build.0 = Debug|Any CPU
+		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Debug-UnitySubset-v35|Any CPU.Build.0 = Debug|Any CPU
+		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.PerformanceTests|Any CPU.ActiveCfg = Debug-UnitySubset-v35|Any CPU
+		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.PerformanceTests|Any CPU.Build.0 = Debug-UnitySubset-v35|Any CPU
+		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Release|Any CPU.ActiveCfg = Release-UnitySubset-v35|Any CPU
 		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Release-Portable-Signed|Any CPU.ActiveCfg = Release-Portable-Signed|Any CPU
 		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Release-Portable-Signed|Any CPU.Build.0 = Release-Portable-Signed|Any CPU
 		{BF32DE1B-6276-4341-B212-F8862ADBBA7A}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release-Portable-Unsigned|Any CPU
@@ -70,6 +76,8 @@ Global
 		{A9F67018-0240-4D16-A4EA-BCB780D0AF05}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
 		{A9F67018-0240-4D16-A4EA-BCB780D0AF05}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
 		{A9F67018-0240-4D16-A4EA-BCB780D0AF05}.PerformanceTests|Any CPU.ActiveCfg = Release|Any CPU
+		{A9F67018-0240-4D16-A4EA-BCB780D0AF05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9F67018-0240-4D16-A4EA-BCB780D0AF05}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A9F67018-0240-4D16-A4EA-BCB780D0AF05}.Release-Portable-Signed|Any CPU.ActiveCfg = Release-Portable|Any CPU
 		{A9F67018-0240-4D16-A4EA-BCB780D0AF05}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release-Portable|Any CPU
 		{A9F67018-0240-4D16-A4EA-BCB780D0AF05}.Release-Portable-Unsigned|Any CPU.Build.0 = Release-Portable|Any CPU
@@ -82,6 +90,7 @@ Global
 		{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
 		{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}.PerformanceTests|Any CPU.ActiveCfg = Release|Any CPU
 		{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}.PerformanceTests|Any CPU.Build.0 = Release|Any CPU
+		{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}.Release-Portable-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
@@ -92,6 +101,7 @@ Global
 		{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
 		{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}.PerformanceTests|Any CPU.ActiveCfg = Release|Any CPU
 		{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}.PerformanceTests|Any CPU.Build.0 = Release|Any CPU
+		{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}.Release-Portable-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
@@ -102,6 +112,7 @@ Global
 		{0FB497EA-A116-406A-AE8C-A24933D8CB21}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
 		{0FB497EA-A116-406A-AE8C-A24933D8CB21}.PerformanceTests|Any CPU.ActiveCfg = Release|Any CPU
 		{0FB497EA-A116-406A-AE8C-A24933D8CB21}.PerformanceTests|Any CPU.Build.0 = Release|Any CPU
+		{0FB497EA-A116-406A-AE8C-A24933D8CB21}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0FB497EA-A116-406A-AE8C-A24933D8CB21}.Release-Portable-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{0FB497EA-A116-406A-AE8C-A24933D8CB21}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{0FB497EA-A116-406A-AE8C-A24933D8CB21}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
@@ -112,6 +123,7 @@ Global
 		{C6E0B465-8422-4D6B-85CE-C59724A28E1F}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
 		{C6E0B465-8422-4D6B-85CE-C59724A28E1F}.PerformanceTests|Any CPU.ActiveCfg = Release|Any CPU
 		{C6E0B465-8422-4D6B-85CE-C59724A28E1F}.PerformanceTests|Any CPU.Build.0 = Release|Any CPU
+		{C6E0B465-8422-4D6B-85CE-C59724A28E1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C6E0B465-8422-4D6B-85CE-C59724A28E1F}.Release-Portable-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{C6E0B465-8422-4D6B-85CE-C59724A28E1F}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{C6E0B465-8422-4D6B-85CE-C59724A28E1F}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
@@ -122,6 +134,7 @@ Global
 		{BE49A287-5F47-4E3B-90EB-97B51451934C}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
 		{BE49A287-5F47-4E3B-90EB-97B51451934C}.PerformanceTests|Any CPU.ActiveCfg = Release|Any CPU
 		{BE49A287-5F47-4E3B-90EB-97B51451934C}.PerformanceTests|Any CPU.Build.0 = Release|Any CPU
+		{BE49A287-5F47-4E3B-90EB-97B51451934C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE49A287-5F47-4E3B-90EB-97B51451934C}.Release-Portable-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{BE49A287-5F47-4E3B-90EB-97B51451934C}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{BE49A287-5F47-4E3B-90EB-97B51451934C}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
@@ -132,6 +145,7 @@ Global
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.PerformanceTests|Any CPU.ActiveCfg = Release|Any CPU
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.PerformanceTests|Any CPU.Build.0 = Release|Any CPU
+		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.Release-Portable-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
@@ -142,6 +156,7 @@ Global
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Debug-AOT|Any CPU.Build.0 = Debug-AOT|Any CPU
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug-AOT|Any CPU
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.PerformanceTests|Any CPU.ActiveCfg = Debug-AOT|Any CPU
+		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Release|Any CPU.ActiveCfg = Debug-AOT|Any CPU
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Release-Portable-Signed|Any CPU.ActiveCfg = Debug-AOT|Any CPU
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Debug-AOT|Any CPU
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Release-Signed|Any CPU.ActiveCfg = Debug-AOT|Any CPU
@@ -152,11 +167,32 @@ Global
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.PerformanceTests|Any CPU.ActiveCfg = Release|Any CPU
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.PerformanceTests|Any CPU.Build.0 = Release|Any CPU
+		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.Release-Portable-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.Release-UnitySubset-v35|Any CPU.ActiveCfg = Release|Any CPU
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}.Release-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Debug-AOT|Any CPU.Build.0 = Debug|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Debug-UnitySubset-v35|Any CPU.ActiveCfg = Debug|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Debug-UnitySubset-v35|Any CPU.Build.0 = Debug|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.PerformanceTests|Any CPU.ActiveCfg = Debug|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.PerformanceTests|Any CPU.Build.0 = Debug|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-Portable-Signed|Any CPU.ActiveCfg = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-Portable-Signed|Any CPU.Build.0 = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-Portable-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-Portable-Unsigned|Any CPU.Build.0 = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-Signed|Any CPU.Build.0 = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-UnitySubset-v35|Any CPU.ActiveCfg = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-UnitySubset-v35|Any CPU.Build.0 = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{20C5D482-25AE-4096-A4C1-42A678348CF7}.Release-Unsigned|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/YamlDotNet/YamlDotNet.Signed.nuspec
+++ b/YamlDotNet/YamlDotNet.Signed.nuspec
@@ -21,8 +21,7 @@
         <file src="bin\Release-Portable-Signed\YamlDotNet.pdb" target="lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1" />
         <file src="bin\Release-Portable-Signed\YamlDotNet.xml" target="lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1" />
 
-        <file src="bin\Release-Portable-Signed\YamlDotNet.dll" target="lib\dotnet" />
-        <file src="bin\Release-Portable-Signed\YamlDotNet.pdb" target="lib\dotnet" />
-        <file src="bin\Release-Portable-Signed\YamlDotNet.xml" target="lib\dotnet" />
+        <file src="D:\Git\YamlDotNet\YamlDotNet.NetCore\bin\Debug\netstandard1.0\YamlDotNet.NetCore.dll" target="lib\netstandard1.0" />
+        <file src="D:\Git\YamlDotNet\YamlDotNet.NetCore\bin\Debug\netstandard1.0\YamlDotNet.NetCore.pdb" target="lib\netstandard1.0" />
     </files>
 </package>


### PR DESCRIPTION
In the vein of: https://github.com/aaubry/YamlDotNet/issues/180 and https://github.com/aaubry/YamlDotNet/pull/181

I made a separate project and directory for a net core build.  Though I'd recommend consolidating everything into one xproj/project.json.  I didn't want to do it all at once as it seems your build has quite a few things that need to get put into project.json.  You can use mine as a starting point to put even `net20` and `net35` targets.

All your nuspec and options in csprojs can go into a project.json.  Here's the spec: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/project-json

You can update your tooling as well here: https://www.microsoft.com/net

You're correct in that your code supports .NET Core.  However, the nuget targetting is off in that you have use an `import` statement for `dotnet` to do so.  You might could just get away with changing the `dotnet` in your nuspec files to `netstandard1.0` but it would be questionable if that works 100%.
