### PR TITLE
Fix type conflicts when targeting frameworks without nullability attributes

### DIFF
--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -244,7 +244,7 @@ namespace YamlDotNet
         {
             return ex.InnerException;
         }
-        
+
         public static bool IsInstanceOf(this Type type, object o)
         {
             return o.GetType() == type || o.GetType().GetTypeInfo().IsSubclassOf(type);
@@ -740,23 +740,6 @@ namespace System.Runtime.Versioning
         {
             FrameworkName = frameworkName;
         }
-    }
-}
-#endif
-
-#if !(NETCOREAPP3_0 || NETSTANDARD2_1)
-namespace System.Diagnostics.CodeAnalysis
-{
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    public sealed class NotNullWhenAttribute : Attribute
-    {
-        public NotNullWhenAttribute(bool returnValue) { }
-    }
-
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    public sealed class MaybeNullWhenAttribute : Attribute
-    {
-        public MaybeNullWhenAttribute(bool returnValue) { }
     }
 }
 #endif

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -29,7 +29,11 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp3.0'">
     <NetStandard>true</NetStandard>
   </PropertyGroup>
-  
+
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.1.1" PrivateAssets="all" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>


### PR DESCRIPTION
In its current form, YamlDotNet produces type conflicts with other projects that target frameworks which do not include nullability attributes, but add them in other ways to allow full nullability support in the compiler. The issue typically displays as a warning during compilation that one or the other type was selected.

```
Appearance.cs(255, 14): [CS0436] The type 'NotNullWhenAttribute' in '/[PROJECT]/obj/Debug/netstandard2.0/NuGet/16700ED22EA87F787941E08E0F8DABDD3F92ADDC/Nullable/1.1.1/Nullable/NullableAttributes.cs' conflicts with the imported type 'NotNullWhenAttribute' in 'YamlDotNet, Version=8.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e'. Using the type defined in '[PROJECT]/obj/Debug/netstandard2.0/NuGet/16700ED22EA87F787941E08E0F8DABDD3F92ADDC/Nullable/1.1.1/Nullable/NullableAttributes.cs'.
```

The issue is caused by YamlDotNet declaring the polyfill attributes in Portability.cs as `public`, and not covering all frameworks in the preprocessor directives that guard them.

This pull request removes YamlDotNet's own polyfill attributes, and references a compile-time NuGet packages which defines all nullability attributes and compiles them as internal attributes into targets which require them, preventing any conflicts with other projects. The package used ([Nullable](https://github.com/manuelroemer/Nullable)) is completely transparent to the end user, and does not incur any additional dependencies for consumers.

Fixes #456.