### PR TITLE
Relax anchor names allowed characters set

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1,4 +1,4 @@
-//  This file is part of YamlDotNet - A .NET library for YAML.
+﻿//  This file is part of YamlDotNet - A .NET library for YAML.
 //  Copyright (c) Antoine Aubry and contributors
 
 //  Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -1722,6 +1722,36 @@ namespace YamlDotNet.Test.Serialization
             ");
 
             Assert.Equal(expected.NormalizeNewLines(), yaml.NormalizeNewLines().TrimNewLines());
+        }
+
+        [Fact]
+        public void AnchorNameWithTrailingColonReferencedInKeyCanBeDeserialized()
+        {
+            var sut = new Deserializer();
+            var deserialized = sut.Deserialize<GenericTestDictionary<string, string>>(Yaml.ReaderForText(@"
+                a: &::::scaryanchor:::: anchor "" value ""
+                *::::scaryanchor::::: 2
+                myvalue: *::::scaryanchor::::
+            "));
+
+            Assert.Equal(@"anchor "" value """, deserialized["a"]);
+            Assert.Equal("2", deserialized[@"anchor "" value """]);
+            Assert.Equal(@"anchor "" value """, deserialized["myvalue"]);
+        }
+
+        [Fact]
+        public void AnchorWithAllowedCharactersCanBeDeserialized()
+        {
+            var sut = new Deserializer();
+            var deserialized = sut.Deserialize<GenericTestDictionary<string, string>>(Yaml.ReaderForText(@"
+                a: &@nchor<>""@-_123$>>>😁🎉🐻🍔end some value
+                myvalue: my *@nchor<>""@-_123$>>>😁🎉🐻🍔end test
+                interpolated value: *@nchor<>""@-_123$>>>😁🎉🐻🍔end
+            "));
+
+            Assert.Equal("some value", deserialized["a"]);
+            Assert.Equal(@"my *@nchor<>""@-_123$>>>😁🎉🐻🍔end test", deserialized["myvalue"]);
+            Assert.Equal("some value", deserialized["interpolated value"]);
         }
 
         [TypeConverter(typeof(DoublyConvertedTypeConverter))]

--- a/YamlDotNet.Test/Spec/SpecTests.cs
+++ b/YamlDotNet.Test/Spec/SpecTests.cs
@@ -38,13 +38,13 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly string specFixtureDirectory = GetTestFixtureDirectory();
 
-        // Note: all of these (36) tests are failing the assertion on line 65
+        // Note: all of these (32) tests are failing the assertion on line 65
         private static readonly List<string> ignoredSuites = new List<string>
         {
-            "DK3J", "6M2F", "NJ66", "4MUZ", "NHX8", "WZ62", "W5VH", "M7A3", "6LVF", "DBG4",
-            "8XYN", "4ABK", "KZN9", "Q5MG", "Y2GN", "2JQS", "S3PD", "R4YG", "9SA2", "UT92",
-            "HWV9", "9MMW", "6BCT", "W4TN", "S4JQ", "K3WX", "8MK2", "52DL", "2SXE", "5MUD",
-            "FP8R", "FRK4", "2LFX", "7Z25", "QT73", "A2M4"
+            "DK3J", "6M2F", "NJ66", "4MUZ", "NHX8", "WZ62", "M7A3", "6LVF", "DBG4", "7Z25",
+            "2LFX", "4ABK", "KZN9", "Q5MG", "2JQS", "S3PD", "R4YG", "9SA2", "UT92", "QT73",
+            "HWV9", "9MMW", "6BCT", "W4TN", "S4JQ", "K3WX", "8MK2", "52DL", "5MUD", "A2M4",
+            "FP8R", "FRK4"
         };
 
         [Theory, MemberData(nameof(GetYamlSpecDataSuites))]

--- a/YamlDotNet/Core/Events/AnchorAlias.cs
+++ b/YamlDotNet/Core/Events/AnchorAlias.cs
@@ -68,7 +68,7 @@ namespace YamlDotNet.Core.Events
 
             if (!NodeEvent.anchorValidator.IsMatch(value))
             {
-                throw new YamlException(start, end, "Anchor value must contain alphanumerical characters only.");
+                throw new YamlException(start, end, "Anchor value must not contain disallowed characters: []{},");
             }
 
             this.value = value;

--- a/YamlDotNet/Core/Events/NodeEvent.cs
+++ b/YamlDotNet/Core/Events/NodeEvent.cs
@@ -29,7 +29,7 @@ namespace YamlDotNet.Core.Events
     /// </summary>
     public abstract class NodeEvent : ParsingEvent
     {
-        internal static readonly Regex anchorValidator = new Regex(@"^[0-9a-zA-Z_\-]+$", StandardRegexOptions.Compiled);
+        internal static readonly Regex anchorValidator = new Regex(@"^(?![\[\]\{\},]+).*$", StandardRegexOptions.Compiled);
 
         private readonly string anchor;
 
@@ -87,7 +87,7 @@ namespace YamlDotNet.Core.Events
 
                 if (!anchorValidator.IsMatch(anchor))
                 {
-                    throw new ArgumentException("Anchor value must contain alphanumerical characters only.", nameof(anchor));
+                    throw new ArgumentException("Anchor value must not contain disallowed characters: []{},", nameof(anchor));
                 }
             }
 


### PR DESCRIPTION
Except for the disallowed ones (`[`, `]`, `{`, `}`, `,`), all
characters are allowed (including unicode) in anchor name.

This delta fixes the remaining anchor spec tests. Two additional tests
are added to exercise corner case where anchor name has trailing colon
and alias is used in the key, and other with tag name containing emoji
characters.

Conforms with following specs:

* [W5VH](https://github.com/yaml/yaml-test-suite/tree/data/W5VH) (Allowed characters in alias)
* [8XYN](https://github.com/yaml/yaml-test-suite/tree/data/8XYN) (Anchor with unicode character)
* [Y2GN](https://github.com/yaml/yaml-test-suite/tree/data/Y2GN) (Anchor with colon in the middle)
* [2SXE](https://github.com/yaml/yaml-test-suite/tree/data/2SXE) (Anchors With Colon in Name)

Contributes to: #398