### PR TITLE
Fix roundtripping of tags on sequences

### DIFF
--- a/YamlDotNet.Test/Serialization/RepresentationModelSerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/RepresentationModelSerializationTests.cs
@@ -37,6 +37,7 @@ namespace YamlDotNet.Test.Serialization
         [InlineData("[a]", new[] { "a" })]
         [InlineData("['a']", new[] { "a" })]
         [InlineData("- a\r\n- b", new[] { "a", "b" })]
+        [InlineData("!bla [a]", new[] { "a" })]
         public void SequenceIsSerializable(string yaml, string[] expectedValues)
         {
             var deserializer = new Deserializer();

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -154,7 +154,7 @@ namespace YamlDotNet.RepresentationModel
         /// <param name="state">The state.</param>
         internal override void Emit(IEmitter emitter, EmitterState state)
         {
-            emitter.Emit(new SequenceStart(Anchor, Tag, true, Style));
+            emitter.Emit(new SequenceStart(Anchor, Tag, string.IsNullOrEmpty(Tag), Style));
             foreach (var node in children)
             {
                 node.Save(emitter, state);


### PR DESCRIPTION
Tags get dropped at the beginning of a sequence when serializing. This PR fixes this. Yaml tags are used extensively by AWS CloudFormation see for the [Join function](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-join.html) for example.

I used string.IsNullOrEmtpy to determine the value of isImplicit because this is what's used during parsing [here](https://github.com/aaubry/YamlDotNet/blob/5ec2dd75704d6dced41c0d49ff5528f3797d1068/YamlDotNet/Core/Parser.cs#L485).