### PR TITLE
Allow scalar to have value without space (x:y)

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTests.cs
+++ b/YamlDotNet.Test/Spec/SpecTests.cs
@@ -38,13 +38,13 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly string specFixtureDirectory = GetTestFixtureDirectory();
 
-        // Note: all of these (40) tests are failing the assertion on line 65
+        // Note: all of these (36) tests are failing the assertion on line 65
         private static readonly List<string> ignoredSuites = new List<string>
         {
-            "DK3J", "6M2F", "NJ66", "4MUZ", "NHX8", "WZ62", "RTP8", "W5VH", "UDM2", "M7A3",
+            "DK3J", "6M2F", "NJ66", "4MUZ", "NHX8", "WZ62", "W5VH", "M7A3", "6LVF", "DBG4",
             "8XYN", "4ABK", "KZN9", "Q5MG", "Y2GN", "2JQS", "S3PD", "R4YG", "9SA2", "UT92",
-            "HWV9", "6ZKB", "9MMW", "6BCT", "W4TN", "S4JQ", "K3WX", "8MK2", "52DL", "2SXE",
-            "FP8R", "9DXL", "FRK4", "2LFX", "7Z25", "QT73", "A2M4", "6LVF", "DBG4", "5MUD"
+            "HWV9", "9MMW", "6BCT", "W4TN", "S4JQ", "K3WX", "8MK2", "52DL", "2SXE", "5MUD",
+            "FP8R", "FRK4", "2LFX", "7Z25", "QT73", "A2M4"
         };
 
         [Theory, MemberData(nameof(GetYamlSpecDataSuites))]

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -1855,16 +1855,9 @@ namespace YamlDotNet.Core
                 // Consume non-blank characters.
                 while (!analyzer.IsWhiteBreakOrZero())
                 {
-                    // Check for 'x:x' in the flow context. TODO: Fix the test "spec-08-13".
-
-                    if (flowLevel > 0 && analyzer.Check(':') && !analyzer.IsWhiteBreakOrZero(1))
-                    {
-                        throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a plain scalar, found unexpected ':'.");
-                    }
-
                     // Check for indicators that may end a plain scalar.
 
-                    if ((analyzer.Check(':') && analyzer.IsWhiteBreakOrZero(1)) || (flowLevel > 0 && analyzer.Check(",:?[]{}")))
+                    if (analyzer.Check(':') && (analyzer.IsWhiteBreakOrZero(1) || analyzer.Check(',', 1)) || (flowLevel > 0 && analyzer.Check(",?[]{}")))
                     {
                         break;
                     }


### PR DESCRIPTION
Conforms with following specs:

* [RTP8](https://github.com/yaml/yaml-test-suite/tree/data/RTP8) (Spec Example 9.2. Document Markers)
* [UDM2](https://github.com/yaml/yaml-test-suite/tree/data/UDM2) (Plain URL in flow mapping)
* [9DXL](https://github.com/yaml/yaml-test-suite/tree/data/9DXL) (Spec Example 9.6. Stream [1.3])
* [6ZKB](https://github.com/yaml/yaml-test-suite/tree/data/6ZKB) (Spec Example 9.6. Stream)

Contributes to: #398