### PR TITLE
Add additional indentation for sequences

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1845,7 +1845,7 @@ c: *anchor1");
             Assert.Equal("public2,internal,protected,private", deserialized.ToString());
         }
 
-                [Fact]
+        [Fact]
         public void DeserializationNonPublicPropertiesAreIncluded()
         {
             var sut = new DeserializerBuilder().IncludeNonPublicProperties().Build();
@@ -1879,6 +1879,93 @@ c: *anchor1");
             "));
 
             Assert.Equal("public2,internal,protected,private", deserialized.ToString());
+        }
+
+        [Fact]
+        public void ShouldNotIndentSequences()
+        {
+            var sut = new SerializerBuilder()
+                .Build();
+
+            var yaml = sut.Serialize(new
+            {
+                first = "first",
+                items = new[]
+                {
+                    "item1",
+                    "item2"
+                },
+                nested = new[]
+                {
+                    new
+                    {
+                        name = "name1",
+                        more = new[]
+                        {
+                            "nested1",
+                            "nested2"
+                        }
+                    }
+                }
+            });
+
+            var expected = Yaml.Text(@"
+                first: first
+                items:
+                - item1
+                - item2
+                nested:
+                - name: name1
+                  more:
+                  - nested1
+                  - nested2
+            ");
+
+            Assert.Equal(expected.NormalizeNewLines(), yaml.NormalizeNewLines().TrimNewLines());
+        }
+
+        [Fact]
+        public void ShouldIndentSequences()
+        {
+            var sut = new SerializerBuilder()
+                .WithIndentedSequences()
+                .Build();
+
+            var yaml = sut.Serialize(new
+            {
+                first = "first",
+                items = new[]
+                {
+                    "item1",
+                    "item2"
+                },
+                nested = new[]
+                {
+                    new
+                    {
+                        name = "name1",
+                        more = new[]
+                        {
+                            "nested1",
+                            "nested2"
+                        }
+                    }
+                }
+            });
+
+            var expected = Yaml.Text(@"
+                first: first
+                items:
+                  - item1
+                  - item2
+                nested:
+                  - name: name1
+                    more:
+                      - nested1
+                      - nested2
+            ");
+
+            Assert.Equal(expected.NormalizeNewLines(), yaml.NormalizeNewLines().TrimNewLines());
         }
 
         [TypeConverter(typeof(DoublyConvertedTypeConverter))]

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -62,6 +62,7 @@ namespace YamlDotNet.Core
         private int column;
         private bool isWhitespace;
         private bool isIndentation;
+        private bool forceIndentLess;
 
         private bool isDocumentEndWritten;
 
@@ -142,6 +143,7 @@ namespace YamlDotNet.Core
             this.isCanonical = settings.IsCanonical;
             this.maxSimpleKeyLength = settings.MaxSimpleKeyLength;
             this.skipAnchorName = settings.SkipAnchorName;
+            this.forceIndentLess = !settings.IndentSequences;
 
             this.output = output;
             this.outputUsesUnicodeEncoding = IsUnicode(output.Encoding);
@@ -1636,7 +1638,7 @@ namespace YamlDotNet.Core
             {
                 indent = isFlow ? bestIndent : 0;
             }
-            else if (!isIndentless)
+            else if (!isIndentless || !forceIndentLess)
             {
                 indent += bestIndent;
             }

--- a/YamlDotNet/Core/EmitterSettings.cs
+++ b/YamlDotNet/Core/EmitterSettings.cs
@@ -53,13 +53,18 @@ namespace YamlDotNet.Core
         /// </remarks>
         public int MaxSimpleKeyLength { get; } = 1024;
 
+        /// <summary>
+        /// Indent sequences. The default is to not indent.
+        /// </summary>
+        public bool IndentSequences { get; } = false;
+
         public static readonly EmitterSettings Default = new EmitterSettings();
 
         public EmitterSettings()
         {
         }
 
-        public EmitterSettings(int bestIndent, int bestWidth, bool isCanonical, int maxSimpleKeyLength, bool skipAnchorName = false)
+        public EmitterSettings(int bestIndent, int bestWidth, bool isCanonical, int maxSimpleKeyLength, bool skipAnchorName = false, bool indentSequences = false)
         {
             if (bestIndent < 2 || bestIndent > 9)
             {
@@ -81,6 +86,7 @@ namespace YamlDotNet.Core
             IsCanonical = isCanonical;
             MaxSimpleKeyLength = maxSimpleKeyLength;
             SkipAnchorName = skipAnchorName;
+            IndentSequences = indentSequences;
         }
 
         public EmitterSettings WithBestIndent(int bestIndent)
@@ -127,6 +133,18 @@ namespace YamlDotNet.Core
         {
             SkipAnchorName = true;
             return this;
+        }
+
+        public EmitterSettings WithIndentedSequences()
+        {
+            return new EmitterSettings(
+                BestIndent,
+                BestWidth,
+                IsCanonical,
+                MaxSimpleKeyLength,
+                SkipAnchorName,
+                true
+            );
         }
     }
 }

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -495,6 +495,22 @@ namespace YamlDotNet.Serialization
         }
 
         /// <summary>
+        /// Creates sequences with extra indentation
+        /// </summary>
+        /// <example>
+        ///  list:
+        ///    - item
+        ///    - item
+        /// </example>
+        /// <returns></returns>
+        public SerializerBuilder WithIndentedSequences()
+        {
+            emitterSettings = emitterSettings.WithIndentedSequences();
+
+            return this;
+        }
+
+        /// <summary>
         /// Creates a new <see cref="Serializer" /> according to the current configuration.
         /// </summary>
         public ISerializer Build()


### PR DESCRIPTION
Fixes #15 

This adds the ability specify additional indentation for lists. By default, the emitter emits:

```
list:
- item1
- item2
```

By using this option, the emitter will output:

```
list:
  - item1
  - item2
```

Example code:

```c#
var serializer = new SerializerBuilder()
    .WithIndentedSequences()
    .Build();
```