### PR TITLE
Add support for private properties.

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -539,4 +539,32 @@ namespace YamlDotNet.Test.Serialization
         [YamlIgnore]
         public string fourthTest { get; set; }
     }
+
+    public class NonPublicPropertiesExample
+    {
+        public string Public { get; set; } = "public";
+
+        internal string Internal { get; set; } = "internal";
+
+        protected string Protected { get; set; } = "protected";
+
+        private string Private { get; set; } = "private";
+
+        /// <inheritdoc />
+        public override string ToString() => $"{Public},{Internal},{Protected},{Private}";
+    }
+
+    public class NonPublicFieldsExample
+    {
+        public string Public = "public";
+
+        internal string Internal = "internal";
+
+        protected string Protected = "protected";
+
+        private string Private = "private";
+
+        /// <inheritdoc />
+        public override string ToString() => $"{Public},{Internal},{Protected},{Private}";
+    }
 }

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1764,6 +1764,80 @@ namespace YamlDotNet.Test.Serialization
             Assert.Equal("some value", deserialized["interpolated value"]);
         }
 
+        [Fact]
+        public void SerializationNonPublicPropertiesAreIgnored()
+        {
+            var sut = new SerializerBuilder().Build();
+            var yaml = sut.Serialize(new NonPublicPropertiesExample());
+            Assert.Equal("Public: public", yaml.TrimNewLines());
+        }
+
+        [Fact]
+        public void SerializationNonPublicPropertiesAreIncluded()
+        {
+            var sut = new SerializerBuilder().IncludeNonPublicProperties().Build();
+            var yaml = sut.Serialize(new NonPublicPropertiesExample());
+
+            var expected = Yaml.Text(@"
+                Public: public
+                Internal: internal
+                Protected: protected
+                Private: private
+            ");
+
+            Assert.Equal(expected.NormalizeNewLines(), yaml.NormalizeNewLines().TrimNewLines());
+        }
+
+        [Fact]
+        public void DeserializationNonPublicPropertiesAreIgnored()
+        {
+            var sut = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
+            var deserialized = sut.Deserialize<NonPublicPropertiesExample>(Yaml.ReaderForText(@"
+                Public: public2
+                Internal: internal2
+                Protected: protected2
+                Private: private2
+            "));
+
+            Assert.Equal("public2,internal,protected,private", deserialized.ToString());
+        }
+
+                [Fact]
+        public void DeserializationNonPublicPropertiesAreIncluded()
+        {
+            var sut = new DeserializerBuilder().IncludeNonPublicProperties().Build();
+            var deserialized = sut.Deserialize<NonPublicPropertiesExample>(Yaml.ReaderForText(@"
+                Public: public2
+                Internal: internal2
+                Protected: protected2
+                Private: private2
+            "));
+
+            Assert.Equal("public2,internal2,protected2,private2", deserialized.ToString());
+        }
+
+        [Fact]
+        public void SerializationNonPublicFieldsAreIgnored()
+        {
+            var sut = new SerializerBuilder().Build();
+            var yaml = sut.Serialize(new NonPublicFieldsExample());
+            Assert.Equal("Public: public", yaml.TrimNewLines());
+        }
+
+        [Fact]
+        public void DeserializationNonPublicFieldsAreIgnored()
+        {
+            var sut = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
+            var deserialized = sut.Deserialize<NonPublicFieldsExample>(Yaml.ReaderForText(@"
+                Public: public2
+                Internal: internal2
+                Protected: protected2
+                Private: private2
+            "));
+
+            Assert.Equal("public2,internal,protected,private", deserialized.ToString());
+        }
+
         [TypeConverter(typeof(DoublyConvertedTypeConverter))]
         public class DoublyConverted
         {

--- a/YamlDotNet/Helpers/Portability.cs
+++ b/YamlDotNet/Helpers/Portability.cs
@@ -182,15 +182,22 @@ namespace YamlDotNet
             return type.GetRuntimeProperty(name);
         }
 
+        public static IEnumerable<PropertyInfo> GetProperties(this Type type, bool includeNonPublic)
+        {
+            var instancePublic
+                = new Func<PropertyInfo, bool>(
+                                               p => !p.GetMethod.IsStatic
+                                                    && (p.GetMethod.IsPublic || includeNonPublic));
+            return type.IsInterface()
+                       ? (new Type[] { type })
+                         .Concat(type.GetInterfaces())
+                         .SelectMany(i => i.GetRuntimeProperties().Where(instancePublic))
+                       : type.GetRuntimeProperties().Where(instancePublic);
+        }
+
         public static IEnumerable<PropertyInfo> GetPublicProperties(this Type type)
         {
-            var instancePublic = new Func<PropertyInfo, bool>(
-                p => !p.GetMethod.IsStatic && p.GetMethod.IsPublic);
-            return type.IsInterface()
-                ? (new Type[] { type })
-                    .Concat(type.GetInterfaces())
-                    .SelectMany(i => i.GetRuntimeProperties().Where(instancePublic))
-                : type.GetRuntimeProperties().Where(instancePublic);
+            return GetProperties(type, false);
         }
 
         public static IEnumerable<FieldInfo> GetPublicFields(this Type type)
@@ -225,7 +232,7 @@ namespace YamlDotNet
                 .FirstOrDefault(m => m.IsPublic && !m.IsStatic && m.Name.Equals(name));
         }
 
-        public static MethodInfo GetGetMethod(this PropertyInfo property)
+        public static MethodInfo GetGetMethod(this PropertyInfo property, bool _)
         {
             return property.GetMethod;
         }
@@ -324,12 +331,23 @@ namespace YamlDotNet
 
         public static IEnumerable<PropertyInfo> GetPublicProperties(this Type type)
         {
-            var instancePublic = BindingFlags.Instance | BindingFlags.Public;
+            return GetProperties(type, false);
+        }
+
+        public static IEnumerable<PropertyInfo> GetProperties(this Type type, bool includeNonPublic)
+        {
+            var bindingFlags = BindingFlags.Instance | BindingFlags.Public;
+
+            if (includeNonPublic)
+            {
+                bindingFlags |= BindingFlags.NonPublic;
+            }
+
             return type.IsInterface
                 ? (new Type[] { type })
                     .Concat(type.GetInterfaces())
-                    .SelectMany(i => i.GetProperties(instancePublic))
-                : type.GetProperties(instancePublic);
+                    .SelectMany(i => i.GetProperties(bindingFlags))
+                : type.GetProperties(bindingFlags);
         }
 
         public static IEnumerable<FieldInfo> GetPublicFields(this Type type)

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -412,7 +412,7 @@ namespace YamlDotNet.RepresentationModel
             foreach (var property in mapping.GetType().GetPublicProperties())
             {
                 // CanRead == true => GetGetMethod() != null
-                if (property.CanRead && property.GetGetMethod()!.GetParameters().Length == 0)
+                if (property.CanRead && property.GetGetMethod(false)!.GetParameters().Length == 0)
                 {
                     var value = property.GetValue(mapping, null);
                     if (!(value is YamlNode valueNode))

--- a/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -40,6 +40,7 @@ namespace YamlDotNet.Serialization
         internal readonly LazyComponentRegistrationList<Nothing, IYamlTypeConverter> typeConverterFactories;
         internal readonly LazyComponentRegistrationList<ITypeInspector, ITypeInspector> typeInspectorFactories;
         private bool ignoreFields;
+        private bool includeNonPublicProperties = false;
 
         internal BuilderSkeleton(ITypeResolver typeResolver)
         {
@@ -59,7 +60,7 @@ namespace YamlDotNet.Serialization
 
         internal ITypeInspector BuildTypeInspector()
         {
-            ITypeInspector innerInspector = new ReadablePropertiesTypeInspector(typeResolver);
+            ITypeInspector innerInspector = new ReadablePropertiesTypeInspector(typeResolver, includeNonPublicProperties);
             if (!ignoreFields)
             {
                 innerInspector = new CompositeTypeInspector(
@@ -78,6 +79,15 @@ namespace YamlDotNet.Serialization
         public TBuilder IgnoreFields()
         {
             ignoreFields = true;
+            return Self;
+        }
+
+        /// <summary>
+        /// Allows serialization and deserialization of non-public properties.
+        /// </summary>
+        public TBuilder IncludeNonPublicProperties()
+        {
+            includeNonPublicProperties = true;
             return Self;
         }
 

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -33,22 +33,29 @@ namespace YamlDotNet.Serialization.TypeInspectors
     public sealed class ReadablePropertiesTypeInspector : TypeInspectorSkeleton
     {
         private readonly ITypeResolver typeResolver;
+        private readonly bool includeNonPublicProperties;
 
         public ReadablePropertiesTypeInspector(ITypeResolver typeResolver)
+            :this(typeResolver, false)
+        {
+        }
+
+        public ReadablePropertiesTypeInspector(ITypeResolver typeResolver, bool includeNonPublicProperties)
         {
             this.typeResolver = typeResolver ?? throw new ArgumentNullException(nameof(typeResolver));
+            this.includeNonPublicProperties = includeNonPublicProperties;
         }
 
         private static bool IsValidProperty(PropertyInfo property)
         {
             return property.CanRead
-                && property.GetGetMethod()!.GetParameters().Length == 0;
+                && property.GetGetMethod(true)!.GetParameters().Length == 0;
         }
 
         public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container)
         {
             return type
-                .GetPublicProperties()
+                .GetProperties(includeNonPublicProperties)
                 .Where(IsValidProperty)
                 .Select(p => (IPropertyDescriptor)new ReflectionPropertyDescriptor(p, typeResolver));
         }


### PR DESCRIPTION
Motivation: It can be necessary to serialize and deserialize `internal` (or more private) properties in order to restore object state. It is desirable to restrict access to these properties to encapsulate functionality.

Extend the `ReadablePropertiesTypeInspector` to handle non-public properties.

While it is possible for the user to provide custom type inspectors, it's not easy for these to surface additional properties. An alternative approach to the work here would be to make `ReflectionPropertyDescriptor` protected and unseal `ReadablePropertiesTypeInspector`. The  BuilderSkeleton` would also need to allow the root `ITypeInspector`(s) to be customized.

This approach surfaces the non-public properties while leaving any more complex filtering (such as only serializing them if they have an extra attribute) to downstream type inspectors.