### PR TITLE
Add support for supplying custom IObjectGraphTraversalStrategy implementations  

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 # Changelog
 
+## Version 5.2.1
+
+Bug fixes:
+* Fix roundtripping of tags on sequences (#347)
+
 ## Version 5.2.0
 
 Improvements:

--- a/YamlDotNet/Serialization/ObjectGraphTraversalStrategyFactory.cs
+++ b/YamlDotNet/Serialization/ObjectGraphTraversalStrategyFactory.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace YamlDotNet.Serialization
+{
+    /// <summary>
+    /// A factory method for creating <see cref="IObjectGraphTraversalStrategy"/> instances
+    /// </summary>
+    /// <param name="typeInspector">The type inspector to be used by the traversal strategy.</param>
+    /// <param name="typeResolver">The type resolver to be used by the traversal strategy.</param>
+    /// <param name="typeConverters">The type converters to be used by the traversal strategy.</param>
+    /// <param name="maximumRecursion">The maximum object depth to be supported by the traversal strategy.</param>
+    /// <returns></returns>
+    public delegate IObjectGraphTraversalStrategy
+        ObjectGraphTraversalStrategyFactory(
+            ITypeInspector typeInspector,
+            ITypeResolver typeResolver,
+            IEnumerable<IYamlTypeConverter> typeConverters,
+            int maximumRecursion
+        );
+}


### PR DESCRIPTION
Allows for custom object graph traversal strategies to be implemented and used by the Serializer.