### PR TITLE
[WIP] handling exclamation mark characters when parsing YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ bin
 obj
 tools
 
+# Visual Studio local cache
+.vs/
+
+
 # mstest test results
 TestResults
 *.suo

--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -104,6 +104,12 @@ namespace YamlDotNet.Test.RepresentationModel
         }
 
         [Fact]
+        public void RoundTripVCRExample()
+        {
+            RoundtripTest("vcr-example-file.yaml");
+        }
+
+        [Fact]
         public void RoundtripExample1()
         {
             RoundtripTest("01-directives.yaml");

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -104,6 +104,7 @@
     <EmbeddedResource Include="files\multi-doc-tag.yaml" />
     <EmbeddedResource Include="files\unicode-32bits-escape.yaml" />
     <EmbeddedResource Include="files\anchors-overwriting.yaml" />
+    <EmbeddedResource Include="files\vcr-example-file.yaml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\YamlDotNet\YamlDotNet.csproj">

--- a/YamlDotNet.Test/files/vcr-example-file.yaml
+++ b/YamlDotNet.Test/files/vcr-example-file.yaml
@@ -1,0 +1,110 @@
+﻿---
+http_interactions:
+- request:
+    method: get
+    uri: http://example.com/foo
+    body: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Last-Modified:
+      - Tue, 15 Nov 2005 13:24:10 GMT
+      Connection:
+      - Keep-Alive
+      Etag:
+      - ! '"24ec5-1b6-4059a80bfd280"'
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Wed, 31 Mar 2010 02:43:23 GMT
+      Server:
+      - Apache/2.2.3 (CentOS)
+      Content-Length:
+      - '438'
+      Age:
+      - '3285'
+      Accept-Ranges:
+      - bytes
+    body: example.com get response 1 with path=foo
+    http_version: '1.1'
+  recorded_at: Tue, 01 Nov 2011 04:49:54 GMT
+- request:
+    method: get
+    uri: http://example.com/foo
+    body: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Last-Modified:
+      - Tue, 15 Nov 2005 13:24:10 GMT
+      Connection:
+      - Keep-Alive
+      Etag:
+      - ! '"24ec5-1b6-4059a80bfd280"'
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Wed, 31 Mar 2010 02:43:23 GMT
+      Server:
+      - Apache/2.2.3 (CentOS)
+      Content-Length:
+      - '438'
+      Age:
+      - '3285'
+      Accept-Ranges:
+      - bytes
+    body: example.com get response 2 with path=foo
+    http_version: '1.1'
+  recorded_at: Tue, 01 Nov 2011 04:49:54 GMT
+- request:
+    method: post
+    uri: http://example.com/
+    body: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Last-Modified:
+      - Tue, 15 Nov 2005 13:24:10 GMT
+      Connection:
+      - close
+      Etag:
+      - ! '"24ec5-1b6-4059a80bfd280"'
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Wed, 31 Mar 2010 02:43:26 GMT
+      Server:
+      - Apache/2.2.3 (CentOS)
+      Content-Length:
+      - '438'
+      Accept-Ranges:
+      - bytes
+    body: example.com post response with id=3
+    http_version: '1.1'
+  recorded_at: Tue, 01 Nov 2011 04:49:54 GMT
+- request:
+    method: get
+    uri: http://example.com/two_set_cookie_headers
+    body: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Set-Cookie:
+      - bar=bazz
+      - foo=bar
+    body: this respons has two set-cookie headers
+    http_version: '1.1'
+  recorded_at: Tue, 01 Nov 2011 04:49:54 GMT
+recorded_with: VCR 1.11.3


### PR DESCRIPTION
I wanted to spike up a proof-of-concept which required consuming YAML files generated by the [vcr](https://rubygems.org/gems/vcr) gem, but encountered a parsing problem with this style of node:

```yaml
      Etag:
      - ! '"24ec5-1b6-4059a80bfd280"'
```

It looks like this is a known part of the [1.2 spec](http://www.yaml.org/spec/1.2/spec.html#id2784064):

> By explicitly specifying a “!” non-specific tag property, the node would then be resolved to a “vanilla” sequence, mapping, or string, according to its kind.

And this SO thread mentions that it's a known issue with YamlDotNet: https://stackoverflow.com/questions/9664113/what-does-a-single-exclamation-mark-do-in-yaml

I'm honestly not sure if this is intended to be supported, or even how to make it work properly, but I figure I'd start this off by adding a failing test and see where to go from there.
