### PR TITLE
YamlIgnore attributes are inherited

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -413,6 +413,25 @@ namespace YamlDotNet.Test.Serialization
         }
     }
 
+    public class IgnoreExampleBase
+    {
+        [YamlIgnore]
+        public virtual String IgnoreMe
+        {
+            get { throw new InvalidOperationException("Accessing a [YamlIgnore] property"); }
+            set { throw new InvalidOperationException("Accessing a [YamlIgnore] property"); }
+        }
+    }
+
+    public class IgnoreExampleDerived : IgnoreExampleBase
+    {
+        public override String IgnoreMe
+        {
+            get { throw new InvalidOperationException("Accessing a [YamlIgnore] property"); }
+            set { throw new InvalidOperationException("Accessing a [YamlIgnore] property"); }
+        }
+    }
+
     public class ScalarStyleExample
     {
         public ScalarStyleExample()

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -871,6 +871,19 @@ namespace YamlDotNet.Test.Serialization
         }
 
         [Fact]
+        public void SerializationRespectsYamlIgnoreAttributeOfDerivedClasses()
+        {
+
+            var writer = new StringWriter();
+            var obj = new IgnoreExampleDerived();
+
+            Serializer.Serialize(writer, obj);
+            var serialized = writer.ToString();
+
+            serialized.Should().NotContain("IgnoreMe");
+        }
+
+        [Fact]
         public void SerializationRespectsYamlIgnoreOverride()
         {
 

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -249,6 +249,25 @@ namespace YamlDotNet
         {
             return o.GetType() == type || o.GetType().GetTypeInfo().IsSubclassOf(type);
         }
+
+        public static Attribute[] GetAllCustomAttributes<TAttribute>(this PropertyInfo member)
+        {
+            // IMemberInfo.GetCustomAttributes ignores it's "inherit" parameter for properties,
+            // and the suggested replacement (Attribute.GetCustomAttributes) is not available
+            // on netstandard1.3
+            var result = new List<Attribute>();
+            var type = member.DeclaringType;
+
+            while (type != null)
+            {
+                type.GetPublicProperty(member.Name);
+                result.AddRange(member.GetCustomAttributes(typeof(TAttribute)));
+
+                type = type.BaseType();
+            }
+
+            return result.ToArray();
+        }
     }
 
     internal sealed class CultureInfoAdapter : CultureInfo
@@ -373,6 +392,12 @@ namespace YamlDotNet
         public static bool IsInstanceOf(this Type type, object o)
         {
             return type.IsInstanceOfType(o);
+        }
+
+        public static Attribute[] GetAllCustomAttributes<TAttribute>(this PropertyInfo property)
+        {
+            // Don't use IMemberInfo.GetCustomAttributes, it ignores the inherit parameter
+            return Attribute.GetCustomAttributes(property, typeof(TAttribute));
         }
     }
 

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -79,7 +79,8 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
             public T GetCustomAttribute<T>() where T : Attribute
             {
-                var attributes = propertyInfo.GetCustomAttributes(typeof(T), true);
+                // Don't use IMemberInfo.GetCustomAttributes, it ignores the inherit parameter
+                var attributes = Attribute.GetCustomAttributes(propertyInfo, typeof(T));
                 return (T)attributes.FirstOrDefault();
             }
 

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -79,8 +79,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
             public T GetCustomAttribute<T>() where T : Attribute
             {
-                // Don't use IMemberInfo.GetCustomAttributes, it ignores the inherit parameter
-                var attributes = Attribute.GetCustomAttributes(propertyInfo, typeof(T));
+                var attributes = propertyInfo.GetAllCustomAttributes<T>();
                 return (T)attributes.FirstOrDefault();
             }
 


### PR DESCRIPTION
The source of this bug is the fact that IMemberInfo.GetCustomAttributes actually ignores its "inherit" parameter.

https://docs.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.getcustomattributes

This addresses #271 