### PR TITLE
For discussion purposes:

### DIFF
--- a/YamlDotNet.Samples/ConvertYamlToJson.cs
+++ b/YamlDotNet.Samples/ConvertYamlToJson.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using Xunit.Abstractions;
 using YamlDotNet.Serialization;
 using YamlDotNet.Samples.Helpers;
 
@@ -27,7 +26,7 @@ sequence:
   - one
   - two
 ");
-            var deserializer = new Deserializer();
+            var deserializer = new DeserializerBuilder().Build();
             var yamlObject = deserializer.Deserialize(r);
 
             var serializer = new SerializerBuilder()

--- a/YamlDotNet.Samples/DeserializeObjectGraph.cs
+++ b/YamlDotNet.Samples/DeserializeObjectGraph.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using Xunit.Abstractions;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Samples.Helpers;

--- a/YamlDotNet.Samples/DeserializingMultipleDocuments.cs
+++ b/YamlDotNet.Samples/DeserializingMultipleDocuments.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using Xunit.Abstractions;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
@@ -26,7 +25,7 @@ namespace YamlDotNet.Samples
         {
             var input = new StringReader(Document);
 
-            var deserializer = new Deserializer();
+            var deserializer = new DeserializerBuilder().Build();
 
             var parser = new Parser(input);
 

--- a/YamlDotNet.Samples/Helpers/ExampleRunner.cs
+++ b/YamlDotNet.Samples/Helpers/ExampleRunner.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+using UnityEngine;
+using UnityEngine.Serialization;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace YamlDotNet.Samples.Helpers {
+    public class ExampleRunner : MonoBehaviour {
+
+        private StringTestOutputHelper helper = new StringTestOutputHelper();
+
+        public string[] disabledTests = new string[] {};
+
+        private class StringTestOutputHelper : ITestOutputHelper {
+            private StringBuilder output = new StringBuilder();
+            public void WriteLine() {
+                output.AppendLine();
+            }
+            public void WriteLine(string value) {
+                output.AppendLine(value);
+            }
+            public void WriteLine(string format, params object[] args) {
+                output.AppendFormat(format, args);
+                output.AppendLine();
+            }
+
+            public override string ToString() { return output.ToString(); }
+            public          void   Clear()    { output = new StringBuilder(); }
+        }
+
+        public static string[] GetAllTestNames() {
+            bool skipMethods;
+            var results = new List<string>();
+            foreach (Type t in Assembly.GetExecutingAssembly().GetTypes()) {
+                if (t.Namespace == "YamlDotNet.Samples" && t.IsClass) {
+                    skipMethods = false;
+                    foreach (MethodInfo mi in t.GetMethods()) {
+                        if (mi.Name == "Main") {
+                            SampleAttribute sa = (SampleAttribute) Attribute.GetCustomAttribute(mi, typeof(SampleAttribute));
+                            if (sa != null) {
+                                results.Add(t.Name);
+                                skipMethods = true;
+                                break;
+                            }
+                        }
+                        if (skipMethods) break;
+                    }
+                }
+            }
+            return results.ToArray();
+        }
+
+        public static string[] GetAllTestTitles() {
+            bool skipMethods;
+            var results = new List<string>();
+            foreach (Type t in Assembly.GetExecutingAssembly().GetTypes()) {
+                if (t.Namespace == "YamlDotNet.Samples" && t.IsClass) {
+                    skipMethods = false;
+                    foreach (MethodInfo mi in t.GetMethods()) {
+                        if (mi.Name == "Main") {
+                            SampleAttribute sa = (SampleAttribute) Attribute.GetCustomAttribute(mi, typeof(SampleAttribute));
+                            if (sa != null) {
+                                results.Add(sa.Title);
+                                skipMethods = true;
+                                break;
+                            }
+                        }
+                        if (skipMethods) break;
+                    }
+                }
+            }
+            return results.ToArray();
+        }
+
+        private void Start() {
+            bool skipMethods;
+            foreach (Type t in Assembly.GetExecutingAssembly().GetTypes()) {
+                if (t.Namespace == "YamlDotNet.Samples" && t.IsClass && Array.IndexOf(disabledTests, t.Name) == -1) {
+                    skipMethods = false;
+                    foreach (MethodInfo mi in t.GetMethods()) {
+                        if (mi.Name == "Main") {
+                            SampleAttribute sa = (SampleAttribute) Attribute.GetCustomAttribute(mi, typeof(SampleAttribute));
+                            if (sa != null) {
+                                helper.WriteLine("{0} - {1}", sa.Title, sa.Description);
+                                var testObject = t.GetConstructor(new Type[] { typeof(StringTestOutputHelper) }).Invoke(new object[] { helper });
+                                mi.Invoke(testObject, new object[] {});
+                                Debug.Log(helper.ToString());
+                                helper.Clear();
+                                skipMethods = true;
+                                break;
+                            }
+                        }
+                        if (skipMethods) break;
+                    }
+                }
+            }
+        }
+    }
+
+#if UNITY_EDITOR
+    [CustomEditor(typeof(ExampleRunner))]
+    public class ExampleRunnerEditor : Editor {
+        private ExampleRunner runner;
+        private string[] allTests;
+        private string[] allTitles;
+        private bool[] enabledTests;
+
+        public void OnEnable() {
+            runner = (ExampleRunner) target;
+
+            allTests  = ExampleRunner.GetAllTestNames();
+            allTitles = ExampleRunner.GetAllTestTitles();
+            enabledTests = new bool[allTests.Length];
+            for (int i = 0;  i < allTests.Length; i++)
+                enabledTests[i] = Array.IndexOf(runner.disabledTests, allTests[i]) == -1;
+        }
+
+        public override void OnInspectorGUI() {
+            int nextDisabledIndex = 0;
+            for (int i = 0;  i < allTests.Length; i++) {
+                EditorGUI.BeginChangeCheck();
+                if (!enabledTests[i])
+                    nextDisabledIndex++;
+                enabledTests[i] = EditorGUILayout.Toggle(allTitles[i], enabledTests[i]);
+                if (EditorGUI.EndChangeCheck()) {
+                    if (enabledTests[i]) {
+                        var l = new List<string>(runner.disabledTests);
+                        l.Remove(allTests[i]);
+                        runner.disabledTests = l.ToArray();
+                    } else {
+                        var l = new List<string>(runner.disabledTests);
+                        l.Insert(nextDisabledIndex, allTests[i]);
+                        runner.disabledTests = l.ToArray();
+                    }
+                }
+            }
+        }
+    }
+#endif
+}

--- a/YamlDotNet.Samples/Helpers/SampleAttribute.cs
+++ b/YamlDotNet.Samples/Helpers/SampleAttribute.cs
@@ -1,13 +1,15 @@
-﻿using Xunit;
+﻿using System;
 
 namespace YamlDotNet.Samples.Helpers
 {
     /// <summary>
     /// Marks a test as being a code sample.
     /// </summary>
-    internal class SampleAttribute : FactAttribute
+    internal class SampleAttribute : Attribute
     {
         private string title;
+
+        public string DisplayName { get; private set; }
 
         public string Title
         {

--- a/YamlDotNet.Samples/Helpers/TestOutputHelperExtensions.cs
+++ b/YamlDotNet.Samples/Helpers/TestOutputHelperExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Xunit.Abstractions;
-
-namespace YamlDotNet.Samples.Helpers
+﻿namespace YamlDotNet.Samples.Helpers
 {
     public static class TestOutputHelperExtensions
     {

--- a/YamlDotNet.Samples/LoadingAYamlStream.cs
+++ b/YamlDotNet.Samples/LoadingAYamlStream.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using Xunit.Abstractions;
 using YamlDotNet.RepresentationModel;
 using YamlDotNet.Samples.Helpers;
 

--- a/YamlDotNet.Samples/SerializeObjectGraph.cs
+++ b/YamlDotNet.Samples/SerializeObjectGraph.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Xunit.Abstractions;
 using YamlDotNet.Serialization;
 using YamlDotNet.Samples.Helpers;
 
@@ -20,32 +19,32 @@ namespace YamlDotNet.Samples
         )]
         public void Main()
         {
-            var address = new
+            var address = new Address
             {
                 street = "123 Tornado Alley\nSuite 16",
                 city = "East Westville",
                 state = "KS"
             };
 
-            var receipt = new
+            var receipt = new Receipt
             {
                 receipt = "Oz-Ware Purchase Invoice",
                 date = new DateTime(2007, 8, 6),
-                customer = new
+                customer = new Customer
                 {
                     given = "Dorothy",
                     family = "Gale"
                 },
-                items = new[]
+                items = new Item[]
                 {
-                    new
+                    new Item
                     {
                         part_no = "A4786",
                         descrip = "Water Bucket (Filled)",
                         price = 1.47M,
                         quantity = 4
                     },
-                    new
+                    new Item
                     {
                         part_no = "E1628",
                         descrip = "High Heeled \"Ruby\" Slippers",
@@ -61,9 +60,37 @@ namespace YamlDotNet.Samples
                                   "man behind the curtain."
             };
 
-            var serializer = new Serializer();
+            var serializer = new SerializerBuilder().Build();
             var yaml = serializer.Serialize(receipt);
             output.WriteLine(yaml);
         }
+    }
+
+    public class Address {
+        public string street { get; set; }
+        public string city   { get; set; }
+        public string state  { get; set; }
+    }
+
+    public class Receipt {
+        public string   receipt         { get; set; }
+        public DateTime date            { get; set; }
+        public Customer customer        { get; set; }
+        public Item[]   items           { get; set; }
+        public Address  bill_to         { get; set; }
+        public Address  ship_to         { get; set; }
+        public string   specialDelivery { get; set; }
+    }
+
+    public class Customer {
+        public string given  { get; set; }
+        public string family { get; set; }
+    }
+
+    public class Item {
+        public string  part_no  { get; set; }
+        public string  descrip  { get; set; }
+        public decimal price    { get; set; }
+        public int     quantity { get; set; }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -106,6 +106,13 @@ namespace YamlDotNet.RepresentationModel
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlMappingNode"/> class.
         /// </summary>
+        public YamlMappingNode(int dummy) // dummy makes the call to the constructor unambiguous to buggy compilers like mono in Unity.
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YamlMappingNode"/> class.
+        /// </summary>
         public YamlMappingNode(params KeyValuePair<YamlNode, YamlNode>[] children)
             : this((IEnumerable<KeyValuePair<YamlNode, YamlNode>>)children)
         {
@@ -404,7 +411,7 @@ namespace YamlDotNet.RepresentationModel
                 throw new ArgumentNullException("mapping");
             }
 
-            var result = new YamlMappingNode();
+            var result = new YamlMappingNode(0);
             foreach (var property in mapping.GetType().GetPublicProperties())
             {
                 if (property.CanRead && property.GetGetMethod().GetParameters().Length == 0)


### PR DESCRIPTION
These are some of the changes for the Unity version of the library.
ExampleRunner.cs has been added to enable running of the examples.
'ValidatingDuringDeserialization.cs' has been skipped since I didn't find out how to address the dependencies.

Consider if you want to include any of these changes. I'm maintaining a difference between the code bases for Unity users, for convenience, but of course I want to keep it as small as possible. In my package I don't want to require the 'UNITY' define flag either, so the package has a few additional changes compared to this.