### PR TITLE
Add base method for WithTagMapping().

### DIFF
--- a/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -87,6 +87,8 @@ namespace YamlDotNet.Serialization
             return Self;
         }
 
+        public abstract TBuilder WithTagMapping(string tag, Type type);
+
 #if !NET20
         /// <summary>
         /// Register an <see cref="Attribute"/> for for a given property.

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -283,7 +283,7 @@ namespace YamlDotNet.Serialization
         /// <summary>
         /// Registers a tag mapping.
         /// </summary>
-        public DeserializerBuilder WithTagMapping(string tag, Type type)
+        public override DeserializerBuilder WithTagMapping(string tag, Type type)
         {
             if (tag == null)
             {

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -79,7 +79,7 @@ namespace YamlDotNet.Serialization
 
         /// <summary>
         /// Sets the maximum recursion that is allowed while traversing the object graph. The default value is 50.
-        /// <summary>
+        /// </summary>
         public SerializerBuilder WithMaximumRecursion(int maximumRecursion)
         {
             if (maximumRecursion <= 0)
@@ -177,7 +177,7 @@ namespace YamlDotNet.Serialization
         /// <summary>
         /// Registers a tag mapping.
         /// </summary>
-        public SerializerBuilder WithTagMapping(string tag, Type type)
+        public override SerializerBuilder WithTagMapping(string tag, Type type)
         {
             if (tag == null)
             {


### PR DESCRIPTION
Having an abstract `.WithTagMapping` class in the base `BuilderSkeleton` class eliminates the need to chain identical `.WithTagMapping` calls in two different places, i.e. when serializing and when deserializing custom objects. With the base method in place, I am able to declare an extension method (there are other ways to do it of course) and apply the same tag mappings to `SerializerBuilder` and to `DeserializerBuilder` objects, which keeps the code DRY.

Example extension method, taken from my actual project:

```c#
static class YamlTagMappingExtension
{
    public static TBuilder WithCommonTagMappings<TBuilder>(this TBuilder builder)
        where TBuilder : BuilderSkeleton<TBuilder>
    {
        return builder
            .WithTagMapping("!Settings", typeof(Settings))
            .WithTagMapping("!SettingsList", typeof(List<Settings>))
            .WithTagMapping("!ElementsList", typeof(List<ElementBase>))
            .WithTagMapping("!FormatElementsList", typeof(List<FormatElementBase>))
            .WithTagMapping("!Items", typeof(Items))
            .WithTagMapping("!SelectFirstDay", typeof(SelectFirstDay))
            .WithTagMapping("!SelectEachDay", typeof(SelectEachDay))
            .WithTagMapping("!SelectLastDay", typeof(SelectLastDay))
            .WithTagMapping("!TwoColumns", typeof(TwoColumns))
            .WithTagMapping("!NextColumn", typeof(NextColumn));
    }
}
```

This is then used with `SerializerBiulder` or `DeserializerBuilder` objects alike:

```c#
SerializerBuilder builder = new SerializerBuilder().WithCommonTagMappings().EnsureRoundtrip();
// Serialize stuff, then later in the logic flow:
DeserializerBuilder builder = new DeserializerBuilder().WithCommonTagMappings();
```

Hopefully I have not missed something important...