### PR TITLE
Switch to C# classlib GUIDs for all projects in SLN

### DIFF
--- a/YamlDotNet.sln
+++ b/YamlDotNet.sln
@@ -3,39 +3,43 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29123.88
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet", "YamlDotNet\YamlDotNet.csproj", "{ABFC2E37-119B-439D-82B6-49E9680EEA90}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet", "YamlDotNet\YamlDotNet.csproj", "{ABFC2E37-119B-439D-82B6-49E9680EEA90}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.Samples", "YamlDotNet.Samples\YamlDotNet.Samples.csproj", "{689D2A30-C52E-4CF8-8BA1-3178F4EB245A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.Samples", "YamlDotNet.Samples\YamlDotNet.Samples.csproj", "{689D2A30-C52E-4CF8-8BA1-3178F4EB245A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.Test", "YamlDotNet.Test\YamlDotNet.Test.csproj", "{A9F67018-0240-4D16-A4EA-BCB780D0AF05}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.Test", "YamlDotNet.Test\YamlDotNet.Test.csproj", "{A9F67018-0240-4D16-A4EA-BCB780D0AF05}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PerformanceTests", "PerformanceTests", "{9A64B652-30A5-4632-AF4D-716EF29C5250}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.Lib", "PerformanceTests\YamlDotNet.PerformanceTests.Lib\YamlDotNet.PerformanceTests.Lib.csproj", "{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.Lib", "PerformanceTests\YamlDotNet.PerformanceTests.Lib\YamlDotNet.PerformanceTests.Lib.csproj", "{773B71D6-FEE5-4E4D-8717-5C5EF58D6F17}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.v1.2.1", "PerformanceTests\YamlDotNet.PerformanceTests.v1.2.1\YamlDotNet.PerformanceTests.v1.2.1.csproj", "{0FB497EA-A116-406A-AE8C-A24933D8CB21}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v1.2.1", "PerformanceTests\YamlDotNet.PerformanceTests.v1.2.1\YamlDotNet.PerformanceTests.v1.2.1.csproj", "{0FB497EA-A116-406A-AE8C-A24933D8CB21}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.v2.2.0", "PerformanceTests\YamlDotNet.PerformanceTests.v2.2.0\YamlDotNet.PerformanceTests.v2.2.0.csproj", "{C6E0B465-8422-4D6B-85CE-C59724A28E1F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v2.2.0", "PerformanceTests\YamlDotNet.PerformanceTests.v2.2.0\YamlDotNet.PerformanceTests.v2.2.0.csproj", "{C6E0B465-8422-4D6B-85CE-C59724A28E1F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.v2.3.0", "PerformanceTests\YamlDotNet.PerformanceTests.v2.3.0\YamlDotNet.PerformanceTests.v2.3.0.csproj", "{BE49A287-5F47-4E3B-90EB-97B51451934C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v2.3.0", "PerformanceTests\YamlDotNet.PerformanceTests.v2.3.0\YamlDotNet.PerformanceTests.v2.3.0.csproj", "{BE49A287-5F47-4E3B-90EB-97B51451934C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.v3.8.0", "PerformanceTests\YamlDotNet.PerformanceTests.v3.8.0\YamlDotNet.PerformanceTests.v3.8.0.csproj", "{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v3.8.0", "PerformanceTests\YamlDotNet.PerformanceTests.v3.8.0\YamlDotNet.PerformanceTests.v3.8.0.csproj", "{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.v4.0.0", "PerformanceTests\YamlDotNet.PerformanceTests.v4.0.0\YamlDotNet.PerformanceTests.v4.0.0.csproj", "{747DD2E9-2A0A-4D5E-8D97-85AA9AC5A036}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v4.0.0", "PerformanceTests\YamlDotNet.PerformanceTests.v4.0.0\YamlDotNet.PerformanceTests.v4.0.0.csproj", "{747DD2E9-2A0A-4D5E-8D97-85AA9AC5A036}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.v5.2.1", "PerformanceTests\YamlDotNet.PerformanceTests.v5.2.1\YamlDotNet.PerformanceTests.v5.2.1.csproj", "{BDD556C6-A2A3-46C2-B70A-CA86C16BC060}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v5.2.1", "PerformanceTests\YamlDotNet.PerformanceTests.v5.2.1\YamlDotNet.PerformanceTests.v5.2.1.csproj", "{BDD556C6-A2A3-46C2-B70A-CA86C16BC060}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.vlatest", "PerformanceTests\YamlDotNet.PerformanceTests.vlatest\YamlDotNet.PerformanceTests.vlatest.csproj", "{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v8.0.0", "PerformanceTests\YamlDotNet.PerformanceTests.v8.0.0\YamlDotNet.PerformanceTests.v8.0.0.csproj", "{C0363835-93DB-4AF1-9E3C-0689C65D0FD7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.PerformanceTests.Runner", "PerformanceTests\YamlDotNet.PerformanceTests.Runner\YamlDotNet.PerformanceTests.Runner.csproj", "{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.vlatest", "PerformanceTests\YamlDotNet.PerformanceTests.vlatest\YamlDotNet.PerformanceTests.vlatest.csproj", "{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.AotTest", "YamlDotNet.AotTest\YamlDotNet.AotTest.csproj", "{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.Runner", "PerformanceTests\YamlDotNet.PerformanceTests.Runner\YamlDotNet.PerformanceTests.Runner.csproj", "{A5C7D77C-0F08-4647-8376-3719BD6DEBD9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.AotTest", "YamlDotNet.AotTest\YamlDotNet.AotTest.csproj", "{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EB11D2D9-6E3D-45BF-8BCD-A04BCB1F8020}"
 	ProjectSection(SolutionItems) = preProject
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
 		build.cake = build.cake
+		build.ps1 = build.ps1
+		build.sh = build.sh
 		build\common.props = build\common.props
 		CONTRIBUTING.md = CONTRIBUTING.md
 		GitVersion.yml = GitVersion.yml
@@ -51,8 +55,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docker", "docker", "{45384A
 		docker\Dockerfile.local = docker\Dockerfile.local
 		docker\Dummy.csproj = docker\Dummy.csproj
 	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.PerformanceTests.v8.0.0", "PerformanceTests\YamlDotNet.PerformanceTests.v8.0.0\YamlDotNet.PerformanceTests.v8.0.0.csproj", "{C0363835-93DB-4AF1-9E3C-0689C65D0FD7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -112,6 +114,8 @@ Global
 		{BDD556C6-A2A3-46C2-B70A-CA86C16BC060}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
 		{BDD556C6-A2A3-46C2-B70A-CA86C16BC060}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BDD556C6-A2A3-46C2-B70A-CA86C16BC060}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0363835-93DB-4AF1-9E3C-0689C65D0FD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0363835-93DB-4AF1-9E3C-0689C65D0FD7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
@@ -128,8 +132,6 @@ Global
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Debug-AOT|Any CPU.Build.0 = Debug|Any CPU
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF989FD9-3A2C-4807-A5D3-A8E755CA6648}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C0363835-93DB-4AF1-9E3C-0689C65D0FD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C0363835-93DB-4AF1-9E3C-0689C65D0FD7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -142,10 +144,10 @@ Global
 		{CE856C44-2FE0-4AFA-99CE-F8A076F1BA11} = {9A64B652-30A5-4632-AF4D-716EF29C5250}
 		{747DD2E9-2A0A-4D5E-8D97-85AA9AC5A036} = {9A64B652-30A5-4632-AF4D-716EF29C5250}
 		{BDD556C6-A2A3-46C2-B70A-CA86C16BC060} = {9A64B652-30A5-4632-AF4D-716EF29C5250}
+		{C0363835-93DB-4AF1-9E3C-0689C65D0FD7} = {9A64B652-30A5-4632-AF4D-716EF29C5250}
 		{91A1F4BC-65C0-42E6-B5FD-320A2D59AF71} = {9A64B652-30A5-4632-AF4D-716EF29C5250}
 		{A5C7D77C-0F08-4647-8376-3719BD6DEBD9} = {9A64B652-30A5-4632-AF4D-716EF29C5250}
 		{45384A6E-A0A1-48DF-8FCC-B04405198048} = {EB11D2D9-6E3D-45BF-8BCD-A04BCB1F8020}
-		{C0363835-93DB-4AF1-9E3C-0689C65D0FD7} = {9A64B652-30A5-4632-AF4D-716EF29C5250}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B388A06A-D288-4E48-B2A1-AE0E06E14EE4}

--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,13 @@ for i in "$@"; do
     shift
 done
 
+# Make sure there is no 9A19103F-16F7-4668-BE54-9A1E7A4F7556 GUID in SLN file
+# see https://github.com/dotnet/project-system/issues/1821 bug report.
+if grep -q "9A19103F-16F7-4668-BE54-9A1E7A4F7552" $SCRIPT_DIR/YamlDotNet.sln > /dev/null 2>&1; then
+  echo "Replace 9A19103F-16F7-4668-BE54-9A1E7A4F7552 with FAE04EC0-301F-11D3-BF4B-00C04F79EFBC in YamlDotNet.sln"
+  exit 1
+fi
+
 # Make sure the tools folder exist.
 if [ ! -d "$TOOLS_DIR" ]; then
   mkdir "$TOOLS_DIR"


### PR DESCRIPTION
Whenever we add/remove/re-add project to sln using VS (as opposed to [`dotnet-sln` commands](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-sln#commands)), VS replaces all existing guids with `9A19103F-16F7-4668-BE54-9A1E7A4F7556`, as happened in https://github.com/aaubry/YamlDotNet/commit/e6c355dabd6e2a36ae8df8f1cab8b8c50dbb1b02.

My VS was having hard time discovering tests, and similar problems as seen in: https://github.com/aaubry/YamlDotNet/pull/405.

Until Microsoft fixes this VS bug https://github.com/dotnet/project-system/issues/1821, we would need to manually undo the automagical replacements of this guid. Also added validation in `build.sh` to fail the build in the CI machine, if it gets accidentally checked in.