### PR TITLE
Feature/round trip output (special) strings (i.e. 'null', etc.) as strings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ YamlDotNet/Properties/AssemblyInfo.Generated.cs
 
 /.vs
 /YamlDotNet/Properties/AssemblyInfo.cs
+
+/.idea

--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -346,6 +346,39 @@ namespace YamlDotNet.Test.Core
         }
 
         [Theory]
+        [InlineData("NULL")]
+        [InlineData("Null")]
+        [InlineData("null")]
+        [InlineData("~")]
+        [InlineData("true")]
+        [InlineData("false")]
+        [InlineData("True")]
+        [InlineData("False")]
+        [InlineData("TRUE")]
+        [InlineData("FALSE")]
+        [InlineData("0o77")]
+        [InlineData("0x7A")]
+        [InlineData("+1e10")]
+        [InlineData("1E10")]
+        [InlineData("+.inf")]
+        [InlineData("-.inf")]
+        [InlineData(".inf")]
+        [InlineData(".nan")]
+        [InlineData(".NaN")]
+        [InlineData(".NAN")]
+        [Trait("motive", "issue #387")]
+        public void StringsThatMatchKeywordsAreQuoted(string input)
+        {
+            var events = SequenceWith(
+                Scalar(input).ImplicitPlain
+            );
+
+            var yaml = EmittedTextFrom(StreamedDocumentWith(events));
+            yaml.Should()
+                .Contain(string.Format("- '{0}'", input));
+        }
+
+        [Theory]
         [InlineData("b-carriage-return,b-line-feed\r\nlll", "b-carriage-return,b-line-feed\nlll")]
         [InlineData("b-carriage-return\rlll", "b-carriage-return\nlll")]
         [InlineData("b-line-feed\nlll", "b-line-feed\nlll")]

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -154,6 +154,13 @@ namespace YamlDotNet.Test.Serialization
         }
 
         [Fact]
+        public void DeserializeQuotedStringNullAsString()
+        {
+            var result = Deserializer.Deserialize<string>(UsingReaderFor("'null'"));
+            result.Should().Be("null");
+        }
+
+        [Fact]
         public void RoundtripEnums()
         {
             var flags = EnumExample.One | EnumExample.Two;


### PR DESCRIPTION
Hi, not sure if this meets your requirements for pull requests, so feel free to tell me what I need to improve to do so.

I was having trouble building all the tests / running all the tests so it's possible these don't work on all platforms - for some reason my machine couldn't run tests on many of the platforms (but I was able to run on .NET core platforms and the tests work there).

If you'd like to talk about what I need to do to get my setup working, I'd be happy to do so and do additional work to bring this pull request in line.

This pull request relates to issue #387 and I believe fixes the associated issue.