### PR TITLE
Respect DocumentEnd while scanning the block scalar

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTests.cs
+++ b/YamlDotNet.Test/Spec/SpecTests.cs
@@ -41,7 +41,7 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly List<string> ignoredSuites = new List<string>
         {
-            "W4TN"
+            // no spec test is ignored as of https://github.com/yaml/yaml-test-suite/commit/053b73a9c12c0cd76da797fdc2ffbd4bb5264c12
         };
 
         private static readonly List<string> knownFalsePositives = new List<string>


### PR DESCRIPTION
Also extracted `IsDocumentStart` and `IsDocumentEnd` as <del>readonly
properties</del> separate methods.
<sup>(changed from prop to method for alignment with existing code)</sup>

Conforms with following specs:

* [W4TN](https://github.com/yaml/yaml-test-suite/tree/data/W4TN) (Spec Example 9.5. Directives Documents)

Contributes to: #398