### PR TITLE
Fix writePtr decrementation

### DIFF
--- a/YamlDotNet/Core/InsertionQueue.cs
+++ b/YamlDotNet/Core/InsertionQueue.cs
@@ -198,7 +198,7 @@ namespace YamlDotNet.Core
                 copyIndex = writePtr + 1;
                 copyOffset = -1;
                 copyLength = moveLeftCost;
-                --writePtr;
+                writePtr = (writePtr - 1) & mask;
             }
         }
 


### PR DESCRIPTION
The following yaml:
```yaml
key1: value1
key2: value2
key3:
  key4: value3
  key5:
    - { w: a  , x: a , y: a , z: a }
    - { w: a  , x: a , y: a , z: a }
    - { w: a  , x: a , y: a , z: a }
```
was triggering IndexOutOfRangeException in https://github.com/aaubry/YamlDotNet/blob/48623887ce3da3231d32adac5b92eac9315637cf/YamlDotNet/Core/InsertionQueue.cs#L77 since writePtr was negative as a result of https://github.com/aaubry/YamlDotNet/blob/48623887ce3da3231d32adac5b92eac9315637cf/YamlDotNet/Core/InsertionQueue.cs#L201
Not sure where is the best place to put it in a test.