### PR TITLE
Enable filling get only ICollection property

### DIFF
--- a/YamlDotNet/Serialization/TypeInspectors/ReadableAndWritablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadableAndWritablePropertiesTypeInspector.cs
@@ -39,8 +39,16 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
         public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container)
         {
-            return innerTypeDescriptor.GetProperties(type, container)
-                .Where(p => p.CanWrite);
+            return innerTypeDescriptor
+                .GetProperties(type, container)
+                .Where(p =>
+                    p.CanWrite ||
+                    (p.Type.IsGenericType
+                        && typeof(ICollection<>)
+                            .MakeGenericType(p.Type.GenericTypeArguments[0])
+                            .IsAssignableFrom(p.Type)
+                    )
+                );
         }
     }
 }


### PR DESCRIPTION
A get-only property can not be set but if it is an ICollection and the constructor initialized it we can copy the deserialized items with Add.

This yaml currently can't be deserialized to the class below.

```yaml
contents:
- asd1
- asd2
- asd3
- asd4
```

```csharp
public class Container
{
    public List<string> Contents { get; } = new List<string>();
}
```