### PR TITLE
Update .travis.yml to use latest mono version and support C# 6 withing the AOT build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 sudo: required
 dist: trusty
+language: csharp
+mono:
+  - latest
 
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y mono-xbuild libmono-microsoft-build-tasks-v4.0-4.0-cil mono-mcs
 
 install:
-  - sudo mono --aot=full /usr/lib/mono/2.0/mscorlib.dll
-  - sudo mono --aot=full /usr/lib/mono/gac/System/2.0.0.0__b77a5c561934e089/System.dll
-  - sudo mono --aot=full /usr/lib/mono/gac/System.Xml/2.0.0.0__b77a5c561934e089/System.Xml.dll
-  - sudo mono --aot=full /usr/lib/mono/gac/Mono.Security/2.0.0.0__0738eb9f132ed756/Mono.Security.dll
-  - sudo mono --aot=full /usr/lib/mono/gac/System.Configuration/2.0.0.0__b03f5f7f11d50a3a/System.Configuration.dll
-  - sudo mono --aot=full /usr/lib/mono/gac/System.Security/2.0.0.0__b03f5f7f11d50a3a/System.Security.dll
-  - sudo mono --aot=full /usr/lib/mono/gac/System.Core/3.5.0.0__b77a5c561934e089/System.Core.dll
-  - sudo mono --aot=full /usr/lib/mono/gac/Mono.Posix/2.0.0.0__0738eb9f132ed756/Mono.Posix.dll
+  - sudo mono --aot=full /usr/lib/mono/4.5/mscorlib.dll
+  - sudo mono --aot=full /usr/lib/mono/gac/System/4.0.0.0__b77a5c561934e089/System.dll
+  - sudo mono --aot=full /usr/lib/mono/gac/System.Xml/4.0.0.0__b77a5c561934e089/System.Xml.dll
+  - sudo mono --aot=full /usr/lib/mono/gac/Mono.Security/4.0.0.0__0738eb9f132ed756/Mono.Security.dll
+  - sudo mono --aot=full /usr/lib/mono/gac/System.Configuration/4.0.0.0__b03f5f7f11d50a3a/System.Configuration.dll
+  - sudo mono --aot=full /usr/lib/mono/gac/System.Security/4.0.0.0__b03f5f7f11d50a3a/System.Security.dll
+  - sudo mono --aot=full /usr/lib/mono/gac/System.Core/4.0.0.0__b77a5c561934e089/System.Core.dll
+  - sudo mono --aot=full /usr/lib/mono/gac/Mono.Posix/4.0.0.0__0738eb9f132ed756/Mono.Posix.dll
 
 script:
   - YamlDotNet.AotTest/run.sh


### PR DESCRIPTION
Everything seems to work properly with AOT on another Travis CI instance.

Not using nameof, expression-bodied members, and other features of C# 6 because of the AOT build is driving me mad.