### PR TITLE
Fix remaining error cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ YamlDotNet is a YAML library for [netstandard and other .NET runtimes](#the-yaml
 
 YamlDotNet provides low level parsing and emitting of YAML as well as a high level object model similar to XmlDocument. A serialization library is also included that allows to read and write objects from and to YAML streams.
 
-Currently, YamlDotNet supports [version 1.1 of the YAML specification](http://yaml.org/spec/1.1/).
+YamlDotNet's conformance with YAML specifications:
+
+|            YAML Spec                | YDN Parser | YDN Emitter |
+|:-----------------------------------:|:----------:|:-----------:|
+|  [v1.1](http://yaml.org/spec/1.1/)  |     ✓      |      ✓      |
+|  [v1.2](http://yaml.org/spec/1.2/)  |     ✓      |             |
+
 
 ## What is YAML?
 

--- a/YamlDotNet.Test/Spec/SpecTests.cs
+++ b/YamlDotNet.Test/Spec/SpecTests.cs
@@ -51,7 +51,7 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly List<string> knownParserDesyncInErrorCases = new List<string>
         {
-            "BS4K", "H7J7"
+            "5LLU" // remove 5LLU once https://github.com/yaml/yaml-test-suite/pull/61 is released
         };
 
         [Theory, MemberData(nameof(GetYamlSpecDataSuites))]

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -67,6 +67,7 @@ namespace YamlDotNet.Core
         private readonly Cursor cursor;
         private bool streamStartProduced;
         private bool streamEndProduced;
+        private bool plainScalarFollowedByComment;
         private int flowSequenceStartLine;
         private int indent = -1;
         private bool simpleKeyAllowed;
@@ -486,6 +487,15 @@ namespace YamlDotNet.Core
                 {
                     throw new SyntaxErrorException("While scanning a document start, found mapping key starting after '---' indicator.");
                 }
+
+                if (plainScalarFollowedByComment)
+                {
+                    var startMark = cursor.Mark();
+                    tokens.Enqueue(new Error("While scanning plain scalar, found a comment between adjacent scalars.", startMark, startMark));
+                }
+
+                plainScalarFollowedByComment = false;
+
                 FetchPlainScalar();
                 return;
             }
@@ -1685,7 +1695,13 @@ namespace YamlDotNet.Core
             if (isLiteral && indentOfFirstLine > 1 && currentIndent < indentOfFirstLine - 1)
             {
                 // W9L4
-                throw new SemanticErrorException(end, cursor.Mark(), "While scanning a literal block scaler, found extra spaces in fist line.");
+                throw new SemanticErrorException(end, cursor.Mark(), "While scanning a literal block scalar, found extra spaces in first line.");
+            }
+
+            if (!isLiteral && maxIndent > cursor.LineOffset)
+            {
+                // S98Z
+                throw new SemanticErrorException(end, cursor.Mark(), "While scanning a literal block scalar, found more spaces in lines above first content line.");
             }
 
             // Determine the indentation level if needed.
@@ -2020,6 +2036,10 @@ namespace YamlDotNet.Core
 
                 if (analyzer.Check('#'))
                 {
+                    if (indent < 0 && flowLevel == 0)
+                    {
+                        plainScalarFollowedByComment = true;
+                    }
                     break;
                 }
 


### PR DESCRIPTION
Conforms with following specs:

* [BS4K](https://github.com/yaml/yaml-test-suite/tree/data/BS4K) (Comment between plain scalar lines)
* [H7J7](https://github.com/yaml/yaml-test-suite/tree/data/H7J7) (Node anchor not indented)

Also add note in README about the parser conformance to 1.2 spec.

Fixes: #398