### PR TITLE
Rev yaml-test-suite submodule to tip of data branch

### DIFF
--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -1887,7 +1887,7 @@ namespace YamlDotNet.Core
                 {
                     // Check for indicators that may end a plain scalar.
 
-                    if (analyzer.Check(':') && !isAliasValue && (analyzer.IsWhiteBreakOrZero(1) || analyzer.Check(',', 1)) || (flowLevel > 0 && analyzer.Check(",?[]{}")))
+                    if (analyzer.Check(':') && !isAliasValue && (analyzer.IsWhiteBreakOrZero(1) || (flowLevel > 0 && analyzer.Check(',', 1))) || (flowLevel > 0 && analyzer.Check(",?[]{}")))
                     {
                         break;
                     }


### PR DESCRIPTION
There are 13 additional spec tests added since the update (308 to 321).
One of the new tests required hardening scalar scanning in block
sequence:

* [S7BG](https://github.com/yaml/yaml-test-suite/tree/data/S7BG) (Colon followed by comma)

Contributes to: #398