### PR TITLE
Merge sequence of anchors in reverse order

### DIFF
--- a/YamlDotNet/Core/MergingParser.cs
+++ b/YamlDotNet/Core/MergingParser.cs
@@ -89,7 +89,7 @@ namespace YamlDotNet.Core
 
             if (node.Value is AnchorAlias anchorAlias)
             {
-                return HandleAnchorAlias(node, anchorAlias);
+                return HandleAnchorAlias(node, node, anchorAlias);
             }
 
             if (node.Value is SequenceStart)
@@ -100,23 +100,41 @@ namespace YamlDotNet.Core
             return false;
         }
 
+        private bool HandleMergeSequence(LinkedListNode<ParsingEvent> sequenceStart, LinkedListNode<ParsingEvent>? node)
+        {
+            if (node is null)
+            {
+                return false;
+            }
+            if (node.Value is AnchorAlias anchorAlias)
+            {
+                return HandleAnchorAlias(sequenceStart, node, anchorAlias);
+            }
+            if (node.Value is SequenceStart)
+            {
+                return HandleSequence(node);
+            }
+            return false;
+        }
+
         private bool IsMergeToken(LinkedListNode<ParsingEvent> node)
         {
             return node.Value is Scalar merge && merge.Value == "<<";
         }
 
-        private bool HandleAnchorAlias(LinkedListNode<ParsingEvent> node, AnchorAlias anchorAlias)
+        private bool HandleAnchorAlias(LinkedListNode<ParsingEvent> node, LinkedListNode<ParsingEvent> anchorNode, AnchorAlias anchorAlias)
         {
             var mergedEvents = GetMappingEvents(anchorAlias.Value);
 
             events.AddAfter(node, mergedEvents);
-            events.MarkDeleted(node);
+            events.MarkDeleted(anchorNode);
 
             return true;
         }
 
         private bool HandleSequence(LinkedListNode<ParsingEvent> node)
         {
+            var sequenceStart = node;
             events.MarkDeleted(node);
 
             LinkedListNode<ParsingEvent>? current = node;
@@ -129,7 +147,7 @@ namespace YamlDotNet.Core
                 }
 
                 var next = current.Next;
-                HandleMerge(next);
+                HandleMergeSequence(sequenceStart, next);
                 current = next;
             }
 


### PR DESCRIPTION
The idea is that we are adding anchor value after the sequence start instead after the anchors.

Fixes: #594 

- Remove the comment about the fact that it is not safe to fix it when anchors are defined later and added same test but with definition at the end of the document.

I'm only worried if there are consumers which actually reversed their sequence in order to resolve this bug, so we need to mark this in the release notes.

