### PR TITLE
Skip indentation indicators while scanning tokens

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTests.cs
+++ b/YamlDotNet.Test/Spec/SpecTests.cs
@@ -41,8 +41,8 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly List<string> ignoredSuites = new List<string>
         {
-            "R4YG", "W4TN", "6BCT", "52DL", "NHX8", "WZ62", "M7A3", "6LVF", "S4JQ", "A2M4",
-            "2LFX", "S3PD", "8MK2", "Q5MG", "2JQS"
+            "2LFX", "W4TN", "S3PD", "52DL", "NHX8", "WZ62", "M7A3", "6LVF", "S4JQ", "8MK2",
+            "2JQS"
         };
 
         private static readonly List<string> knownFalsePositives = new List<string>

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -483,6 +483,12 @@ namespace YamlDotNet.Core
                 return;
             }
 
+            if (analyzer.IsWhiteBreakOrZero())
+            {
+                Skip();
+                return;
+            }
+
             // If we don't determine the token type so far, it is an error.
             var start = cursor.Mark();
             Skip();
@@ -1548,13 +1554,6 @@ namespace YamlDotNet.Core
                 if (cursor.LineOffset > maxIndent)
                 {
                     maxIndent = cursor.LineOffset;
-                }
-
-                // Check for a tab character messing the indentation.
-
-                if ((currentIndent == 0 || cursor.LineOffset < currentIndent) && analyzer.IsTab())
-                {
-                    throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a block scalar, found a tab character where an found space is expected.");
                 }
 
                 // Have we find a non-empty line?


### PR DESCRIPTION
Conforms with following specs:

* [R4YG](https://github.com/yaml/yaml-test-suite/tree/data/R4YG) (Spec Example 8.2. Block Indentation Indicator)
* [6BCT](https://github.com/yaml/yaml-test-suite/tree/data/6BCT) (Spec Example 6.3. Separation Spaces)
* [A2M4](https://github.com/yaml/yaml-test-suite/tree/data/A2M4) (Spec Example 6.2. Indentation Indicators)
* [Q5MG](https://github.com/yaml/yaml-test-suite/tree/data/Q5MG) (Tab at beginning of line followed by a flow mapping)

Contributes to: #398