### PR TITLE
Improve the indent detection for block scalar

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTests.cs
+++ b/YamlDotNet.Test/Spec/SpecTests.cs
@@ -41,8 +41,8 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly List<string> ignoredSuites = new List<string>
         {
-            "DK3J", "W4TN", "6BCT", "52DL", "NHX8", "WZ62", "M7A3", "6LVF", "S4JQ", "A2M4",
-            "2LFX", "FP8R", "8MK2", "Q5MG", "2JQS", "S3PD", "R4YG"
+            "R4YG", "W4TN", "6BCT", "52DL", "NHX8", "WZ62", "M7A3", "6LVF", "S4JQ", "A2M4",
+            "2LFX", "S3PD", "8MK2", "Q5MG", "2JQS"
         };
 
         private static readonly List<string> knownFalsePositives = new List<string>

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -1572,7 +1572,7 @@ namespace YamlDotNet.Core
 
             // Determine the indentation level if needed.
 
-            if (currentIndent == 0)
+            if (currentIndent == 0 && (cursor.LineOffset > 0 || indent > -1))
             {
                 currentIndent = Math.Max(maxIndent, Math.Max(indent + 1, 1));
             }


### PR DESCRIPTION
Conforms with following specs:

* [DK3J](https://github.com/yaml/yaml-test-suite/tree/data/DK3J) (Zero indented block scalar with line that looks like a comment)
* [FP8R](https://github.com/yaml/yaml-test-suite/tree/data/FP8R) (Zero indented block scalar)

Contributes to: #398