### PR TITLE
Fix deserialization for Nullable types.

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -138,6 +138,14 @@ namespace YamlDotNet.Test.Serialization
         }
 
         [Fact]
+        public void DeserializeNullableScalarOctalNumber()
+        {
+            var result = Deserializer.Deserialize<int?>(UsingReaderFor("+071_352"));
+
+            result.Should().Be(29418);
+        }
+
+        [Fact]
         public void DeserializeScalarHexNumber()
         {
             var result = Deserializer.Deserialize<int>(UsingReaderFor("-0x_0F_B9"));

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -48,7 +48,8 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             }
             else
             {
-                var typeCode = expectedType.GetTypeCode();
+                var underlyingType = Nullable.GetUnderlyingType(expectedType);
+                var typeCode = underlyingType != null ? underlyingType.GetTypeCode() : expectedType.GetTypeCode();
                 switch (typeCode)
                 {
                     case TypeCode.Boolean:


### PR DESCRIPTION
Octal (and Hex and other format) deserialization assumes that the type is concrete, but it should also work for Nullable types.

#ref https://github.com/kubernetes-client/csharp/issues/500

Thanks!