### PR TITLE
Fix imutable pattern in EmitterSettings.SkipAnchorName

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,14 @@
 # Release notes
 
-## Release 9.1.2
+## Release 9.1.3
 
-- Fix writePtr decrementation in InsertionQueue [#558]
-
-This fixes another critical bug that was causing failures while parsing Yaml documents. If you are using release 9.1.1, please use this version instead.
+- Fix an error when a stream returns less than the requested amount of bytes  
+  Fixes #560
 
 
 # Previous releases
 
+- [9.1.2](releases/9.1.2.md)
 - [9.1.1](releases/9.1.1.md)
 - [9.1.0](releases/9.1.0.md)
 - [8.1.2](releases/8.1.2.md)

--- a/YamlDotNet/Core/EmitterSettings.cs
+++ b/YamlDotNet/Core/EmitterSettings.cs
@@ -89,7 +89,8 @@ namespace YamlDotNet.Core
                 bestIndent,
                 BestWidth,
                 IsCanonical,
-                MaxSimpleKeyLength
+                MaxSimpleKeyLength,
+                SkipAnchorName
             );
         }
 
@@ -99,7 +100,8 @@ namespace YamlDotNet.Core
                 BestIndent,
                 bestWidth,
                 IsCanonical,
-                MaxSimpleKeyLength
+                MaxSimpleKeyLength,
+                SkipAnchorName
             );
         }
 
@@ -109,7 +111,8 @@ namespace YamlDotNet.Core
                 BestIndent,
                 BestWidth,
                 IsCanonical,
-                maxSimpleKeyLength
+                maxSimpleKeyLength,
+                SkipAnchorName
             );
         }
 
@@ -119,14 +122,20 @@ namespace YamlDotNet.Core
                 BestIndent,
                 BestWidth,
                 true,
-                MaxSimpleKeyLength
+                MaxSimpleKeyLength,
+                SkipAnchorName
             );
         }
 
         public EmitterSettings WithoutAnchorName()
         {
-            SkipAnchorName = true;
-            return this;
+            return new EmitterSettings(
+                BestIndent,
+                BestWidth,
+                IsCanonical,
+                MaxSimpleKeyLength,
+                true
+            );
         }
     }
 }


### PR DESCRIPTION
In class `EmitterSettings` the imutable pattern is not implemented consistent. `SkipAnchorName` is not handled correct.

The following test fails (this ist not a big thing):
```csharp
var settings1 = new EmitterSettings();
var settings2 = settings1.WithoutAnchorName();
Assert.IsFalse(settings1.SkipAnchorName);
```
Reason: The method `WithoutAnchorName()` does not create a new instance like all other Methods.


The following test also fails - and this is a trap:
```csharp
var settings = new EmitterSettings().WithoutAnchorName().WithBestIndent();
Assert.IsTrue(settings.SkipAnchorName);
```
Reason: all other Method don't give `SkipAnchorName ` into the ctor.