### PR TITLE
Improve YAML spec conformance by three tests

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTests.cs
+++ b/YamlDotNet.Test/Spec/SpecTests.cs
@@ -38,19 +38,19 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly string specFixtureDirectory = GetTestFixtureDirectory();
 
-        // Note: all of these (43) tests are failing the assertion on line 65
+        // Note: all of these (40) tests are failing the assertion on line 65
         private static readonly List<string> ignoredSuites = new List<string>
         {
-            "DK3J", "6M2F", "NJ66", "4MUZ", "NHX8", "WZ62", "RTP8", "W5VH", "27NA", "UDM2",
+            "DK3J", "6M2F", "NJ66", "4MUZ", "NHX8", "WZ62", "RTP8", "W5VH", "UDM2", "M7A3",
             "8XYN", "4ABK", "KZN9", "Q5MG", "Y2GN", "2JQS", "S3PD", "R4YG", "9SA2", "UT92",
             "HWV9", "6ZKB", "9MMW", "6BCT", "W4TN", "S4JQ", "K3WX", "8MK2", "52DL", "2SXE",
-            "FP8R", "9DXL", "FRK4", "2LFX", "7Z25", "3UYS", "QT73", "A2M4", "6LVF", "DBG4",
-            "M7A3", "BEC7", "5MUD"
+            "FP8R", "9DXL", "FRK4", "2LFX", "7Z25", "QT73", "A2M4", "6LVF", "DBG4", "5MUD"
         };
 
         [Theory, MemberData(nameof(GetYamlSpecDataSuites))]
         public void ConformsWithYamlSpec(string name, string description, string inputFile, string expectedEventFile, bool error)
         {
+            var expectedResult = File.ReadAllText(expectedEventFile);
             using (var writer = new StringWriter())
             {
                 try
@@ -62,13 +62,13 @@ namespace YamlDotNet.Test.Spec
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(error, "Unexpected spec failure. Writer: " + writer + ", Exception: " + ex);
+                    Assert.True(error, "Unexpected spec failure.\nExpected:\n" + expectedResult + "\nActual:\n[Writer Output]\n" + writer + "\n[Exception]\n" + ex);
                     return;
                 }
 
                 try
                 {
-                    Assert.Equal(File.ReadAllText(expectedEventFile), writer.ToString(), ignoreLineEndingDifferences: true);
+                    Assert.Equal(expectedResult, writer.ToString(), ignoreLineEndingDifferences: true);
                 }
                 catch (EqualException)
                 {

--- a/YamlDotNet/Core/Constants.cs
+++ b/YamlDotNet/Core/Constants.cs
@@ -19,7 +19,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-using System;
 using YamlDotNet.Core.Tokens;
 
 namespace YamlDotNet.Core
@@ -36,7 +35,7 @@ namespace YamlDotNet.Core
         };
 
         public const int MajorVersion = 1;
-        public const int MinorVersion = 1;
+        public const int MinorVersion = 3;
 
         public const char HandleCharacter = '!';
         public const string DefaultHandle = "!";

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -691,10 +691,11 @@ namespace YamlDotNet.Core
                 {
                     AnalyzeVersionDirective(documentStart.Version);
 
+                    var documentVersion = documentStart.Version.Version;
                     isImplicit = false;
                     WriteIndicator("%YAML", true, false, false);
                     WriteIndicator(string.Format(CultureInfo.InvariantCulture,
-                        "{0}.{1}", Constants.MajorVersion, Constants.MinorVersion),
+                        "{0}.{1}", documentVersion.Major, documentVersion.Minor),
                         true, false, false);
                     WriteIndent();
                 }
@@ -780,7 +781,7 @@ namespace YamlDotNet.Core
         // ReSharper disable UnusedParameter.Local
         private void AnalyzeVersionDirective(VersionDirective versionDirective)
         {
-            if (versionDirective.Version.Major != Constants.MajorVersion || versionDirective.Version.Minor != Constants.MinorVersion)
+            if (versionDirective.Version.Major != Constants.MajorVersion || versionDirective.Version.Minor > Constants.MinorVersion)
             {
                 throw new YamlException("Incompatible %YAML directive");
             }

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -318,7 +318,7 @@ namespace YamlDotNet.Core
                         throw new SemanticErrorException(currentVersion.Start, currentVersion.End, "Found duplicate %YAML directive.");
                     }
 
-                    if (currentVersion.Version.Major != Constants.MajorVersion || currentVersion.Version.Minor != Constants.MinorVersion)
+                    if (currentVersion.Version.Major != Constants.MajorVersion || currentVersion.Version.Minor > Constants.MinorVersion)
                     {
                         throw new SemanticErrorException(currentVersion.Start, currentVersion.End, "Found incompatible YAML document.");
                     }
@@ -472,7 +472,7 @@ namespace YamlDotNet.Core
                 }
                 else
                 {
-                    throw new SemanticErrorException(tag.Start, tag.End, "While parsing a node, find undefined tag handle.");
+                    throw new SemanticErrorException(tag.Start, tag.End, "While parsing a node, found undefined tag handle.");
                 }
             }
             if (string.IsNullOrEmpty(tagName))

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -53,6 +53,7 @@ namespace YamlDotNet.Core
             { '"', '"' },
             { '\'', '\'' },
             { '\\', '\\' },
+            { '/', '/' },
             { 'N', '\x85' },
             { '_', '\xA0' },
             { 'L', '\x2028' },
@@ -485,7 +486,7 @@ namespace YamlDotNet.Core
             Skip();
             var end = cursor.Mark();
 
-            throw new SyntaxErrorException(start, end, "While scanning for the next token, find character that cannot start any token.");
+            throw new SyntaxErrorException(start, end, "While scanning for the next token, found character that cannot start any token.");
         }
 
         private bool CheckWhiteSpace()
@@ -740,7 +741,7 @@ namespace YamlDotNet.Core
                     break;
 
                 default:
-                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a directive, find unknown directive name.");
+                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a directive, found unknown directive name.");
             }
 
             // Eat the rest of the line including any comments.
@@ -1351,7 +1352,7 @@ namespace YamlDotNet.Core
 
                     if (analyzer.Check('0'))
                     {
-                        throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a block scalar, find an indentation indicator equal to 0.");
+                        throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a block scalar, found an indentation indicator equal to 0.");
                     }
 
                     // Get the indentation level and eat the indicator.
@@ -1368,7 +1369,7 @@ namespace YamlDotNet.Core
             {
                 if (analyzer.Check('0'))
                 {
-                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a block scalar, find an indentation indicator equal to 0.");
+                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a block scalar, found an indentation indicator equal to 0.");
                 }
 
                 increment = analyzer.AsDigit();
@@ -1526,7 +1527,7 @@ namespace YamlDotNet.Core
 
                 if ((currentIndent == 0 || cursor.LineOffset < currentIndent) && analyzer.IsTab())
                 {
-                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a block scalar, find a tab character where an indentation space is expected.");
+                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a block scalar, found a tab character where an found space is expected.");
                 }
 
                 // Have we find a non-empty line?
@@ -1596,14 +1597,14 @@ namespace YamlDotNet.Core
 
                 if (IsDocumentIndicator())
                 {
-                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a quoted scalar, find unexpected document indicator.");
+                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a quoted scalar, found unexpected document indicator.");
                 }
 
                 // Check for EOF.
 
                 if (analyzer.IsZero())
                 {
-                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a quoted scalar, find unexpected end of stream.");
+                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a quoted scalar, found unexpected end of stream.");
                 }
 
                 // Consume non-blank characters.
@@ -1669,7 +1670,7 @@ namespace YamlDotNet.Core
                                 }
                                 else
                                 {
-                                    throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a quoted scalar, find unknown escape character.");
+                                    throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a quoted scalar, found unknown escape character.");
                                 }
                                 break;
                         }
@@ -1698,7 +1699,7 @@ namespace YamlDotNet.Core
 
                             if ((character >= 0xD800 && character <= 0xDFFF) || character > 0x10FFFF)
                             {
-                                throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a quoted scalar, find invalid Unicode character escape code.");
+                                throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a quoted scalar, found invalid Unicode character escape code.");
                             }
 
                             value.Append(char.ConvertFromUtf32(character));
@@ -1858,7 +1859,7 @@ namespace YamlDotNet.Core
 
                     if (flowLevel > 0 && analyzer.Check(':') && !analyzer.IsWhiteBreakOrZero(1))
                     {
-                        throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a plain scalar, find unexpected ':'.");
+                        throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a plain scalar, found unexpected ':'.");
                     }
 
                     // Check for indicators that may end a plain scalar.
@@ -1929,7 +1930,7 @@ namespace YamlDotNet.Core
 
                         if (hasLeadingBlanks && cursor.LineOffset < currentIndent && analyzer.IsTab())
                         {
-                            throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a plain scalar, find a tab character that violate indentation.");
+                            throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a plain scalar, found a tab character that violate indentation.");
                         }
 
                         // Consume a space or a tab character.
@@ -2032,7 +2033,7 @@ namespace YamlDotNet.Core
 
             if (!analyzer.IsWhiteBreakOrZero())
             {
-                throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a directive, find unexpected non-alphabetical character.");
+                throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a directive, found unexpected non-alphabetical character.");
             }
 
             return name.ToString();
@@ -2202,7 +2203,7 @@ namespace YamlDotNet.Core
 
                     if (width == 0)
                     {
-                        throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a tag, find an incorrect leading UTF-8 octet.");
+                        throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a tag, found an incorrect leading UTF-8 octet.");
                     }
 
                     charBytes = new byte[width];
@@ -2213,7 +2214,7 @@ namespace YamlDotNet.Core
 
                     if ((octet & 0xC0) != 0x80)
                     {
-                        throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a tag, find an incorrect trailing UTF-8 octet.");
+                        throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a tag, found an incorrect trailing UTF-8 octet.");
                     }
                 }
 
@@ -2231,7 +2232,7 @@ namespace YamlDotNet.Core
 
             if (result.Length == 0 || result.Length > 2)
             {
-                throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a tag, find an incorrect UTF-8 sequence.");
+                throw new SyntaxErrorException(start, cursor.Mark(), "While parsing a tag, found an incorrect UTF-8 sequence.");
             }
 
             return result;
@@ -2308,7 +2309,7 @@ namespace YamlDotNet.Core
 
                 if (++length > MaxVersionNumberLength)
                 {
-                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a %YAML directive, find extremely long version number.");
+                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a %YAML directive, found extremely long version number.");
                 }
 
                 value = value * 10 + analyzer.AsDigit();


### PR DESCRIPTION
* Relax the verison checks to support 1.1 to 1.3 range.
  * Fix up emitter to use version from `DocumentStart` object instead
    of constant.
* Add YAML 1.2 escape character '/'
  * This was the only difference in escaped sequence between 1.1 and
    1.2: https://yaml.org/spec/1.1/#id872840 and
    https://yaml.org/spec/1.2/spec.html#id2776092
* Improve grammar in SyntaxErrorException: `find` -> `found` to match
  with the counter part `did not find` (used in other cases).
* Improve formatting of failing test error message in SpecTests.
  * <details>
    <summary>Sample failure:</summary>

    ```
    Test Name:	YamlDotNet.Test.Spec.SpecTests.ConformsWithYamlSpec(name: "4ABK", description: "Spec Example 7.17. Flow Mapping Separate Values", inputFile: "C:\\Users\\adeel\\Source\\Repos\\yamldotnet\\YamlD"..., expectedEventFile: "C:\\Users\\adeel\\Source\\Repos\\yamldotnet\\YamlD"..., error: False)
    Test FullName:	YamlDotNet.Test.Spec.SpecTests.ConformsWithYamlSpec (04719e7467f756f24522681db96dacf88dbb3cd7)
    Test Source:	C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet.Test\Spec\SpecTests.cs : line 51
    Test Outcome:	Failed
    Test Duration:	0:00:00.332

    Result StackTrace:	at YamlDotNet.Test.Spec.SpecTests.ConformsWithYamlSpec(String name, String description, String inputFile, String expectedEventFile, Boolean error) in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet.Test\Spec\SpecTests.cs:line 65
    Result Message:
    Unexpected spec failure.
    Expected:
    +STR
    +DOC
    +MAP
    =VAL :unquoted
    =VAL "separate
    =VAL :http://foo.com
    =VAL :
    =VAL :omitted value
    =VAL :
    =VAL :
    =VAL :omitted key
    -MAP
    -DOC
    -STR

    Actual:
    [Writer Output]
    +STR
    +DOC
    +MAP
    =VAL :unquoted
    =VAL "separate

    [Exception]
    YamlDotNet.Core.SyntaxErrorException: (Line: 3, Col: 1, Idx: 27) - (Line: 3, Col: 5, Idx: 31): While scanning a plain scalar, found unexpected ':'.
    at YamlDotNet.Core.Scanner.ScanPlainScalar() in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Scanner.cs:line 1867
    at YamlDotNet.Core.Scanner.FetchPlainScalar() in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Scanner.cs:line 1817
    at YamlDotNet.Core.Scanner.FetchNextToken() in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Scanner.cs:line 480
    at YamlDotNet.Core.Scanner.FetchMoreTokens() in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Scanner.cs:line 213
    at YamlDotNet.Core.Scanner.MoveNextWithoutConsuming() in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Scanner.cs:line 127
    at YamlDotNet.Core.Parser.GetCurrentToken() in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Parser.cs:line 51
    at YamlDotNet.Core.Parser.ParseFlowMappingKey(Boolean isFirst) in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Parser.cs:line 896
    at YamlDotNet.Core.Parser.StateMachine() in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Parser.cs:line 187
    at YamlDotNet.Core.Parser.MoveNext() in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet\Core\Parser.cs:line 115
    at YamlDotNet.Test.Spec.SpecTests.ConvertToLibYamlStyleAnnotatedEventStream(TextReader textReader, TextWriter textWriter) in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet.Test\Spec\SpecTests.cs:line 96
    at YamlDotNet.Test.Spec.SpecTests.ConformsWithYamlSpec(String name, String description, String inputFile, String expectedEventFile, Boolean error) in C:\Users\adeel\Source\Repos\yamldotnet\YamlDotNet.Test\Spec\SpecTests.cs:line 60
    Expected: True
    Actual:   False
    ```
    </details>

Fixes specs:

* [UDM2](https://github.com/yaml/yaml-test-suite/tree/data/UDM2) (Plain URL in flow mapping)
* [3UYS](https://github.com/yaml/yaml-test-suite/tree/data/3UYS) (Escaped slash in double quotes)
* [5MUD](https://github.com/yaml/yaml-test-suite/tree/data/5MUD) (Colon and adjacent value on next line)

Contributes to: #398