### PR TITLE
Handle flow mapping key when scanned as a scalar

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTests.cs
+++ b/YamlDotNet.Test/Spec/SpecTests.cs
@@ -41,9 +41,8 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly List<string> ignoredSuites = new List<string>
         {
-            "DK3J", "W4TN", "NJ66", "4MUZ", "NHX8", "WZ62", "M7A3", "6LVF", "S4JQ", "A2M4",
-            "2LFX", "K3WX", "8MK2", "Q5MG", "2JQS", "S3PD", "R4YG", "9SA2", "UT92", "FP8R",
-            "52DL", "5MUD", "6BCT"
+            "DK3J", "W4TN", "6BCT", "52DL", "NHX8", "WZ62", "M7A3", "6LVF", "S4JQ", "A2M4",
+            "2LFX", "FP8R", "8MK2", "Q5MG", "2JQS", "S3PD", "R4YG"
         };
 
         private static readonly List<string> knownFalsePositives = new List<string>

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -937,6 +937,11 @@ namespace YamlDotNet.Core
                         return ProcessEmptyScalar(GetCurrentToken().Start);
                     }
                 }
+                else if (GetCurrentToken() is Scalar)
+                {
+                    states.Push(ParserState.FlowMappingValue);
+                    return ParseNode(false, false);
+                }
                 else if (!(GetCurrentToken() is FlowMappingEnd))
                 {
                     states.Push(ParserState.FlowMappingEmptyValue);


### PR DESCRIPTION
Conforms with following specs:

* [4MUZ](https://github.com/yaml/yaml-test-suite/tree/data/4MUZ) (Flow mapping colon on line after key)
* [NJ66](https://github.com/yaml/yaml-test-suite/tree/data/NJ66) (Multiline plain flow mapping key)
* [UT92](https://github.com/yaml/yaml-test-suite/tree/data/UT92) (Spec Example 9.4. Explicit Documents)
* [9SA2](https://github.com/yaml/yaml-test-suite/tree/data/9SA2) (Multiline double quoted flow mapping key)
* [K3WX](https://github.com/yaml/yaml-test-suite/tree/data/K3WX) (Colon and adjacent value after comment on next line)
* [5MUD](https://github.com/yaml/yaml-test-suite/tree/data/5MUD) (Colon and adjacent value on next line)

Contributes to: #398