### PR TITLE
Create a value promise right after seeing an anchor

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1968,6 +1968,41 @@ c: *anchor1");
             Assert.Equal(expected.NormalizeNewLines(), yaml.NormalizeNewLines().TrimNewLines());
         }
 
+        public class CycleTestEntity
+        {
+            public CycleTestEntity Cycle { get; set; }
+        }
+
+        [Fact]
+        public void SerializeCycleWithAnchors()
+        {
+            var sut = new SerializerBuilder()
+                .WithTagMapping("!CycleTag", typeof(CycleTestEntity))
+                .Build();
+
+            var entity = new CycleTestEntity();
+            entity.Cycle = entity;
+            var yaml = sut.Serialize(entity);
+            var expected = Yaml.Text(@"&o0 !CycleTag
+Cycle: *o0");
+
+            Assert.Equal(expected.NormalizeNewLines(), yaml.NormalizeNewLines().TrimNewLines());
+        }
+
+        [Fact]
+        public void DeserializeCycleWithAnchors()
+        {
+            var sut = new DeserializerBuilder()
+                .WithTagMapping("!CycleTag", typeof(CycleTestEntity))
+                .Build();
+
+            var yaml = Yaml.Text(@"&o0 !CycleTag
+Cycle: *o0");
+            var obj = sut.Deserialize<CycleTestEntity>(yaml);
+
+            Assert.Same(obj, obj.Cycle);
+        }
+
         [TypeConverter(typeof(DoublyConvertedTypeConverter))]
         public class DoublyConverted
         {

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -31,6 +31,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using Xunit;
 using YamlDotNet.Core;
@@ -1974,7 +1975,7 @@ c: *anchor1");
         }
 
         [Fact]
-        public void SerializeCycleWithAnchors()
+        public void SerializeCycleWithAlias()
         {
             var sut = new SerializerBuilder()
                 .WithTagMapping("!CycleTag", typeof(CycleTestEntity))
@@ -1990,7 +1991,7 @@ Cycle: *o0");
         }
 
         [Fact]
-        public void DeserializeCycleWithAnchors()
+        public void DeserializeCycleWithAlias()
         {
             var sut = new DeserializerBuilder()
                 .WithTagMapping("!CycleTag", typeof(CycleTestEntity))
@@ -2001,6 +2002,49 @@ Cycle: *o0");
             var obj = sut.Deserialize<CycleTestEntity>(yaml);
 
             Assert.Same(obj, obj.Cycle);
+        }
+
+        [Fact]
+        public void DeserializeCycleWithoutAlias()
+        {
+            var sut = new DeserializerBuilder()
+                .Build();
+
+            var yaml = Yaml.Text(@"&o0
+Cycle: *o0");
+            var obj = sut.Deserialize<CycleTestEntity>(yaml);
+
+            Assert.Same(obj, obj.Cycle);
+        }
+
+        public static IEnumerable<object[]> Depths => Enumerable.Range(1, 10).Select(i => new[] { (object)i });
+
+        [Theory]
+        [MemberData(nameof(Depths))]
+        public void DeserializeCycleWithAnchorsWithDepth(int? depth)
+        {
+            var sut = new DeserializerBuilder()
+                .WithTagMapping("!CycleTag", typeof(CycleTestEntity))
+                .Build();
+
+            StringBuilder builder = new StringBuilder(@"&o0 !CycleTag");
+            builder.AppendLine();
+            string indentation;
+            for (int i = 0; i < depth - 1; ++i)
+            {
+                indentation = string.Concat(Enumerable.Repeat("  ", i));
+                builder.AppendLine($"{indentation}Cycle: !CycleTag");
+            }
+            indentation = string.Concat(Enumerable.Repeat("  ", depth.Value - 1));
+            builder.AppendLine($"{indentation}Cycle: *o0");
+            var yaml = Yaml.Text(builder.ToString());
+            var obj = sut.Deserialize<CycleTestEntity>(yaml);
+            CycleTestEntity iterator = obj;
+            for (int i = 0; i < depth; ++i)
+            {
+                iterator = iterator.Cycle;
+            }
+            Assert.Same(obj, iterator);
         }
 
         [TypeConverter(typeof(DoublyConvertedTypeConverter))]

--- a/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
@@ -115,7 +115,7 @@ namespace YamlDotNet.Serialization.ValueDeserializers
             {
                 anchor = nodeEvent.Anchor;
                 var aliasState = state.Get<AliasState>();
-                if (!aliasState.ContainsKey(nodeEvent.Anchor))
+                if (!aliasState.ContainsKey(anchor))
                 {
                     aliasState[anchor] = new ValuePromise(new AnchorAlias(anchor));
                 }

--- a/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
@@ -114,6 +114,11 @@ namespace YamlDotNet.Serialization.ValueDeserializers
             if (parser.Accept<NodeEvent>(out var nodeEvent) && !nodeEvent.Anchor.IsEmpty)
             {
                 anchor = nodeEvent.Anchor;
+                var aliasState = state.Get<AliasState>();
+                if (!aliasState.ContainsKey(nodeEvent.Anchor))
+                {
+                    aliasState[anchor] = new ValuePromise(new AnchorAlias(anchor));
+                }
             }
 
             value = innerDeserializer.DeserializeValue(parser, expectedType, state, nestedObjectDeserializer);


### PR DESCRIPTION
This PR is related to #597.

Creating a promise for an alias before deserialization allows the deserializer to handle cycles in object graph.

Currently, if there is a reference to an anchor of a node which is being deserialized, deserializer throws an exception `AnchorNotFoundException`.
