### PR TITLE
Fix indentation check for first content line

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -194,6 +194,18 @@ namespace YamlDotNet.Test.Serialization
         }
 
         [Fact]
+        public void DeserializeWithGapsBetweenKeys()
+        {
+            var yamlReader = new StringReader(@"Text: >
+  Some Text.
+  
+Value: foo");
+            var result = Deserializer.Deserialize(yamlReader);
+
+            result.Should().NotBeNull();
+        }
+
+        [Fact]
         public void SerializeCustomTags()
         {
             var expectedResult = Yaml.StreamFrom("tags.yaml").ReadToEnd().NormalizeNewLines();

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -1693,7 +1693,7 @@ namespace YamlDotNet.Core
                 throw new SemanticErrorException(end, cursor.Mark(), "While scanning a literal block scalar, found extra spaces in first line.");
             }
 
-            if (!isLiteral && maxIndent > cursor.LineOffset)
+            if (!isLiteral && maxIndent > cursor.LineOffset && indentOfFirstLine > -1)
             {
                 // S98Z
                 throw new SemanticErrorException(end, cursor.Mark(), "While scanning a literal block scalar, found more spaces in lines above first content line.");


### PR DESCRIPTION
When the first content line has more spaces than the preceding non-content lines, it is an error (spec test S98Z).

However, this only holds if that first content line belongs to the multi-line scalar. This PR fixes the scanner to identify that case.

Fixes #492.