### PR TITLE
Add support for deserializing fields in addition to properties

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -347,6 +347,11 @@ namespace YamlDotNet.Test.Serialization
         public string aaa { get; set; }
     }
 
+    public class SimpleField
+    {
+        public string theField;
+    }
+
     public class SimpleScratch
     {
         public string Scratch { get; set; }

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -357,6 +357,17 @@ namespace YamlDotNet.Test.Serialization
         }
 
         [Fact]
+        public void DeserializeField()
+        {
+            var text = @"theField: Howdy
+...";
+
+            var result = Deserializer.Deserialize<SimpleField>(UsingReaderFor(text));
+
+            result.theField.Should().Be("Howdy");
+        }
+
+        [Fact]
         public void RoundtripDerivedClassWithSerializeAs()
         {
             var obj = new InheritanceExample


### PR DESCRIPTION
I made changes so that I can deserialize yaml to fields, which should address #117 "Serializing also fields and not just properties will make life easier". This is convenient for Unity objects with [SerializeField] members because Unity disallows using properties for these fields. 

I'm not setup to test on platforms other than net46, so there may be issues on other platforms. I added a simple unit test. I'll attempt to execute the docker-based build/test soon when I have a chance to review how it works. I haven't done a pull request on a public repo before, so let me know if there is protocol I'm overlooking.

Thank you for publishing this library! It has been very useful to us.