### PR TITLE
Typos and nameof

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Bug fixes:
 ## Version 5.2.0
 
 Improvements:
-* Allow to specify the maximum recusion limit (fixes #352) with the [WithMaximumRecursion](https://github.com/aaubry/YamlDotNet/pull/353/files#diff-86074b6acff29ccad667aca741f62ac5R83) method.
+* Allow to specify the maximum recursion limit (fixes #352) with the [WithMaximumRecursion](https://github.com/aaubry/YamlDotNet/pull/353/files#diff-86074b6acff29ccad667aca741f62ac5R83) method.
 
 ## Version 5.1.0
 
@@ -91,8 +91,8 @@ mainly if you are parsing documents from sources that you do not trust.
 
 **Many thanks to [Kurt Boberg](mailto:kurt.boberg@docusign.com), from the DocuSign Application Security Team, who identified this issue and provided feedback on mitigation strategies.**
 
-* **Remove the legacy backwards-compatibe syntax that enabled to create
-  `Serializer` and `Deserializer` directly then changing their configutation.**  
+* **Remove the legacy backwards-compatible syntax that enabled to create
+  `Serializer` and `Deserializer` directly then changing their configuration.**  
   In most cases, the calls to the constructors should be replaced by
   instantiations of `SerializerBuilder` and `DeserializerBuilder`.
   These can be configured at will, then used to create instances of
@@ -161,7 +161,7 @@ Bug fixes:
 
 Bug fixes:
 
-* Actualy cache in CachedTypeInspector.
+* Actually cache in CachedTypeInspector.
 
 ## Version 4.2.1
 
@@ -202,8 +202,8 @@ Bug fixes:
   Use the `Without...` methods on `SerializerBuilder` and `DeserializerBuilder` for that.
 * New [`DateTimeConverter`](https://github.com/aaubry/YamlDotNet/pull/234)  
   * It accepts [`DateTimeKind.Utc`](https://msdn.microsoft.com/en-us/library/shx7s921(v=vs.110).aspx) and [Standard Date and Time Format Strings](https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx) of "G" as its default parameters, if they are omitted.
-  * For deserialisation, it accepts as many number of formats as we want. If a value doesn't match against provided formats, it will return [`FormatException`](https://msdn.microsoft.com/en-us/library/system.formatexception(v=vs.110).aspx). Please refer to my whole test cases.
-  * For serialisation, it only considers the first format in the format list.
+  * For deserialization, it accepts as many number of formats as we want. If a value doesn't match against provided formats, it will return [`FormatException`](https://msdn.microsoft.com/en-us/library/system.formatexception(v=vs.110).aspx). Please refer to my whole test cases.
+  * For serialization, it only considers the first format in the format list.
 * Improve the (de)serializer builders so that it is possible to [wrap existing component registrations](https://github.com/aaubry/YamlDotNet/commit/204ff4979dca7e2cfcbe86cd1387bf6b6f2398c3).
 * Added the `ApplyNamingConventions` property to `YamlMemberAttribute`.  
   When this property is true, naming conventions are not applied to the associated member. This solves [issue 228](https://github.com/aaubry/YamlDotNet/issues/228).
@@ -252,7 +252,7 @@ This a major release that introduces a few breaking changes.
   the composition of services performed by these two classes.
   This means that every aspect of the composition should be
   extensible / overridable. Things like injecting a custom TypeInspector
-  or replacing the the default ArrayNodeDeserializer with
+  or replacing the default ArrayNodeDeserializer with
   an alternative implementation become possible and easy.  
   In order to avoid breaking existing code,
   the constructors of Serializer and Deserializer have been kept

--- a/YamlDotNet.Test/Portability.cs
+++ b/YamlDotNet.Test/Portability.cs
@@ -29,7 +29,7 @@ namespace YamlDotNet.Test
             var property = TryGetMemberExpression<PropertyInfo>(propertyAccessor);
             if (property == null)
             {
-                throw new ArgumentException("Expected a lambda expression in the form: x => x.SomeProperty", "propertyAccessor");
+                throw new ArgumentException("Expected a lambda expression in the form: x => x.SomeProperty", nameof(propertyAccessor));
             }
 
             return property;

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -788,7 +788,7 @@ namespace YamlDotNet.Test.Serialization
         }
 
         [Fact]
-        // Todo: this is actualy roundtrip
+        // Todo: this is actually roundtrip
         public void DeserializationOfDefaultsWorkInJson()
         {
             var writer = new StringWriter();
@@ -1135,15 +1135,15 @@ namespace YamlDotNet.Test.Serialization
 
             result["derived1"].Should()
                 .Contain("key", "D1", "key should be overriden by the actual mapping")
-                .And.Contain("level", "1", "level should should be inherited from the backreferenced mapping");
+                .And.Contain("level", "1", "level should be inherited from the backreferenced mapping");
 
             result["derived2"].Should()
                 .Contain("key", "D2", "key should be overriden by the actual mapping")
-                .And.Contain("level", "2", "level should should be inherited from the backreferenced mapping");
+                .And.Contain("level", "2", "level should be inherited from the backreferenced mapping");
 
             result["derived3"].Should()
                 .Contain("key", "D3", "key should be overriden by the actual mapping")
-                .And.Contain("level", "2", "level should should be inherited from the backreferenced mapping");
+                .And.Contain("level", "2", "level should be inherited from the backreferenced mapping");
         }
 
         [Fact]

--- a/YamlDotNet/Core/CharacterAnalyzer.cs
+++ b/YamlDotNet/Core/CharacterAnalyzer.cs
@@ -172,7 +172,7 @@ namespace YamlDotNet.Core
 
         public bool Check(string expectedCharacters, int offset = 0)
         {
-            // Todo: using it this way doesn't break anything, it's not realy wrong...
+            // Todo: using it this way doesn't break anything, it's not really wrong...
             Debug.Assert(expectedCharacters.Length > 1, "Use Check(char, int) instead.");
 
             var character = buffer.Peek(offset);

--- a/YamlDotNet/Core/Constants.cs
+++ b/YamlDotNet/Core/Constants.cs
@@ -25,7 +25,7 @@ using YamlDotNet.Core.Tokens;
 namespace YamlDotNet.Core
 {
     /// <summary>
-    /// Defines constants thar relate to the YAML specification.
+    /// Defines constants that relate to the YAML specification.
     /// </summary>
     public static class Constants
     {

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -138,7 +138,7 @@ namespace YamlDotNet.Core
         {
             if (bestIndent < MinBestIndent || bestIndent > MaxBestIndent)
             {
-                throw new ArgumentOutOfRangeException("bestIndent", string.Format(CultureInfo.InvariantCulture,
+                throw new ArgumentOutOfRangeException(nameof(bestIndent), string.Format(CultureInfo.InvariantCulture,
                     "The bestIndent parameter must be between {0} and {1}.", MinBestIndent, MaxBestIndent));
             }
 
@@ -146,7 +146,7 @@ namespace YamlDotNet.Core
 
             if (bestWidth <= bestIndent * 2)
             {
-                throw new ArgumentOutOfRangeException("bestWidth", "The bestWidth parameter must be greater than bestIndent * 2.");
+                throw new ArgumentOutOfRangeException(nameof(bestWidth), "The bestWidth parameter must be greater than bestIndent * 2.");
             }
 
             this.bestWidth = bestWidth;
@@ -664,7 +664,7 @@ namespace YamlDotNet.Core
         {
             if (!(evt is StreamStart))
             {
-                throw new ArgumentException("Expected STREAM-START.", "evt");
+                throw new ArgumentException("Expected STREAM-START.", nameof(evt));
             }
 
             indent = -1;

--- a/YamlDotNet/Core/Events/NodeEvent.cs
+++ b/YamlDotNet/Core/Events/NodeEvent.cs
@@ -82,18 +82,18 @@ namespace YamlDotNet.Core.Events
             {
                 if (anchor.Length == 0)
                 {
-                    throw new ArgumentException("Anchor value must not be empty.", "anchor");
+                    throw new ArgumentException("Anchor value must not be empty.", nameof(anchor));
                 }
 
                 if (!anchorValidator.IsMatch(anchor))
                 {
-                    throw new ArgumentException("Anchor value must contain alphanumerical characters only.", "anchor");
+                    throw new ArgumentException("Anchor value must contain alphanumerical characters only.", nameof(anchor));
                 }
             }
 
             if (tag != null && tag.Length == 0)
             {
-                throw new ArgumentException("Tag value must not be empty.", "tag");
+                throw new ArgumentException("Tag value must not be empty.", nameof(tag));
             }
 
             this.anchor = anchor;

--- a/YamlDotNet/Core/FakeList.cs
+++ b/YamlDotNet/Core/FakeList.cs
@@ -71,7 +71,7 @@ namespace YamlDotNet.Core
                 {
                     if (!collection.MoveNext())
                     {
-                        throw new ArgumentOutOfRangeException("index");
+                        throw new ArgumentOutOfRangeException(nameof(index));
                     }
                     ++currentIndex;
                 }

--- a/YamlDotNet/Core/ILookAheadBuffer.cs
+++ b/YamlDotNet/Core/ILookAheadBuffer.cs
@@ -34,7 +34,7 @@ namespace YamlDotNet.Core
         }
 
         /// <summary>
-        /// Gets the character at thhe specified offset.
+        /// Gets the character at the specified offset.
         /// </summary>
         char Peek(int offset);
 

--- a/YamlDotNet/Core/IParser.cs
+++ b/YamlDotNet/Core/IParser.cs
@@ -24,7 +24,7 @@ using YamlDotNet.Core.Events;
 namespace YamlDotNet.Core
 {
     /// <summary>
-    /// Represents a YAML stream paser.
+    /// Represents a YAML stream parser.
     /// </summary>
     public interface IParser
     {

--- a/YamlDotNet/Core/LookAheadBuffer.cs
+++ b/YamlDotNet/Core/LookAheadBuffer.cs
@@ -49,11 +49,11 @@ namespace YamlDotNet.Core
         {
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
             if (capacity < 1)
             {
-                throw new ArgumentOutOfRangeException("capacity", "The capacity must be positive.");
+                throw new ArgumentOutOfRangeException(nameof(capacity), "The capacity must be positive.");
             }
 
             this.input = input;
@@ -91,7 +91,7 @@ namespace YamlDotNet.Core
         {
             if (offset < 0 || offset >= buffer.Length)
             {
-                throw new ArgumentOutOfRangeException("offset", "The offset must be between zero and the capacity of the buffer.");
+                throw new ArgumentOutOfRangeException(nameof(offset), "The offset must be between zero and the capacity of the buffer.");
             }
 
             Cache(offset);
@@ -139,7 +139,7 @@ namespace YamlDotNet.Core
         {
             if (length < 1 || length > count)
             {
-                throw new ArgumentOutOfRangeException("length", "The length must be between 1 and the number of characters in the buffer. Use the Peek() and / or Cache() methods to fill the buffer.");
+                throw new ArgumentOutOfRangeException(nameof(length), "The length must be between 1 and the number of characters in the buffer. Use the Peek() and / or Cache() methods to fill the buffer.");
             }
             firstIndex = GetIndexForOffset(length);
             count -= length;

--- a/YamlDotNet/Core/LookAheadBuffer.cs
+++ b/YamlDotNet/Core/LookAheadBuffer.cs
@@ -85,13 +85,13 @@ namespace YamlDotNet.Core
         }
 
         /// <summary>
-        /// Gets the character at thhe specified offset.
+        /// Gets the character at the specified offset.
         /// </summary>
         public char Peek(int offset)
         {
             if (offset < 0 || offset >= buffer.Length)
             {
-                throw new ArgumentOutOfRangeException("offset", "The offset must be betwwen zero and the capacity of the buffer.");
+                throw new ArgumentOutOfRangeException("offset", "The offset must be between zero and the capacity of the buffer.");
             }
 
             Cache(offset);

--- a/YamlDotNet/Core/Mark.cs
+++ b/YamlDotNet/Core/Mark.cs
@@ -59,15 +59,15 @@ namespace YamlDotNet.Core
         {
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException("index", "Index must be greater than or equal to zero.");
+                throw new ArgumentOutOfRangeException(nameof(index), "Index must be greater than or equal to zero.");
             }
             if (line < 1)
             {
-                throw new ArgumentOutOfRangeException("line", "Line must be greater than or equal to 1.");
+                throw new ArgumentOutOfRangeException(nameof(line), "Line must be greater than or equal to 1.");
             }
             if (column < 1)
             {
-                throw new ArgumentOutOfRangeException("column", "Column must be greater than or equal to 1.");
+                throw new ArgumentOutOfRangeException(nameof(column), "Column must be greater than or equal to 1.");
             }
 
             Index = index;
@@ -118,7 +118,7 @@ namespace YamlDotNet.Core
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj");
+                throw new ArgumentNullException(nameof(obj));
             }
             return CompareTo(obj as Mark);
         }
@@ -128,7 +128,7 @@ namespace YamlDotNet.Core
         {
             if (other == null)
             {
-                throw new ArgumentNullException("other");
+                throw new ArgumentNullException(nameof(other));
             }
 
             var cmp = Line.CompareTo(other.Line);

--- a/YamlDotNet/Core/ParserExtensions.cs
+++ b/YamlDotNet/Core/ParserExtensions.cs
@@ -69,7 +69,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Checks whether the current event is of the specified type.
         /// If the event is of the specified type, returns it and moves to the next event.
-        /// Otherwise retruns null.
+        /// Otherwise returns null.
         /// </summary>
         /// <typeparam name="T">Type of the <see cref="ParsingEvent"/>.</typeparam>
         /// <returns>Returns the current event if it is of type T; otherwise returns null.</returns>

--- a/YamlDotNet/Core/ParserExtensions.cs
+++ b/YamlDotNet/Core/ParserExtensions.cs
@@ -56,7 +56,7 @@ namespace YamlDotNet.Core
         /// <returns>Returns true if the current event is of type <typeparamref name="T"/>. Otherwise returns false.</returns>
         public static bool Accept<T>(this IParser parser) where T : ParsingEvent
         {
-            if(parser.Current == null)
+            if (parser.Current == null)
             {
                 if (!parser.MoveNext())
                 {

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -740,7 +740,7 @@ namespace YamlDotNet.Core
                     break;
 
                 default:
-                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a directive, find uknown directive name.");
+                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a directive, find unknown directive name.");
             }
 
             // Eat the rest of the line including any comments.
@@ -982,7 +982,7 @@ namespace YamlDotNet.Core
 
             if (flowLevel == 0)
             {
-                // Check if we are allowed to start a new key (not nessesary simple).
+                // Check if we are allowed to start a new key (not necessary simple).
 
                 if (!simpleKeyAllowed)
                 {
@@ -1689,7 +1689,7 @@ namespace YamlDotNet.Core
                             {
                                 if (!analyzer.IsHex(k))
                                 {
-                                    throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a quoted scalar, did not find expected hexdecimal number.");
+                                    throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a quoted scalar, did not find expected hexadecimal number.");
                                 }
                                 character = ((character << 4) + analyzer.AsHex(k));
                             }

--- a/YamlDotNet/Core/StringLookAheadBuffer.cs
+++ b/YamlDotNet/Core/StringLookAheadBuffer.cs
@@ -66,7 +66,7 @@ namespace YamlDotNet.Core
         {
             if (length < 0)
             {
-                throw new ArgumentOutOfRangeException("length", "The length must be positive.");
+                throw new ArgumentOutOfRangeException(nameof(length), "The length must be positive.");
             }
             Position += length;
         }

--- a/YamlDotNet/Core/Tokens/TagDirective.cs
+++ b/YamlDotNet/Core/Tokens/TagDirective.cs
@@ -82,19 +82,19 @@ namespace YamlDotNet.Core.Tokens
         {
             if (string.IsNullOrEmpty(handle))
             {
-                throw new ArgumentNullException("handle", "Tag handle must not be empty.");
+                throw new ArgumentNullException(nameof(handle), "Tag handle must not be empty.");
             }
 
             if (!tagHandleValidator.IsMatch(handle))
             {
-                throw new ArgumentException("Tag handle must start and end with '!' and contain alphanumerical characters only.", "handle");
+                throw new ArgumentException("Tag handle must start and end with '!' and contain alphanumerical characters only.", nameof(handle));
             }
 
             this.handle = handle;
 
             if (string.IsNullOrEmpty(prefix))
             {
-                throw new ArgumentNullException("prefix", "Tag prefix must not be empty.");
+                throw new ArgumentNullException(nameof(prefix), "Tag prefix must not be empty.");
             }
 
             this.prefix = prefix;

--- a/YamlDotNet/Core/Version.cs
+++ b/YamlDotNet/Core/Version.cs
@@ -42,8 +42,8 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="Version"/> class.
         /// </summary>
-        /// <param name="major">The the major version number.</param>
-        /// <param name="minor">The the minor version number.</param>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
         public Version(int major, int minor)
         {
             Major = major;

--- a/YamlDotNet/Helpers/ExpressionExtensions.cs
+++ b/YamlDotNet/Helpers/ExpressionExtensions.cs
@@ -20,7 +20,7 @@ namespace YamlDotNet.Helpers
             var property = TryGetMemberExpression<PropertyInfo>(propertyAccessor);
             if (property == null)
             {
-                throw new ArgumentException("Expected a lambda expression in the form: x => x.SomeProperty", "propertyAccessor");
+                throw new ArgumentException("Expected a lambda expression in the form: x => x.SomeProperty", nameof(propertyAccessor));
             }
 
             return property;

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -401,7 +401,7 @@ namespace YamlDotNet.RepresentationModel
         {
             if (mapping == null)
             {
-                throw new ArgumentNullException("mapping");
+                throw new ArgumentNullException(nameof(mapping));
             }
 
             var result = new YamlMappingNode();

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -155,21 +155,7 @@ namespace YamlDotNet.RepresentationModel
         /// <summary>
         /// Gets a value indicating whether two objects are equal.
         /// </summary>
-        protected static bool SafeEquals(object first, object second)
-        {
-            if (first != null)
-            {
-                return first.Equals(second);
-            }
-            else if (second != null)
-            {
-                return second.Equals(first);
-            }
-            else
-            {
-                return true;
-            }
-        }
+        protected static bool SafeEquals(object first, object second) => object.Equals(first, second);
 
         /// <summary>
         /// Serves as a hash function for a particular type.

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -102,7 +102,7 @@ namespace YamlDotNet.RepresentationModel
                 return state.GetNode(alias.Value, false, alias.Start, alias.End) ?? new YamlAliasNode(alias.Value);
             }
 
-            throw new ArgumentException("The current event is of an unsupported type.", "events");
+            throw new ArgumentException("The current event is of an unsupported type.", nameof(parser));
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -109,7 +109,7 @@ namespace YamlDotNet.Serialization
 
 #if !NET20
         /// <summary>
-        /// Register an <see cref="Attribute"/> for for a given property.
+        /// Register an <see cref="Attribute"/> for a given property.
         /// </summary>
         /// <typeparam name="TClass"></typeparam>
         /// <param name="propertyAccessor">An expression in the form: x => x.SomeProperty</param>
@@ -123,7 +123,7 @@ namespace YamlDotNet.Serialization
 #endif
 
         /// <summary>
-        /// Register an <see cref="Attribute"/> for for a given property.
+        /// Register an <see cref="Attribute"/> for a given property.
         /// </summary>
         public TBuilder WithAttributeOverride(Type type, string member, Attribute attribute)
         {

--- a/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -84,7 +84,7 @@ namespace YamlDotNet.Serialization
         {
             if (namingConvention == null)
             {
-                throw new ArgumentNullException("namingConvention");
+                throw new ArgumentNullException(nameof(namingConvention));
             }
 
             this.namingConvention = namingConvention;
@@ -98,7 +98,7 @@ namespace YamlDotNet.Serialization
         {
             if (typeResolver == null)
             {
-                throw new ArgumentNullException("typeResolver");
+                throw new ArgumentNullException(nameof(typeResolver));
             }
 
             this.typeResolver = typeResolver;
@@ -151,12 +151,12 @@ namespace YamlDotNet.Serialization
         {
             if (typeConverter == null)
             {
-                throw new ArgumentNullException("typeConverter");
+                throw new ArgumentNullException(nameof(typeConverter));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(typeConverterFactories.CreateRegistrationLocationSelector(typeConverter.GetType(), _ => typeConverter));
@@ -176,12 +176,12 @@ namespace YamlDotNet.Serialization
         {
             if (typeConverterFactory == null)
             {
-                throw new ArgumentNullException("typeConverterFactory");
+                throw new ArgumentNullException(nameof(typeConverterFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(typeConverterFactories.CreateTrackingRegistrationLocationSelector(typeof(TYamlTypeConverter), (wrapped, _) => typeConverterFactory(wrapped)));
@@ -204,7 +204,7 @@ namespace YamlDotNet.Serialization
         {
             if (converterType == null)
             {
-                throw new ArgumentNullException("converterType");
+                throw new ArgumentNullException(nameof(converterType));
             }
 
             typeConverterFactories.Remove(converterType);
@@ -234,12 +234,12 @@ namespace YamlDotNet.Serialization
         {
             if (typeInspectorFactory == null)
             {
-                throw new ArgumentNullException("typeInspectorFactory");
+                throw new ArgumentNullException(nameof(typeInspectorFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(typeInspectorFactories.CreateRegistrationLocationSelector(typeof(TTypeInspector), inner => typeInspectorFactory(inner)));
@@ -259,12 +259,12 @@ namespace YamlDotNet.Serialization
         {
             if (typeInspectorFactory == null)
             {
-                throw new ArgumentNullException("typeInspectorFactory");
+                throw new ArgumentNullException(nameof(typeInspectorFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(typeInspectorFactories.CreateTrackingRegistrationLocationSelector(typeof(TTypeInspector), (wrapped, inner) => typeInspectorFactory(wrapped, inner)));
@@ -287,7 +287,7 @@ namespace YamlDotNet.Serialization
         {
             if (inspectorType == null)
             {
-                throw new ArgumentNullException("inspectorType");
+                throw new ArgumentNullException(nameof(inspectorType));
             }
 
             typeInspectorFactories.Remove(inspectorType);

--- a/YamlDotNet/Serialization/Deserializer.cs
+++ b/YamlDotNet/Serialization/Deserializer.cs
@@ -49,7 +49,7 @@ namespace YamlDotNet.Serialization
         /// Initializes a new instance of <see cref="Deserializer" /> using the default configuration.
         /// </summary>
         /// <remarks>
-        /// To customize the bahavior of the deserializer, use <see cref="DeserializerBuilder" />.
+        /// To customize the behavior of the deserializer, use <see cref="DeserializerBuilder" />.
         /// </remarks>
         public Deserializer()
             : this(new DeserializerBuilder().BuildValueDeserializer())
@@ -72,7 +72,7 @@ namespace YamlDotNet.Serialization
 
         /// <summary>
         /// Creates a new <see cref="Deserializer" /> that uses the specified <see cref="IValueDeserializer" />.
-        /// This method is available for advanced scenarios. The preferred way to customize the bahavior of the
+        /// This method is available for advanced scenarios. The preferred way to customize the behavior of the
         /// deserializer is to use <see cref="DeserializerBuilder" />.
         /// </summary>
         public static Deserializer FromValueDeserializer(IValueDeserializer valueDeserializer)

--- a/YamlDotNet/Serialization/Deserializer.cs
+++ b/YamlDotNet/Serialization/Deserializer.cs
@@ -64,7 +64,7 @@ namespace YamlDotNet.Serialization
         {
             if (valueDeserializer == null)
             {
-                throw new ArgumentNullException("valueDeserializer");
+                throw new ArgumentNullException(nameof(valueDeserializer));
             }
 
             this.valueDeserializer = valueDeserializer;
@@ -131,12 +131,12 @@ namespace YamlDotNet.Serialization
         {
             if (parser == null)
             {
-                throw new ArgumentNullException("reader");
+                throw new ArgumentNullException(nameof(parser));
             }
 
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             var hasStreamStart = parser.Allow<StreamStart>() != null;

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -341,7 +341,7 @@ namespace YamlDotNet.Serialization
 
         /// <summary>
         /// Creates a new <see cref="IValueDeserializer" /> that implements the current configuration.
-        /// This method is available for advanced scenarios. The preferred way to customize the bahavior of the
+        /// This method is available for advanced scenarios. The preferred way to customize the behavior of the
         /// deserializer is to use the <see cref="Build" /> method.
         /// </summary>
         public IValueDeserializer BuildValueDeserializer()

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -100,7 +100,7 @@ namespace YamlDotNet.Serialization
         {
             if (objectFactory == null)
             {
-                throw new ArgumentNullException("objectFactory");
+                throw new ArgumentNullException(nameof(objectFactory));
             }
 
             this.objectFactory = objectFactory;
@@ -114,7 +114,7 @@ namespace YamlDotNet.Serialization
         {
             if (objectFactory == null)
             {
-                throw new ArgumentNullException("objectFactory");
+                throw new ArgumentNullException(nameof(objectFactory));
             }
 
             return WithObjectFactory(new LambdaObjectFactory(objectFactory));
@@ -140,12 +140,12 @@ namespace YamlDotNet.Serialization
         {
             if (nodeDeserializer == null)
             {
-                throw new ArgumentNullException("nodeDeserializer");
+                throw new ArgumentNullException(nameof(nodeDeserializer));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(nodeDeserializerFactories.CreateRegistrationLocationSelector(nodeDeserializer.GetType(), _ => nodeDeserializer));
@@ -165,12 +165,12 @@ namespace YamlDotNet.Serialization
         {
             if (nodeDeserializerFactory == null)
             {
-                throw new ArgumentNullException("nodeDeserializerFactory");
+                throw new ArgumentNullException(nameof(nodeDeserializerFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(nodeDeserializerFactories.CreateTrackingRegistrationLocationSelector(typeof(TNodeDeserializer), (wrapped, _) => nodeDeserializerFactory(wrapped)));
@@ -193,7 +193,7 @@ namespace YamlDotNet.Serialization
         {
             if (nodeDeserializerType == null)
             {
-                throw new ArgumentNullException("nodeDeserializerType");
+                throw new ArgumentNullException(nameof(nodeDeserializerType));
             }
 
             nodeDeserializerFactories.Remove(nodeDeserializerType);
@@ -220,12 +220,12 @@ namespace YamlDotNet.Serialization
         {
             if (nodeTypeResolver == null)
             {
-                throw new ArgumentNullException("nodeTypeResolver");
+                throw new ArgumentNullException(nameof(nodeTypeResolver));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(nodeTypeResolverFactories.CreateRegistrationLocationSelector(nodeTypeResolver.GetType(), _ => nodeTypeResolver));
@@ -245,12 +245,12 @@ namespace YamlDotNet.Serialization
         {
             if (nodeTypeResolverFactory == null)
             {
-                throw new ArgumentNullException("nodeTypeResolverFactory");
+                throw new ArgumentNullException(nameof(nodeTypeResolverFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(nodeTypeResolverFactories.CreateTrackingRegistrationLocationSelector(typeof(TNodeTypeResolver), (wrapped, _) => nodeTypeResolverFactory(wrapped)));
@@ -273,7 +273,7 @@ namespace YamlDotNet.Serialization
         {
             if (nodeTypeResolverType == null)
             {
-                throw new ArgumentNullException("nodeTypeResolverType");
+                throw new ArgumentNullException(nameof(nodeTypeResolverType));
             }
 
             nodeTypeResolverFactories.Remove(nodeTypeResolverType);
@@ -287,18 +287,18 @@ namespace YamlDotNet.Serialization
         {
             if (tag == null)
             {
-                throw new ArgumentNullException("tag");
+                throw new ArgumentNullException(nameof(tag));
             }
 
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             Type alreadyRegisteredType;
             if (tagMappings.TryGetValue(tag, out alreadyRegisteredType))
             {
-                throw new ArgumentException(string.Format("Type already has a registered type '{0}' for tag '{1}'", alreadyRegisteredType.FullName, tag), "tag");
+                throw new ArgumentException(string.Format("Type already has a registered type '{0}' for tag '{1}'", alreadyRegisteredType.FullName, tag), nameof(tag));
             }
 
             tagMappings.Add(tag, type);
@@ -312,7 +312,7 @@ namespace YamlDotNet.Serialization
         {
             if (tag == null)
             {
-                throw new ArgumentNullException("tag");
+                throw new ArgumentNullException(nameof(tag));
             }
 
             if (!tagMappings.Remove(tag))

--- a/YamlDotNet/Serialization/EmissionPhaseObjectGraphVisitorArgs.cs
+++ b/YamlDotNet/Serialization/EmissionPhaseObjectGraphVisitorArgs.cs
@@ -57,35 +57,35 @@ namespace YamlDotNet.Serialization
         {
             if (innerVisitor == null)
             {
-                throw new ArgumentNullException("innerVisitor");
+                throw new ArgumentNullException(nameof(innerVisitor));
             }
 
             InnerVisitor = innerVisitor;
 
             if (eventEmitter == null)
             {
-                throw new ArgumentNullException("eventEmitter");
+                throw new ArgumentNullException(nameof(eventEmitter));
             }
 
             EventEmitter = eventEmitter;
 
             if (preProcessingPhaseVisitors == null)
             {
-                throw new ArgumentNullException("preProcessingPhaseVisitors");
+                throw new ArgumentNullException(nameof(preProcessingPhaseVisitors));
             }
 
             this.preProcessingPhaseVisitors = preProcessingPhaseVisitors;
 
             if (typeConverters == null)
             {
-                throw new ArgumentNullException("typeConverters");
+                throw new ArgumentNullException(nameof(typeConverters));
             }
 
             TypeConverters = typeConverters;
 
             if (nestedObjectSerializer == null)
             {
-                throw new ArgumentNullException("nestedObjectSerializer");
+                throw new ArgumentNullException(nameof(nestedObjectSerializer));
             }
 
             NestedObjectSerializer = nestedObjectSerializer;

--- a/YamlDotNet/Serialization/EmissionPhaseObjectGraphVisitorArgs.cs
+++ b/YamlDotNet/Serialization/EmissionPhaseObjectGraphVisitorArgs.cs
@@ -92,7 +92,7 @@ namespace YamlDotNet.Serialization
         }
 
         /// <summary>
-        /// Gets the visitor of type <typeparamref name="T" /> that was used during the pre-processig phase.
+        /// Gets the visitor of type <typeparamref name="T" /> that was used during the pre-processing phase.
         /// </summary>
         /// <typeparam name="T">The type of the visitor.s</typeparam>
         /// <returns></returns>

--- a/YamlDotNet/Serialization/EventEmitters/ChainedEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/ChainedEventEmitter.cs
@@ -36,7 +36,7 @@ namespace YamlDotNet.Serialization.EventEmitters
         {
             if (nextEmitter == null)
             {
-                throw new ArgumentNullException("nextEmitter");
+                throw new ArgumentNullException(nameof(nextEmitter));
             }
 
             this.nextEmitter = nextEmitter;

--- a/YamlDotNet/Serialization/LazyComponentRegistrationList.cs
+++ b/YamlDotNet/Serialization/LazyComponentRegistrationList.cs
@@ -73,7 +73,7 @@ namespace YamlDotNet.Serialization
         {
             for (int i = 0; i < entries.Count; ++i)
             {
-                if(entries[i].ComponentType == componentType)
+                if (entries[i].ComponentType == componentType)
                 {
                     entries.RemoveAt(i);
                     return;

--- a/YamlDotNet/Serialization/NodeDeserializers/TypeConverterNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/TypeConverterNodeDeserializer.cs
@@ -34,7 +34,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
         {
             if (converters == null)
             {
-                throw new ArgumentNullException("converters");
+                throw new ArgumentNullException(nameof(converters));
             }
 
             this.converters = converters;

--- a/YamlDotNet/Serialization/NodeTypeResolvers/TagNodeTypeResolver.cs
+++ b/YamlDotNet/Serialization/NodeTypeResolvers/TagNodeTypeResolver.cs
@@ -33,7 +33,7 @@ namespace YamlDotNet.Serialization.NodeTypeResolvers
         {
             if (tagMappings == null)
             {
-                throw new ArgumentNullException("tagMappings");
+                throw new ArgumentNullException(nameof(tagMappings));
             }
 
             this.tagMappings = tagMappings;

--- a/YamlDotNet/Serialization/ObjectDescriptor.cs
+++ b/YamlDotNet/Serialization/ObjectDescriptor.cs
@@ -42,14 +42,14 @@ namespace YamlDotNet.Serialization
 
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             Type = type;
 
             if (staticType == null)
             {
-                throw new ArgumentNullException("staticType");
+                throw new ArgumentNullException(nameof(staticType));
             }
 
             StaticType = staticType;

--- a/YamlDotNet/Serialization/ObjectFactories/LambdaObjectFactory.cs
+++ b/YamlDotNet/Serialization/ObjectFactories/LambdaObjectFactory.cs
@@ -34,7 +34,7 @@ namespace YamlDotNet.Serialization.ObjectFactories
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             _factory = factory;

--- a/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -46,19 +46,19 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
         {
             if (maxRecursion <= 0)
             {
-                throw new ArgumentOutOfRangeException("maxRecursion", maxRecursion, "maxRecursion must be greater than 1");
+                throw new ArgumentOutOfRangeException(nameof(maxRecursion), maxRecursion, "maxRecursion must be greater than 1");
             }
 
             if (typeDescriptor == null)
             {
-                throw new ArgumentNullException("typeDescriptor");
+                throw new ArgumentNullException(nameof(typeDescriptor));
             }
 
             this.typeDescriptor = typeDescriptor;
 
             if (typeResolver == null)
             {
-                throw new ArgumentNullException("typeResolver");
+                throw new ArgumentNullException(nameof(typeResolver));
             }
 
             this.typeResolver = typeResolver;

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigner.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/AnchorAssigner.cs
@@ -87,7 +87,7 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
 
         private void VisitObject(IObjectDescriptor value)
         {
-            if(value.Value != null)
+            if (value.Value != null)
             {
                 assignments.Add(value.Value, new AnchorAssignment());
             }

--- a/YamlDotNet/Serialization/Serializer.cs
+++ b/YamlDotNet/Serialization/Serializer.cs
@@ -65,7 +65,7 @@ namespace YamlDotNet.Serialization
 
         /// <summary>
         /// Creates a new <see cref="Serializer" /> that uses the specified <see cref="IValueSerializer" />.
-        /// This method is available for advanced scenarios. The preferred way to customize the bahavior of the
+        /// This method is available for advanced scenarios. The preferred way to customize the behavior of the
         /// deserializer is to use <see cref="SerializerBuilder" />.
         /// </summary>
         public static Serializer FromValueSerializer(IValueSerializer valueSerializer)

--- a/YamlDotNet/Serialization/Serializer.cs
+++ b/YamlDotNet/Serialization/Serializer.cs
@@ -57,7 +57,7 @@ namespace YamlDotNet.Serialization
         {
             if (valueSerializer == null)
             {
-                throw new ArgumentNullException("valueSerializer");
+                throw new ArgumentNullException(nameof(valueSerializer));
             }
 
             this.valueSerializer = valueSerializer;
@@ -116,7 +116,7 @@ namespace YamlDotNet.Serialization
         {
             if (emitter == null)
             {
-                throw new ArgumentNullException("emitter");
+                throw new ArgumentNullException(nameof(emitter));
             }
 
             EmitDocument(emitter, graph, null);
@@ -132,12 +132,12 @@ namespace YamlDotNet.Serialization
         {
             if (emitter == null)
             {
-                throw new ArgumentNullException("emitter");
+                throw new ArgumentNullException(nameof(emitter));
             }
 
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             EmitDocument(emitter, graph, type);

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -114,12 +114,12 @@ namespace YamlDotNet.Serialization
         {
             if (eventEmitterFactory == null)
             {
-                throw new ArgumentNullException("eventEmitterFactory");
+                throw new ArgumentNullException(nameof(eventEmitterFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(eventEmitterFactories.CreateRegistrationLocationSelector(typeof(TEventEmitter), inner => eventEmitterFactory(inner)));
@@ -139,12 +139,12 @@ namespace YamlDotNet.Serialization
         {
             if (eventEmitterFactory == null)
             {
-                throw new ArgumentNullException("eventEmitterFactory");
+                throw new ArgumentNullException(nameof(eventEmitterFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(eventEmitterFactories.CreateTrackingRegistrationLocationSelector(typeof(TEventEmitter), (wrapped, inner) => eventEmitterFactory(wrapped, inner)));
@@ -167,7 +167,7 @@ namespace YamlDotNet.Serialization
         {
             if (eventEmitterType == null)
             {
-                throw new ArgumentNullException("eventEmitterType");
+                throw new ArgumentNullException(nameof(eventEmitterType));
             }
 
             eventEmitterFactories.Remove(eventEmitterType);
@@ -181,18 +181,18 @@ namespace YamlDotNet.Serialization
         {
             if (tag == null)
             {
-                throw new ArgumentNullException("tag");
+                throw new ArgumentNullException(nameof(tag));
             }
 
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             string alreadyRegisteredTag;
             if (tagMappings.TryGetValue(type, out alreadyRegisteredTag))
             {
-                throw new ArgumentException(string.Format("Type already has a registered tag '{0}' for type '{1}'", alreadyRegisteredTag, type.FullName), "type");
+                throw new ArgumentException(string.Format("Type already has a registered tag '{0}' for type '{1}'", alreadyRegisteredTag, type.FullName), nameof(type));
             }
 
             tagMappings.Add(type, tag);
@@ -206,7 +206,7 @@ namespace YamlDotNet.Serialization
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             if (!tagMappings.Remove(type))
@@ -303,12 +303,12 @@ namespace YamlDotNet.Serialization
         {
             if (objectGraphVisitor == null)
             {
-                throw new ArgumentNullException("objectGraphVisitor");
+                throw new ArgumentNullException(nameof(objectGraphVisitor));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(preProcessingPhaseObjectGraphVisitorFactories.CreateRegistrationLocationSelector(typeof(TObjectGraphVisitor), _ => objectGraphVisitor));
@@ -334,12 +334,12 @@ namespace YamlDotNet.Serialization
         {
             if (objectGraphVisitorFactory == null)
             {
-                throw new ArgumentNullException("objectGraphVisitorFactory");
+                throw new ArgumentNullException(nameof(objectGraphVisitorFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(preProcessingPhaseObjectGraphVisitorFactories.CreateTrackingRegistrationLocationSelector(typeof(TObjectGraphVisitor), (wrapped, _) => objectGraphVisitorFactory(wrapped)));
@@ -362,7 +362,7 @@ namespace YamlDotNet.Serialization
         {
             if (objectGraphVisitorType == null)
             {
-                throw new ArgumentNullException("objectGraphVisitorType");
+                throw new ArgumentNullException(nameof(objectGraphVisitorType));
             }
 
             preProcessingPhaseObjectGraphVisitorFactories.Remove(objectGraphVisitorType);
@@ -406,12 +406,12 @@ namespace YamlDotNet.Serialization
         {
             if (objectGraphVisitorFactory == null)
             {
-                throw new ArgumentNullException("objectGraphVisitorFactory");
+                throw new ArgumentNullException(nameof(objectGraphVisitorFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(emissionPhaseObjectGraphVisitorFactories.CreateRegistrationLocationSelector(typeof(TObjectGraphVisitor), args => objectGraphVisitorFactory(args)));
@@ -432,12 +432,12 @@ namespace YamlDotNet.Serialization
         {
             if (objectGraphVisitorFactory == null)
             {
-                throw new ArgumentNullException("objectGraphVisitorFactory");
+                throw new ArgumentNullException(nameof(objectGraphVisitorFactory));
             }
 
             if (where == null)
             {
-                throw new ArgumentNullException("where");
+                throw new ArgumentNullException(nameof(where));
             }
 
             where(emissionPhaseObjectGraphVisitorFactories.CreateTrackingRegistrationLocationSelector(typeof(TObjectGraphVisitor), (wrapped, args) => objectGraphVisitorFactory(wrapped, args)));
@@ -460,7 +460,7 @@ namespace YamlDotNet.Serialization
         {
             if (objectGraphVisitorType == null)
             {
-                throw new ArgumentNullException("objectGraphVisitorType");
+                throw new ArgumentNullException(nameof(objectGraphVisitorType));
             }
 
             emissionPhaseObjectGraphVisitorFactories.Remove(objectGraphVisitorType);

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -477,7 +477,7 @@ namespace YamlDotNet.Serialization
 
         /// <summary>
         /// Creates a new <see cref="IValueDeserializer" /> that implements the current configuration.
-        /// This method is available for advanced scenarios. The preferred way to customize the bahavior of the
+        /// This method is available for advanced scenarios. The preferred way to customize the behavior of the
         /// deserializer is to use the <see cref="Build" /> method.
         /// </summary>
         public IValueSerializer BuildValueSerializer()

--- a/YamlDotNet/Serialization/TypeInspectors/CachedTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/CachedTypeInspector.cs
@@ -37,7 +37,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
         {
             if (innerTypeDescriptor == null)
             {
-                throw new ArgumentNullException("innerTypeDescriptor");
+                throw new ArgumentNullException(nameof(innerTypeDescriptor));
             }
 
             this.innerTypeDescriptor = innerTypeDescriptor;

--- a/YamlDotNet/Serialization/TypeInspectors/NamingConventionTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/NamingConventionTypeInspector.cs
@@ -38,14 +38,14 @@ namespace YamlDotNet.Serialization.TypeInspectors
         {
             if (innerTypeDescriptor == null)
             {
-                throw new ArgumentNullException("innerTypeDescriptor");
+                throw new ArgumentNullException(nameof(innerTypeDescriptor));
             }
 
             this.innerTypeDescriptor = innerTypeDescriptor;
 
             if (namingConvention == null)
             {
-                throw new ArgumentNullException("namingConvention");
+                throw new ArgumentNullException(nameof(namingConvention));
             }
 
             this.namingConvention = namingConvention;

--- a/YamlDotNet/Serialization/TypeInspectors/ReadableFieldsTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadableFieldsTypeInspector.cs
@@ -36,7 +36,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
         public ReadableFieldsTypeInspector(ITypeResolver typeResolver)
         {
-            this.typeResolver = typeResolver ?? throw new ArgumentNullException("typeResolver");
+            this.typeResolver = typeResolver ?? throw new ArgumentNullException(nameof(typeResolver));
         }
 
         public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -38,7 +38,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
         {
             if (typeResolver == null)
             {
-                throw new ArgumentNullException("typeResolver");
+                throw new ArgumentNullException(nameof(typeResolver));
             }
 
             _typeResolver = typeResolver;

--- a/YamlDotNet/Serialization/Utilities/SerializerState.cs
+++ b/YamlDotNet/Serialization/Utilities/SerializerState.cs
@@ -27,7 +27,7 @@ namespace YamlDotNet.Serialization.Utilities
 {
     /// <summary>
     /// A generic container that is preserved during the entire deserialization process.
-    /// Any disposable object added to this collecion will be disposed when this object is disposed.
+    /// Any disposable object added to this collection will be disposed when this object is disposed.
     /// </summary>
     public sealed class SerializerState : IDisposable
     {

--- a/YamlDotNet/Serialization/Utilities/TypeConverter.cs
+++ b/YamlDotNet/Serialization/Utilities/TypeConverter.cs
@@ -40,7 +40,7 @@ namespace YamlDotNet.Serialization.Utilities
         /// <summary>
         /// Registers a <see cref="System.ComponentModel.TypeConverter"/> dynamically.
         /// </summary>
-        /// <typeparam name="TConvertible">The type to which the coverter should be associated.</typeparam>
+        /// <typeparam name="TConvertible">The type to which the converter should be associated.</typeparam>
         /// <typeparam name="TConverter">The type of the converter.</typeparam>
         [System.Security.Permissions.PermissionSet(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
         public static void RegisterTypeConverter<TConvertible, TConverter>()

--- a/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
@@ -35,7 +35,7 @@ namespace YamlDotNet.Serialization.ValueDeserializers
         {
             if (innerDeserializer == null)
             {
-                throw new ArgumentNullException("innerDeserializer");
+                throw new ArgumentNullException(nameof(innerDeserializer));
             }
 
             this.innerDeserializer = innerDeserializer;

--- a/YamlDotNet/Serialization/ValueDeserializers/NodeValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/NodeValueDeserializer.cs
@@ -37,14 +37,14 @@ namespace YamlDotNet.Serialization.ValueDeserializers
         {
             if (deserializers == null)
             {
-                throw new ArgumentNullException("deserializers");
+                throw new ArgumentNullException(nameof(deserializers));
             }
 
             this.deserializers = deserializers;
 
             if (typeResolvers == null)
             {
-                throw new ArgumentNullException("typeResolvers");
+                throw new ArgumentNullException(nameof(typeResolvers));
             }
             this.typeResolvers = typeResolvers;
         }

--- a/build.cake
+++ b/build.cake
@@ -81,7 +81,7 @@ Task("Set-Build-Version")
 
         System.IO.File.WriteAllText("YamlDotNet/Properties/AssemblyInfo.cs", assemblyInfo);
 
-        if(AppVeyor.IsRunningOnAppVeyor)
+        if (AppVeyor.IsRunningOnAppVeyor)
         {
             if (!string.IsNullOrEmpty(version.PreReleaseTag))
             {
@@ -289,7 +289,7 @@ void BuildSolution(string solutionPath, string configuration, Verbosity verbosit
     {
         if (System.IO.File.Exists(appVeyorLogger)) settings.WithLogger(appVeyorLogger);
 
-        if(IsRunningOnUnix())
+        if (IsRunningOnUnix())
         {
             settings.ToolPath = "/usr/bin/msbuild";
         }


### PR DESCRIPTION
Corrects a number of typos. Use nameof operator instead of string literals. In two places, the literals did not match the names of the input parameters.