### PR TITLE
Allow block style in multiline scalars with trailing spaces

### DIFF
--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -208,6 +208,19 @@ namespace YamlDotNet.Test.Core
             yaml.Should().Contain(">");
         }
 
+
+        [Fact]
+        [Trait("motive", "pr #540")]
+        public void AllowBlockStyleInMultilineScalarsWithTrailingSpaces()
+        {
+            var events = SequenceWith(Scalar("hello  \nworld").ImplicitPlain);
+
+            var yaml = EmittedTextFrom(StreamedDocumentWith(events));
+
+            yaml.Should().Contain("\n");
+        }
+
+
         [Fact]
         public void FoldedStyleDoesNotGenerateExtraLineBreaks()
         {

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -319,11 +319,13 @@ namespace YamlDotNet.Core
             var spaceBreak = false;
             var previousSpace = false;
             var previousBreak = false;
+            var lineOfSpaces = false;
 
             var lineBreaks = false;
 
             var specialCharacters = !ValueIsRepresentableInOutputEncoding(value);
             var singleQuotes = false;
+            var linesOfSpaces = false;
 
             var isFirst = true;
             while (!buffer.EndOfInput)
@@ -403,6 +405,7 @@ namespace YamlDotNet.Core
                     if (previousBreak)
                     {
                         breakSpace = true;
+                        lineOfSpaces = true;
                     }
 
                     previousSpace = true;
@@ -425,6 +428,11 @@ namespace YamlDotNet.Core
                         spaceBreak = true;
                     }
 
+                    if (lineOfSpaces)
+                    {
+                        linesOfSpaces = true;
+                    }
+
                     previousSpace = false;
                     previousBreak = true;
                 }
@@ -432,6 +440,7 @@ namespace YamlDotNet.Core
                 {
                     previousSpace = false;
                     previousBreak = false;
+                    lineOfSpaces = false;
                 }
 
                 preceededByWhitespace = buffer.IsWhiteBreakOrZero();
@@ -472,6 +481,9 @@ namespace YamlDotNet.Core
                 scalarData.isFlowPlainAllowed = false;
                 scalarData.isBlockPlainAllowed = false;
                 scalarData.isSingleQuotedAllowed = false;
+            }
+            if (linesOfSpaces)
+            {
                 scalarData.isBlockAllowed = false;
             }
 


### PR DESCRIPTION
We use a DocFX-based documentation system, which stores markdown in YAML. DocFX-Flavoured Markdown has a syntax for adding a `<br>` tag, and [it looks as follows](https://gist.github.com/shaunlebron/746476e6e7a4d698b373):

```markdown
line before br  <!-- notice the two spaces -->
line after br
```

this converts to 

```html
<p>
  line before br
  <br>
  line after br
</p>
```

When we store it in YAML and re-serialize the value, it's being converted from 

```yaml
summary: >-
  line before br  

  line after br
```
to 
```yaml
summary: "line before br  \nline after br"
```

, which is harder to read and edit. 

I see the reason why trailing spaces are disallowed in blocks (they are hard to notice, and single-line notation makes them more explicit), although I suggest you guys to review our case and compare pros and cons.
Thanks!

P.S.: I'll be grateful for the [hacktoberfest-accepted](https://hacktoberfest.digitalocean.com/hacktoberfest-update) label on this PR.