### PR TITLE
Avoid crashing with a StackOverflowException when iterating over the AllNodes property when it's infinitely recursive

### DIFF
--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -52,13 +52,24 @@ namespace YamlDotNet.Test.RepresentationModel
             // of just on AllNodes because in debug mode, AllNodes
             // is accessed after the document loads to check for unresolved aliases...
             var loadAndAccessAllNodes = new Action(() =>
-                {
-                    var stream = new YamlStream();
-                    stream.Load(Yaml.ParserForText("&a [*a]"));
-                    var allNodes = stream.Documents.Single().AllNodes.ToList();
-                });
+            {
+                var stream = new YamlStream();
+                stream.Load(Yaml.ParserForText("&a [*a]"));
+                var allNodes = stream.Documents.Single().AllNodes.ToList();
+            });
 
             loadAndAccessAllNodes.ShouldThrow<MaximumRecursionLevelReachedException>("because the document is infinitely recursive.");
+        }
+
+        [Fact]
+        public void InfinitelyRecursiveNodeToStringSucceeds()
+        {
+            var stream = new YamlStream();
+            stream.Load(Yaml.ParserForText("&a [*a]"));
+
+            var toString = stream.Documents.Single().RootNode.ToString();
+
+            toString.Should().Contain(YamlNode.MaximumRecursionLevelReachedToStringValue);
         }
 
         [Fact]

--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -48,17 +48,12 @@ namespace YamlDotNet.Test.RepresentationModel
         [Fact]
         public void AccessingAllNodesOnInfinitelyRecursiveDocumentThrows()
         {
-            // We check the exception on the whole following block instead
-            // of just on AllNodes because in debug mode, AllNodes
-            // is accessed after the document loads to check for unresolved aliases...
-            var loadAndAccessAllNodes = new Action(() =>
-            {
-                var stream = new YamlStream();
-                stream.Load(Yaml.ParserForText("&a [*a]"));
-                var allNodes = stream.Documents.Single().AllNodes.ToList();
-            });
+            var stream = new YamlStream();
+            stream.Load(Yaml.ParserForText("&a [*a]"));
 
-            loadAndAccessAllNodes.ShouldThrow<MaximumRecursionLevelReachedException>("because the document is infinitely recursive.");
+            var accessAllNodes = new Action(() => stream.Documents.Single().AllNodes.ToList());
+
+            accessAllNodes.ShouldThrow<MaximumRecursionLevelReachedException>("because the document is infinitely recursive.");
         }
 
         [Fact]

--- a/YamlDotNet/Core/MaximumRecursionLevelReachedException.cs
+++ b/YamlDotNet/Core/MaximumRecursionLevelReachedException.cs
@@ -1,0 +1,81 @@
+//  This file is part of YamlDotNet - A .NET library for YAML.
+//  Copyright (c) Antoine Aubry and contributors
+
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//  of the Software, and to permit persons to whom the Software is furnished to do
+//  so, subject to the following conditions:
+
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace YamlDotNet.Core
+{
+    /// <summary>
+    /// Exception that is thrown when an infinite recursion is detected.
+    /// </summary>
+    [Serializable]
+    public class MaximumRecursionLevelReachedException : YamlException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaximumRecursionLevelReachedException"/> class.
+        /// </summary>
+        public MaximumRecursionLevelReachedException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaximumRecursionLevelReachedException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public MaximumRecursionLevelReachedException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaximumRecursionLevelReachedException"/> class.
+        /// </summary>
+        public MaximumRecursionLevelReachedException(Mark start, Mark end, string message)
+            : base(start, end, message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaximumRecursionLevelReachedException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner.</param>
+        public MaximumRecursionLevelReachedException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+#if !(PORTABLE || UNITY)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaximumRecursionLevelReachedException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is null. </exception>
+        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0). </exception>
+        protected MaximumRecursionLevelReachedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/YamlDotNet/Core/RecursionLevel.cs
+++ b/YamlDotNet/Core/RecursionLevel.cs
@@ -1,0 +1,58 @@
+﻿//  This file is part of YamlDotNet - A .NET library for YAML.
+//  Copyright (c) Antoine Aubry and contributors
+
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//  of the Software, and to permit persons to whom the Software is furnished to do
+//  so, subject to the following conditions:
+
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+namespace YamlDotNet.Core
+{
+    /// <summary>
+    /// Keeps track of the <see cref="Current"/> recursion level,
+    /// and throws <see cref="MaximumRecursionLevelReachedException"/>
+    /// whenever <see cref="Maximum"/> is reached.
+    /// </summary>
+    internal class RecursionLevel
+    {
+        public int Current { get; private set; }
+        public int Maximum { get; }
+
+        public RecursionLevel(int maximum)
+        {
+            Maximum = maximum;
+        }
+
+        /// <summary>
+        /// Increments the <see cref="Current"/> recursion level,
+        /// and throws <see cref="MaximumRecursionLevelReachedException"/>
+        /// if <see cref="Maximum"/> is reached.
+        /// </summary>
+        internal void Increment()
+        {
+            Current++;
+            if (Current >= Maximum)
+            {
+                throw new MaximumRecursionLevelReachedException();
+            }
+        }
+
+        internal void Decrement()
+        {
+            Current--;
+        }
+    }
+}

--- a/YamlDotNet/Core/RecursionLevel.cs
+++ b/YamlDotNet/Core/RecursionLevel.cs
@@ -50,6 +50,16 @@ namespace YamlDotNet.Core
             }
         }
 
+        /// <summary>
+        /// Increments the <see cref="Current"/> recursion level,
+        /// and returns whether <see cref="Current"/> is still less than <see cref="Maximum"/>.
+        /// </summary>
+        internal bool TryIncrement()
+        {
+            Current++;
+            return Current < Maximum;
+        }
+
         internal void Decrement()
         {
             Current--;

--- a/YamlDotNet/RepresentationModel/YamlAliasNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlAliasNode.cs
@@ -94,7 +94,7 @@ namespace YamlDotNet.RepresentationModel
         /// <returns>
         /// A <see cref="System.String"/> that represents this instance.
         /// </returns>
-        public override string ToString()
+        internal override string ToString(RecursionLevel level)
         {
             return "*" + Anchor;
         }

--- a/YamlDotNet/RepresentationModel/YamlAliasNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlAliasNode.cs
@@ -100,11 +100,13 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
-        /// Gets all nodes from the document, starting on the current node.
+        /// Recursively enumerates all the nodes from the document, starting on the current node,
+        /// and throwing <see cref="MaximumRecursionLevelReachedException"/>
+        /// if <see cref="RecursionLevel.Maximum"/> is reached.
         /// </summary>
-        public override IEnumerable<YamlNode> AllNodes
+        internal override IEnumerable<YamlNode> SafeAllNodes(RecursionLevel level)
         {
-            get { yield return this; }
+            yield return this;
         }
 
         /// <summary>

--- a/YamlDotNet/RepresentationModel/YamlDocument.cs
+++ b/YamlDotNet/RepresentationModel/YamlDocument.cs
@@ -79,12 +79,20 @@ namespace YamlDotNet.RepresentationModel
             state.ResolveAliases();
 
 #if DEBUG
-            foreach (var node in AllNodes)
+            try
             {
-                if (node is YamlAliasNode)
+                foreach (var node in AllNodes)
                 {
-                    throw new InvalidOperationException("Error in alias resolution.");
+                    if (node is YamlAliasNode)
+                    {
+                        throw new InvalidOperationException("Error in alias resolution.");
+                    }
                 }
+            }
+            catch (MaximumRecursionLevelReachedException)
+            {
+                // Silently absorb this exception.
+                // This is required to make some unit tests pass in DEBUG mode.
             }
 #endif
 

--- a/YamlDotNet/RepresentationModel/YamlDocument.cs
+++ b/YamlDotNet/RepresentationModel/YamlDocument.cs
@@ -195,6 +195,7 @@ namespace YamlDotNet.RepresentationModel
 
         /// <summary>
         /// Gets all nodes from the document.
+        /// <see cref="MaximumRecursionLevelReachedException"/> is thrown if an infinite recursion is detected.
         /// </summary>
         public IEnumerable<YamlNode> AllNodes
         {

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -356,8 +356,13 @@ namespace YamlDotNet.RepresentationModel
         /// <returns>
         /// A <see cref="System.String"/> that represents this instance.
         /// </returns>
-        public override string ToString()
+        internal override string ToString(RecursionLevel level)
         {
+            if (!level.TryIncrement())
+            {
+                return MaximumRecursionLevelReachedToStringValue;
+            }
+
             var text = new StringBuilder("{ ");
 
             foreach (var child in children)
@@ -366,10 +371,12 @@ namespace YamlDotNet.RepresentationModel
                 {
                     text.Append(", ");
                 }
-                text.Append("{ ").Append(child.Key).Append(", ").Append(child.Value).Append(" }");
+                text.Append("{ ").Append(child.Key.ToString(level)).Append(", ").Append(child.Value.ToString(level)).Append(" }");
             }
 
             text.Append(" }");
+
+            level.Decrement();
 
             return text.ToString();
         }

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -320,25 +320,26 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
-        /// Gets all nodes from the document, starting on the current node.
+        /// Recursively enumerates all the nodes from the document, starting on the current node,
+        /// and throwing <see cref="MaximumRecursionLevelReachedException"/>
+        /// if <see cref="RecursionLevel.Maximum"/> is reached.
         /// </summary>
-        public override IEnumerable<YamlNode> AllNodes
+        internal override IEnumerable<YamlNode> SafeAllNodes(RecursionLevel level)
         {
-            get
+            level.Increment();
+            yield return this;
+            foreach (var child in children)
             {
-                yield return this;
-                foreach (var child in children)
+                foreach (var node in child.Key.SafeAllNodes(level))
                 {
-                    foreach (var node in child.Key.AllNodes)
-                    {
-                        yield return node;
-                    }
-                    foreach (var node in child.Value.AllNodes)
-                    {
-                        yield return node;
-                    }
+                    yield return node;
+                }
+                foreach (var node in child.Value.SafeAllNodes(level))
+                {
+                    yield return node;
                 }
             }
+            level.Decrement();
         }
 
         /// <summary>

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -198,11 +198,23 @@ namespace YamlDotNet.RepresentationModel
 
         /// <summary>
         /// Gets all nodes from the document, starting on the current node.
+        /// <see cref="MaximumRecursionLevelReachedException"/> is thrown if an infinite recursion is detected.
         /// </summary>
-        public abstract IEnumerable<YamlNode> AllNodes
+        public IEnumerable<YamlNode> AllNodes
         {
-            get;
+            get
+            {
+                var level = new RecursionLevel(1000);
+                return SafeAllNodes(level);
+            }
         }
+
+        /// <summary>
+        /// When implemented, recursively enumerates all the nodes from the document, starting on the current node.
+        /// If <see cref="RecursionLevel.Maximum"/> is reached, a <see cref="MaximumRecursionLevelReachedException"/> is thrown
+        /// instead of continuing and crashing with a <see cref="StackOverflowException"/>.
+        /// </summary>
+        internal abstract IEnumerable<YamlNode> SafeAllNodes(RecursionLevel level);
 
         /// <summary>
         /// Gets the type of node.

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -33,6 +33,9 @@ namespace YamlDotNet.RepresentationModel
     [Serializable]
     public abstract class YamlNode
     {
+        private const int MaximumRecursionLevel = 1000;
+        internal const string MaximumRecursionLevelReachedToStringValue = "WARNING! INFINITE RECURSION!";
+
         /// <summary>
         /// Gets or sets the anchor of the node.
         /// </summary>
@@ -196,6 +199,14 @@ namespace YamlDotNet.RepresentationModel
             return unchecked(((h1 << 5) + h1) ^ h2);
         }
 
+        public override string ToString()
+        {
+            var level = new RecursionLevel(MaximumRecursionLevel);
+            return ToString(level);
+        }
+
+        internal abstract string ToString(RecursionLevel level);
+
         /// <summary>
         /// Gets all nodes from the document, starting on the current node.
         /// <see cref="MaximumRecursionLevelReachedException"/> is thrown if an infinite recursion is detected.
@@ -204,7 +215,7 @@ namespace YamlDotNet.RepresentationModel
         {
             get
             {
-                var level = new RecursionLevel(1000);
+                var level = new RecursionLevel(MaximumRecursionLevel);
                 return SafeAllNodes(level);
             }
         }

--- a/YamlDotNet/RepresentationModel/YamlScalarNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlScalarNode.cs
@@ -147,7 +147,7 @@ namespace YamlDotNet.RepresentationModel
         /// <returns>
         /// A <see cref="System.String"/> that represents this instance.
         /// </returns>
-        public override string ToString()
+        internal override string ToString(RecursionLevel level)
         {
             return Value;
         }

--- a/YamlDotNet/RepresentationModel/YamlScalarNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlScalarNode.cs
@@ -153,11 +153,13 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
-        /// Gets all nodes from the document, starting on the current node.
+        /// Recursively enumerates all the nodes from the document, starting on the current node,
+        /// and throwing <see cref="MaximumRecursionLevelReachedException"/>
+        /// if <see cref="RecursionLevel.Maximum"/> is reached.
         /// </summary>
-        public override IEnumerable<YamlNode> AllNodes
+        internal override IEnumerable<YamlNode> SafeAllNodes(RecursionLevel level)
         {
-            get { yield return this; }
+            yield return this;
         }
 
         /// <summary>

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -255,8 +255,13 @@ namespace YamlDotNet.RepresentationModel
         /// <returns>
         /// A <see cref="System.String"/> that represents this instance.
         /// </returns>
-        public override string ToString()
+        internal override string ToString(RecursionLevel level)
         {
+            if (!level.TryIncrement())
+            {
+                return MaximumRecursionLevelReachedToStringValue;
+            }
+
             var text = new StringBuilder("[ ");
 
             foreach (var child in children)
@@ -265,10 +270,12 @@ namespace YamlDotNet.RepresentationModel
                 {
                     text.Append(", ");
                 }
-                text.Append(child);
+                text.Append(child.ToString(level));
             }
 
             text.Append(" ]");
+
+            level.Decrement();
 
             return text.ToString();
         }

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -223,21 +223,22 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
-        /// Gets all nodes from the document, starting on the current node.
+        /// Recursively enumerates all the nodes from the document, starting on the current node,
+        /// and throwing <see cref="MaximumRecursionLevelReachedException"/>
+        /// if <see cref="RecursionLevel.Maximum"/> is reached.
         /// </summary>
-        public override IEnumerable<YamlNode> AllNodes
+        internal override IEnumerable<YamlNode> SafeAllNodes(RecursionLevel level)
         {
-            get
+            level.Increment();
+            yield return this;
+            foreach (var child in children)
             {
-                yield return this;
-                foreach (var child in children)
+                foreach (var node in child.SafeAllNodes(level))
                 {
-                    foreach (var node in child.AllNodes)
-                    {
-                        yield return node;
-                    }
+                    yield return node;
                 }
             }
+            level.Decrement();
         }
 
         /// <summary>

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Core\MergingParser.cs" />
     <Compile Include="Core\Parser.cs" />
     <Compile Include="Core\ParserState.cs" />
+    <Compile Include="Core\MaximumRecursionLevelReachedException.cs" />
     <Compile Include="Core\Tokens\Comment.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Helpers\ExpressionExtensions.cs" />
@@ -222,6 +223,7 @@
     <Compile Include="RepresentationModel\DocumentLoadingState.cs" />
     <Compile Include="RepresentationModel\EmitterState.cs" />
     <Compile Include="RepresentationModel\IYamlVisitor.cs" />
+    <Compile Include="Core\RecursionLevel.cs" />
     <Compile Include="RepresentationModel\YamlAliasNode.cs" />
     <Compile Include="RepresentationModel\YamlDocument.cs" />
     <Compile Include="RepresentationModel\YamlMappingNode.cs" />


### PR DESCRIPTION
The implementations of `AllNodes` are delegated to an `abstract internal IEnumerable<YamlNode> SafeAllNodes(RecursionLevel level)` method that keeps track of the current recursion level and throws a `MaximumRecursionLevelReachedException` if the maximum recursion level is reached.

The maximum recursion level is currently set to 1000.
