### PR TITLE
Add repository location

### DIFF
--- a/YamlDotNet/YamlDotNet.Signed.nuspec
+++ b/YamlDotNet/YamlDotNet.Signed.nuspec
@@ -10,6 +10,7 @@
         <licenseUrl>https://github.com/aaubry/YamlDotNet/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/aaubry/YamlDotNet/wiki</projectUrl>
         <iconUrl>http://aaubry.net/images/yamldotnet.png</iconUrl>
+        <repository type="git" url="https://github.com/aaubry/YamlDotNet.git" />
         <tags>yaml parser development library serialization signed strongname</tags>
     </metadata>
     <files>

--- a/YamlDotNet/YamlDotNet.Unsigned.nuspec
+++ b/YamlDotNet/YamlDotNet.Unsigned.nuspec
@@ -10,6 +10,7 @@
         <licenseUrl>https://github.com/aaubry/YamlDotNet/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/aaubry/YamlDotNet/wiki</projectUrl>
         <iconUrl>http://aaubry.net/images/yamldotnet.png</iconUrl>
+        <repository type="git" url="https://github.com/aaubry/YamlDotNet.git" />
         <tags>yaml parser development library serialization</tags>
     </metadata>
     <files>


### PR DESCRIPTION
Nuget provides elements to specify where the source code repository is for a nuget package, by specifying a [repository element](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd#L67).

It would be great if we had this information straight into the .nuspec, which would allow tooling such as [renovate](https://renovatebot.com/) to fetch detailed information about releases (what specifically has been fixed [sample](https://github.com/tomkerkhove/promitor/pull/75)).

This adds the repository location to the nuspec.