### PR TITLE
Actualy cache in CachedTypeInspector

### DIFF
--- a/YamlDotNet/Serialization/TypeInspectors/CachedTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/CachedTypeInspector.cs
@@ -49,6 +49,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
             if (!cache.TryGetValue(type, out list))
             {
                 list = new List<IPropertyDescriptor>(innerTypeDescriptor.GetProperties(type, container));
+                cache.Add(type, list);
             }
             return list;
         }


### PR DESCRIPTION
Looks like a pretty serious oversight in `CachedTypeInspector.cs` that was messing my parsing of a heavy (248KB) YAML very seriously...

I was seeing parse times of 50 seconds -> 2 seconds after applying this fix locally.

I would GREATLY appreciate a quick push to nuget and a release of 4.2.2 so I can shove into my project properly without too much hackary...