### PR TITLE
Fix use of `DynamicTypeResolver` during deserialization.

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -539,4 +539,16 @@ namespace YamlDotNet.Test.Serialization
         [YamlIgnore]
         public string fourthTest { get; set; }
     }
+
+    public interface IImmutableExample
+    {
+        string FirstTest { get; }
+        string SecondTest { get; }
+    }
+
+    public class ImmutableInterfaceExample : IImmutableExample
+    {
+        public string FirstTest { get; set; }
+        public string SecondTest { get; set; }
+    }
 }

--- a/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
@@ -51,7 +51,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             while (!parser.TryConsume<MappingEnd>(out var _))
             {
                 var propertyName = parser.Consume<Scalar>();
-                var property = typeDescriptor.GetProperty(expectedType, null, propertyName.Value, ignoreUnmatched);
+                var property = typeDescriptor.GetProperty(expectedType, value, propertyName.Value, ignoreUnmatched);
                 if (property == null)
                 {
                     parser.SkipThisAndNestedEvents();

--- a/YamlDotNet/Serialization/TypeInspectors/ReadableFieldsTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadableFieldsTypeInspector.cs
@@ -41,7 +41,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
         public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container)
         {
-            return type
+            return typeResolver.Resolve(type, container)
                 .GetPublicFields()
                 .Select(p => (IPropertyDescriptor)new ReflectionFieldDescriptor(p, typeResolver));
         }

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -47,7 +47,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
         public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container)
         {
-            return type
+            return typeResolver.Resolve(type, container)
                 .GetPublicProperties()
                 .Where(IsValidProperty)
                 .Select(p => (IPropertyDescriptor)new ReflectionPropertyDescriptor(p, typeResolver));


### PR DESCRIPTION
Previously the type resolver would only be able to return the static
type because the object constructed by the factory was not passed into
the type descriptor.

See the added tests for a couple of use cases.