### PR TITLE
Allow values after DocumentStart token

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ YamlDotNet's conformance with YAML specifications:
 
 |            YAML Spec                | YDN Parser | YDN Emitter |
 |:-----------------------------------:|:----------:|:-----------:|
-|  [v1.1](http://yaml.org/spec/1.1/)  |     ✓      |      ✓      |
-|  [v1.2](http://yaml.org/spec/1.2/)  |     ✓      |             |
+|  [v1.1](https://yaml.org/spec/1.1/)  |     ✓      |      ✓      |
+|  [v1.2](https://yaml.org/spec/1.2/spec.html)  |     ✓      |             |
 
 
 ## What is YAML?

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1266,6 +1266,33 @@ namespace YamlDotNet.Test.Serialization
             Assert.Equal(3, exception.Start.Column);
         }
 
+        [Theory]
+        [InlineData("blah")]
+        [InlineData("hello=world")]
+        [InlineData("+190:20:30")]
+        [InlineData("x:y")]
+        public void ValueAllowedAfterDocumentStartToken(string text)
+        {
+            var value = Lines("--- " + text);
+
+            var sut = new Deserializer();
+            var actual = sut.Deserialize<string>(UsingReaderFor(value));
+
+            Assert.Equal(text, actual);
+        }
+
+        [Fact]
+        public void MappingDisallowedAfterDocumentStartToken()
+        {
+            var value = Lines("--- x: y");
+
+            var sut = new Deserializer();
+            var exception = Assert.Throws<SemanticErrorException>(() => sut.Deserialize<string>(UsingReaderFor(value)));
+
+            Assert.Equal(1, exception.Start.Line);
+            Assert.Equal(6, exception.Start.Column);
+        }
+
         [Fact]
         public void SerializeDynamicPropertyAndApplyNamingConvention()
         {

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -483,11 +483,6 @@ namespace YamlDotNet.Core
 
             if (isPlainScalar)
             {
-                if (simpleKeyAllowed && previous is DocumentStart documentStart && documentStart.Start.Line == cursor.Line)
-                {
-                    throw new SyntaxErrorException("While scanning a document start, found mapping key starting after '---' indicator.");
-                }
-
                 if (plainScalarFollowedByComment)
                 {
                     var startMark = cursor.Mark();
@@ -2048,11 +2043,6 @@ namespace YamlDotNet.Core
                 // Consume non-blank characters.
                 while (!analyzer.IsWhiteBreakOrZero())
                 {
-                    if (onDocumentStartLine && analyzer.Check(':'))
-                    {
-                        throw new SyntaxErrorException(start, start, "While scanning a document start, found mapping key starting after '---' indicator.");
-                    }
-
                     // Check for indicators that may end a plain scalar.
 
                     if (analyzer.Check(':') && !isAliasValue && (analyzer.IsWhiteBreakOrZero(1) || (flowLevel > 0 && analyzer.Check(',', 1))) || (flowLevel > 0 && analyzer.Check(",?[]{}")))


### PR DESCRIPTION
Mappings are not allowed after document start token, however, values are allowed. The error case checks were little too strict in that area. Removed the checks and added positive and negative tests to that effect.

Also fixed the spec URL in the README. Asymmetry is known: https://github.com/yaml/yaml-test-suite/issues/66.