### PR TITLE
Fixes issue #293 - Can not deserialize DateTimeOffset in .netcoreapp2.0

### DIFF
--- a/YamlDotNet.Test/Helpers/PortabilityTests.cs
+++ b/YamlDotNet.Test/Helpers/PortabilityTests.cs
@@ -1,0 +1,42 @@
+//  This file is part of YamlDotNet - A .NET library for YAML.
+//  Copyright (c) Antoine Aubry and contributors
+
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//  of the Software, and to permit persons to whom the Software is furnished to do
+//  so, subject to the following conditions:
+
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace YamlDotNet.Test.Helpers
+{
+    public class PortabilytyTests
+    {
+#if PORTABLE
+        [Fact]
+        public void GetPublicStaticMethodReturnsCorrectMethodInfo()
+        {
+            var type = typeof(DateTimeOffset);
+            var expected = type.GetMethod("Parse", new [] { typeof(string), typeof(IFormatProvider) });
+            var method = type.GetPublicStaticMethod("Parse", typeof(string), typeof(IFormatProvider));
+
+            Assert.Equal(expected, method);
+        }
+#endif
+    }
+}

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -244,7 +244,7 @@ namespace YamlDotNet
                     {
                         var parameters = m.GetParameters();
                         return parameters.Length == parameterTypes.Length
-                            && parameters.Zip(parameterTypes, (pi, pt) => pi.Equals(pt)).All(r => r);
+                            && parameters.Zip(parameterTypes, (pi, pt) => pi.ParameterType == pt).All(r => r);
                     }
                     return false;
                 });


### PR DESCRIPTION
- Change comparation scheme in ```ReflectionExtentions::GetPublicStaticMethod```
- Adds test case