### PR TITLE
LowerCaseNamingConvention added

### DIFF
--- a/YamlDotNet.Test/Serialization/NamingConventionTests.cs
+++ b/YamlDotNet.Test/Serialization/NamingConventionTests.cs
@@ -66,6 +66,17 @@ namespace YamlDotNet.Test.Serialization
             ShouldApplyConventionGiven(input, expectedName, UnderscoredNamingConvention.Instance);
         }
 
+        [Theory]
+        [InlineData("test", "test")]
+        [InlineData("thisisatest", "thisIsATest")]
+        [InlineData("thisisatest", "this-is-a-test")]
+        [InlineData("thisisatest", "this_is_a_test")]
+        [InlineData("thisisatest", "ThisIsATest")]
+        public void AppliesLowerCaseConvention(string expectedName, string input)
+        {
+            ShouldApplyConventionGiven(input, expectedName, LowerCaseNamingConvention.Instance);
+        }
+
         private void ShouldApplyConventionGiven(string input, string expectedName, INamingConvention convention)
         {
             convention.Apply(input).Should().Be(expectedName);

--- a/YamlDotNet/Serialization/NamingConventions/LowerCaseNamingConvention.cs
+++ b/YamlDotNet/Serialization/NamingConventions/LowerCaseNamingConvention.cs
@@ -1,0 +1,46 @@
+﻿//  This file is part of YamlDotNet - A .NET library for YAML.
+//  Copyright (c) Antoine Aubry and contributors
+
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//  of the Software, and to permit persons to whom the Software is furnished to do
+//  so, subject to the following conditions:
+
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+using System;
+using YamlDotNet.Serialization.Utilities;
+
+namespace YamlDotNet.Serialization.NamingConventions
+{
+    /// <summary>
+    /// Convert the string with underscores (this_is_a_test) or hyphens (this-is-a-test) to 
+    /// pascal case (ThisIsATest). Pascal case is the same as camel case, except the first letter
+    /// is uppercase.
+    /// </summary>
+    public sealed class LowerCaseNamingConvention : INamingConvention
+    {
+        [Obsolete("Use the Instance static field instead of creating new instances")]
+        public LowerCaseNamingConvention() { }
+
+        public string Apply(string value)
+        {
+            return value.ToCamelCase().ToLower();
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        public static readonly INamingConvention Instance = new LowerCaseNamingConvention();
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+}


### PR DESCRIPTION
For those who prefer lowercase in their YAML regardles of casing on the class properties