### PR TITLE
Avoid definition of SerializationException on NET Standard

### DIFF
--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -534,9 +534,8 @@ namespace YamlDotNet.Core
         private bool IsUnicode(Encoding encoding)
         {
             return encoding is UTF8Encoding ||
-                encoding is UnicodeEncoding ||
-                encoding is UTF7Encoding ||
-                encoding is UTF8Encoding;
+                   encoding is UnicodeEncoding ||
+                   encoding is UTF7Encoding;
         }
 
         private void AnalyzeTag(string tag)

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -78,12 +78,6 @@ namespace YamlDotNet
         }
     }
 
-    /// <summary>
-    /// Mock SerializableAttribute to avoid having to add #if all over the place
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
-    internal sealed class SerializableAttribute : Attribute { }
-
     internal static class ReflectionExtensions
     {
         public static Type BaseType(this Type type)
@@ -303,11 +297,6 @@ namespace YamlDotNet
         Decimal = 15,
         DateTime = 16,
         String = 18,
-    }
-
-    internal abstract class DBNull
-    {
-        private DBNull() {}
     }
 
     internal sealed class CultureInfoAdapter : CultureInfo

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -42,42 +42,6 @@ namespace YamlDotNet
 #endif
 
 #if NETSTANDARD1_3
-    /// <summary>
-    /// Mock UTF7Encoding to avoid having to add #if all over the place
-    /// </summary>
-    internal sealed class UTF7Encoding : System.Text.Encoding
-    {
-        public override int GetByteCount(char[] chars, int index, int count)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override int GetCharCount(byte[] bytes, int index, int count)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override int GetMaxByteCount(int charCount)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override int GetMaxCharCount(int byteCount)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
     internal static class ReflectionExtensions
     {
         public static Type BaseType(this Type type)

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -277,28 +277,6 @@ namespace YamlDotNet
         }
     }
 
-    internal enum TypeCode
-    {
-        Empty = 0,
-        Object = 1,
-        DBNull = 2,
-        Boolean = 3,
-        Char = 4,
-        SByte = 5,
-        Byte = 6,
-        Int16 = 7,
-        UInt16 = 8,
-        Int32 = 9,
-        UInt32 = 10,
-        Int64 = 11,
-        UInt64 = 12,
-        Single = 13,
-        Double = 14,
-        Decimal = 15,
-        DateTime = 16,
-        String = 18,
-    }
-
     internal sealed class CultureInfoAdapter : CultureInfo
     {
         private readonly IFormatProvider _provider;

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -457,18 +457,6 @@ namespace YamlDotNet
 #endif
 }
 
-#if NETSTANDARD1_3
-namespace System.Runtime.Serialization
-{
-    public class SerializationException : Exception
-    {
-        public SerializationException(string message) : base(message)
-        {
-        }
-    }
-}
-#endif
-
 #if NET20
 namespace System.Runtime.CompilerServices
 {

--- a/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -102,14 +102,15 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
                     visitor.VisitScalar(value, context);
                     break;
 
-                case TypeCode.DBNull:
-                    visitor.VisitScalar(new ObjectDescriptor(null, typeof(object), typeof(object)), context);
-                    break;
-
                 case TypeCode.Empty:
                     throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "TypeCode.{0} is not supported.", typeCode));
 
                 default:
+                    if (value.Type == typeof(DBNull))
+                    {
+                        visitor.VisitScalar(new ObjectDescriptor(null, typeof(object), typeof(object)), context);
+                    }
+
                     if (value.Value == null || value.Type == typeof(TimeSpan))
                     {
                         visitor.VisitScalar(value, context);

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -40,6 +40,9 @@
     <PackageReference Include="System.Data.Common">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Runtime">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <PackageReference Include="System.Runtime.Serialization.Formatters">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -37,7 +37,10 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Runtime.Serialization.Primitives">
+    <PackageReference Include="System.Data.Common">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Runtime.Serialization.Formatters">
       <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -36,5 +36,10 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.3' And '$(TargetFramework)' != 'net20'">
     <Reference Include="System.Core" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Runtime.Serialization.Primitives">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Problem

When a project targeting NET Standard 2.0 pulls in YamlDotNet 4.3.0 then
build errors related to the multiple definition of `System.Runtime.Serialization.SerializationException` occur. This is because the NET Standard (1.3) version of YamlDotNet provides its own definition of this type, but NET Standard reintroduced it in version 2.0.

# Solution

The problem is easily fixed by removing the local definition and instead referencing `System.Runtime.Serialization.Primitives` which defines the type for pre-NET Standard 2.0.