### PR TITLE
Disallow usage of alias before anchor declaration

### DIFF
--- a/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
@@ -104,8 +104,7 @@ namespace YamlDotNet.Serialization.ValueDeserializers
                 var aliasState = state.Get<AliasState>();
                 if (!aliasState.TryGetValue(alias.Value, out var valuePromise))
                 {
-                    valuePromise = new ValuePromise(alias);
-                    aliasState.Add(alias.Value, valuePromise);
+                    throw new AnchorNotFoundException(alias.Start, alias.End, $"Alias ${alias.Value} cannot precede anchor declaration");
                 }
 
                 return valuePromise.HasValue ? valuePromise.Value : valuePromise;


### PR DESCRIPTION
According to [YAML 1.1 `§8.4`](https://yaml.org/spec/1.1/#id902561) and [YAML 1.2 `§7.1`](https://yaml.org/spec/1.2/spec.html#id2786196):

> It is an error to have an alias node use an anchor that does not previously occur in the document.

Currently we emit `a: test0`  for this YAML:

```yaml
a: *anchor1
b: &anchor1 test0
```

PR aligns it with spec and changes it to throw `AnchorNotFoundException` instead.

Adjusted some tests which were asserting that forward alias usage is allowed.

Also added a test for duplicate anchors case, explicitly asserting what values are expected, per `YAML 1.2 §3.2.2.2`: https://github.com/yaml/yaml-spec/issues/48.