### PR TITLE
Allow omitting empty collections via `DefaultValuesHandling`

### DIFF
--- a/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
+++ b/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
@@ -48,8 +48,6 @@ namespace YamlDotNet.Test.Serialization
             [DefaultValue(2)] public int? ANullableNonZeroNonDefaultInteger => 1;
 
             // Enumerables
-            public IList<int> ANullList => null;
-
             public int[] AnEmptyArray => new int[0];
             public IList<int> AnEmptyList => new List<int>();
             public Dictionary<string, string> AnEmptyDictionary => new Dictionary<string, string>();

--- a/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
+++ b/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
@@ -62,6 +62,34 @@ namespace YamlDotNet.Test.Serialization
         }
 
         [Fact]
+        public void All_default_values_and_nulls_are_emitted_when_no_configuration_is_performed()
+        {
+            // Arrange
+            var sut = new SerializerBuilder()
+                .Build();
+
+            // Act
+            var yaml = sut.Serialize(new Model());
+
+            // Assert
+            Assert.Contains(nameof(Model.ANullString) + ':', yaml);
+            Assert.Contains(nameof(Model.ADefaultString) + ':', yaml);
+            Assert.Contains(nameof(Model.ANonDefaultString) + ':', yaml);
+            Assert.Contains(nameof(Model.ANonDefaultNullString) + ':', yaml);
+
+            Assert.Contains(nameof(Model.AZeroInteger) + ':', yaml);
+            Assert.Contains(nameof(Model.ANonZeroInteger) + ':', yaml);
+            Assert.Contains(nameof(Model.ADefaultInteger) + ':', yaml);
+            Assert.Contains(nameof(Model.ANonDefaultZeroInteger) + ':', yaml);
+
+            Assert.Contains(nameof(Model.ANullInteger) + ':', yaml);
+            Assert.Contains(nameof(Model.ANullableZeroInteger) + ':', yaml);
+            Assert.Contains(nameof(Model.ANullableNonZeroInteger) + ':', yaml);
+            Assert.Contains(nameof(Model.ANullableNonZeroDefaultInteger) + ':', yaml);
+            Assert.Contains(nameof(Model.ANullableNonZeroNonDefaultInteger) + ':', yaml);
+        }
+
+        [Fact]
         public void Only_null_values_are_omitted_when_DefaultValuesHandling_is_OmitNull()
         {
             // Arrange

--- a/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
+++ b/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
@@ -59,45 +59,14 @@ namespace YamlDotNet.Test.Serialization
             public IList<int> AnNonEmptyList => new List<int> { 6, 9, 42 };
             public IEnumerable<bool> ANonEmptyEnumerable => new[] { true, false };
             public Dictionary<string, string> ANonEmptyDictionary => new Dictionary<string, string>() { { "foo", "bar" } };
-
         }
 
         [Fact]
-        public void All_default_values_and_nulls_are_emitted_when_no_configuration_is_performed()
+        public void Only_null_values_are_omitted_when_DefaultValuesHandling_is_OmitNull()
         {
             // Arrange
             var sut = new SerializerBuilder()
-                .Build();
-
-            // Act
-            var yaml = sut.Serialize(new Model());
-
-            // Assert
-            Assert.Contains(nameof(Model.ANullString) + ':', yaml);
-            Assert.Contains(nameof(Model.ADefaultString) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonDefaultString) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonDefaultNullString) + ':', yaml);
-
-            Assert.Contains(nameof(Model.AZeroInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonZeroInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ADefaultInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonDefaultZeroInteger) + ':', yaml);
-
-            Assert.Contains(nameof(Model.ANullInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANullableZeroInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANullableNonZeroInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANullableNonZeroDefaultInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANullableNonZeroNonDefaultInteger) + ':', yaml);
-        }
-
-        [Theory]
-        [InlineData(DefaultValuesHandling.OmitNull)]
-        [InlineData(DefaultValuesHandling.OmitNullOrEmpty)]
-        public void Only_null_values_are_omitted_when_DefaultValuesHandling_is_OmitNull(DefaultValuesHandling defaultValuesHandling)
-        {
-            // Arrange
-            var sut = new SerializerBuilder()
-                .ConfigureDefaultValuesHandling(defaultValuesHandling)
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
                 .Build();
 
             // Act
@@ -121,14 +90,12 @@ namespace YamlDotNet.Test.Serialization
             Assert.Contains(nameof(Model.ANullableNonZeroNonDefaultInteger) + ':', yaml);
         }
 
-        [Theory]
-        [InlineData(DefaultValuesHandling.OmitDefaults)]
-        [InlineData(DefaultValuesHandling.OmitDefaultsOrEmpty)]
-        public void All_default_values_are_omitted_when_DefaultValuesHandling_is_OmitDefaults(DefaultValuesHandling defaultValuesHandling)
+        [Fact]
+        public void All_default_values_are_omitted_when_DefaultValuesHandling_is_OmitAll()
         {
             // Arrange
             var sut = new SerializerBuilder()
-                .ConfigureDefaultValuesHandling(defaultValuesHandling)
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
                 .Build();
 
             // Act
@@ -152,31 +119,22 @@ namespace YamlDotNet.Test.Serialization
             Assert.Contains(nameof(Model.ANullableNonZeroNonDefaultInteger) + ':', yaml);
         }
 
-        [Theory]
-        [InlineData(DefaultValuesHandling.OmitNullOrEmpty)]
-        [InlineData(DefaultValuesHandling.OmitDefaultsOrEmpty)]
-        public void Empty_enumerables_are_omitted_when_DefaultValuesHandling_is_OmitDefaultsOrEmpty(DefaultValuesHandling defaultValuesHandling)
+        [Fact]
+        public void Empty_enumerables_are_omitted_when_DefaultValuesHandling_is_OmitEmpty()
         {
             // Arrange
             var sut = new SerializerBuilder()
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaultsOrEmpty)
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitEmpty)
                 .Build();
 
             // Act
             var yaml = sut.Serialize(new Model());
 
             // Assert enumerables
-            Assert.DoesNotContain(nameof(Model.ANullList) + ':', yaml);
-
             Assert.DoesNotContain(nameof(Model.AnEmptyArray) + ':', yaml);
             Assert.DoesNotContain(nameof(Model.AnEmptyList) + ':', yaml);
             Assert.DoesNotContain(nameof(Model.AnEmptyDictionary) + ':', yaml);
             Assert.DoesNotContain(nameof(Model.AnEmptyEnumerable) + ':', yaml);
-
-            Assert.Contains(nameof(Model.AnNonEmptyArray) + ':', yaml);
-            Assert.Contains(nameof(Model.AnNonEmptyList) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonEmptyEnumerable) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonEmptyDictionary) + ':', yaml);
         }
 
         [Fact]

--- a/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
+++ b/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
@@ -55,8 +55,8 @@ namespace YamlDotNet.Test.Serialization
             public Dictionary<string, string> AnEmptyDictionary => new Dictionary<string, string>();
             public IEnumerable<int> AnEmptyEnumerable => Enumerable.Empty<int>();
 
-            public string[] AnNonEmptyArray => new[] { "foo", "bar" };
-            public IList<int> AnNonEmptyList => new List<int> { 6, 9, 42 };
+            public string[] ANonEmptyArray => new[] { "foo", "bar" };
+            public IList<int> ANonEmptyList => new List<int> { 6, 9, 42 };
             public IEnumerable<bool> ANonEmptyEnumerable => new[] { true, false };
             public Dictionary<string, string> ANonEmptyDictionary => new Dictionary<string, string>() { { "foo", "bar" } };
         }
@@ -163,6 +163,11 @@ namespace YamlDotNet.Test.Serialization
             Assert.DoesNotContain(nameof(Model.AnEmptyList) + ':', yaml);
             Assert.DoesNotContain(nameof(Model.AnEmptyDictionary) + ':', yaml);
             Assert.DoesNotContain(nameof(Model.AnEmptyEnumerable) + ':', yaml);
+
+            Assert.Contains(nameof(Model.ANonEmptyArray) + ':', yaml);
+            Assert.Contains(nameof(Model.ANonEmptyList) + ':', yaml);
+            Assert.Contains(nameof(Model.ANonEmptyDictionary) + ':', yaml);
+            Assert.Contains(nameof(Model.ANonEmptyEnumerable) + ':', yaml);
         }
 
         [Fact]

--- a/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
+++ b/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
@@ -124,7 +124,7 @@ namespace YamlDotNet.Test.Serialization
         {
             // Arrange
             var sut = new SerializerBuilder()
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitEmpty)
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitEmptyCollections)
                 .Build();
 
             // Act

--- a/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
+++ b/YamlDotNet.Test/Serialization/EmitDefaultValuesTests.cs
@@ -90,12 +90,14 @@ namespace YamlDotNet.Test.Serialization
             Assert.Contains(nameof(Model.ANullableNonZeroNonDefaultInteger) + ':', yaml);
         }
 
-        [Fact]
-        public void Only_null_values_are_omitted_when_DefaultValuesHandling_is_OmitNull()
+        [Theory]
+        [InlineData(DefaultValuesHandling.OmitNull)]
+        [InlineData(DefaultValuesHandling.OmitNullOrEmpty)]
+        public void Only_null_values_are_omitted_when_DefaultValuesHandling_is_OmitNull(DefaultValuesHandling defaultValuesHandling)
         {
             // Arrange
             var sut = new SerializerBuilder()
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+                .ConfigureDefaultValuesHandling(defaultValuesHandling)
                 .Build();
 
             // Act
@@ -150,8 +152,10 @@ namespace YamlDotNet.Test.Serialization
             Assert.Contains(nameof(Model.ANullableNonZeroNonDefaultInteger) + ':', yaml);
         }
 
-        [Fact]
-        public void Empty_enumerables_are_omitted_when_DefaultValuesHandling_is_OmitDefaultsOrEmpty()
+        [Theory]
+        [InlineData(DefaultValuesHandling.OmitNullOrEmpty)]
+        [InlineData(DefaultValuesHandling.OmitDefaultsOrEmpty)]
+        public void Empty_enumerables_are_omitted_when_DefaultValuesHandling_is_OmitDefaultsOrEmpty(DefaultValuesHandling defaultValuesHandling)
         {
             // Arrange
             var sut = new SerializerBuilder()
@@ -160,23 +164,6 @@ namespace YamlDotNet.Test.Serialization
 
             // Act
             var yaml = sut.Serialize(new Model());
-
-            // Assert defaults
-            Assert.DoesNotContain(nameof(Model.ANullString) + ':', yaml);
-            Assert.DoesNotContain(nameof(Model.ADefaultString) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonDefaultString) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonDefaultNullString) + ':', yaml);
-
-            Assert.DoesNotContain(nameof(Model.AZeroInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonZeroInteger) + ':', yaml);
-            Assert.DoesNotContain(nameof(Model.ADefaultInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANonDefaultZeroInteger) + ':', yaml);
-
-            Assert.DoesNotContain(nameof(Model.ANullInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANullableZeroInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANullableNonZeroInteger) + ':', yaml);
-            Assert.DoesNotContain(nameof(Model.ANullableNonZeroDefaultInteger) + ':', yaml);
-            Assert.Contains(nameof(Model.ANullableNonZeroNonDefaultInteger) + ':', yaml);
 
             // Assert enumerables
             Assert.DoesNotContain(nameof(Model.ANullList) + ':', yaml);

--- a/YamlDotNet/Serialization/DefaultValuesHandling.cs
+++ b/YamlDotNet/Serialization/DefaultValuesHandling.cs
@@ -19,36 +19,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
+
 namespace YamlDotNet.Serialization
 {
     /// <summary>
     /// Specifies the strategy to handle default and null values during serialization of properties.
     /// </summary>
+    [Flags]
     public enum DefaultValuesHandling
     {
         /// <summary>
         /// Specifies that all properties are to be emitted regardless of their value. This is the default behavior.
         /// </summary>
-        Preserve,
+        Preserve = 0,
 
         /// <summary>
         /// Specifies that properties that contain null references or a null Nullable&lt;T&gt; are to be omitted. 
         /// </summary>
-        OmitNull,
+        OmitNull = 1,
 
         /// <summary>
-        /// More relaxed than OmitNull - omits null values and also collections/arrays/enumerations that are empty.
+        /// Omits collections/arrays/enumerations that are empty.
         /// </summary>
-        OmitNullOrEmpty,
+        OmitEmpty = 2,
 
         /// <summary>
         /// Specifies that properties that that contain their default value, either default(T) or the value specified in DefaultValueAttribute are to be omitted. 
         /// </summary>
-        OmitDefaults,
-
-        /// <summary>
-        /// More relaxed than OmitDefaults - omits default values and also collections/arrays/enumerations that are empty.
-        /// </summary>
-        OmitDefaultsOrEmpty,
+        OmitDefaults = 4,
     }
 }

--- a/YamlDotNet/Serialization/DefaultValuesHandling.cs
+++ b/YamlDotNet/Serialization/DefaultValuesHandling.cs
@@ -35,18 +35,18 @@ namespace YamlDotNet.Serialization
         Preserve = 0,
 
         /// <summary>
-        /// Specifies that properties that contain null references or a null Nullable&lt;T&gt; are to be omitted. 
+        /// Specifies that properties that contain null references or a null Nullable&lt;T&gt; are to be omitted.
         /// </summary>
         OmitNull = 1,
 
         /// <summary>
-        /// Omits collections/arrays/enumerations that are empty.
+        /// Specifies that properties that that contain their default value, either default(T) or the value specified in DefaultValueAttribute are to be omitted.
         /// </summary>
-        OmitEmpty = 2,
+        OmitDefaults = 2,
 
         /// <summary>
-        /// Specifies that properties that that contain their default value, either default(T) or the value specified in DefaultValueAttribute are to be omitted. 
+        /// Specifies that properties that that contain collections/arrays/enumerations that are empty are to be omitted.
         /// </summary>
-        OmitDefaults = 4,
+        OmitEmptyCollections = 4,
     }
 }

--- a/YamlDotNet/Serialization/DefaultValuesHandling.cs
+++ b/YamlDotNet/Serialization/DefaultValuesHandling.cs
@@ -37,6 +37,11 @@ namespace YamlDotNet.Serialization
         OmitNull,
 
         /// <summary>
+        /// More relaxed than OmitNull - omits null values and also collections/arrays/enumerations that are empty.
+        /// </summary>
+        OmitNullOrEmpty,
+
+        /// <summary>
         /// Specifies that properties that that contain their default value, either default(T) or the value specified in DefaultValueAttribute are to be omitted. 
         /// </summary>
         OmitDefaults,

--- a/YamlDotNet/Serialization/DefaultValuesHandling.cs
+++ b/YamlDotNet/Serialization/DefaultValuesHandling.cs
@@ -40,5 +40,10 @@ namespace YamlDotNet.Serialization
         /// Specifies that properties that that contain their default value, either default(T) or the value specified in DefaultValueAttribute are to be omitted. 
         /// </summary>
         OmitDefaults,
+
+        /// <summary>
+        /// More relaxed than OmitDefaults - omits default values and also collections/arrays/enumerations that are empty.
+        /// </summary>
+        OmitDefaultsOrEmpty,
     }
 }

--- a/YamlDotNet/Serialization/NodeTypeResolvers/MappingNodeTypeResolver.cs
+++ b/YamlDotNet/Serialization/NodeTypeResolvers/MappingNodeTypeResolver.cs
@@ -31,10 +31,7 @@ namespace YamlDotNet.Serialization.NodeTypeResolvers
 
         public MappingNodeTypeResolver(IDictionary<Type, Type> mappings)
         {
-            if (mappings == null)
-            {
-                throw new ArgumentNullException(nameof(mappings));
-            }
+            if (mappings == null) throw new ArgumentNullException(nameof(mappings));
 
             foreach (var pair in mappings)
             {

--- a/YamlDotNet/Serialization/NodeTypeResolvers/MappingNodeTypeResolver.cs
+++ b/YamlDotNet/Serialization/NodeTypeResolvers/MappingNodeTypeResolver.cs
@@ -31,7 +31,10 @@ namespace YamlDotNet.Serialization.NodeTypeResolvers
 
         public MappingNodeTypeResolver(IDictionary<Type, Type> mappings)
         {
-            if (mappings == null) throw new ArgumentNullException(nameof(mappings));
+            if (mappings == null)
+            {
+                throw new ArgumentNullException(nameof(mappings));
+            }
 
             foreach (var pair in mappings)
             {

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/DefaultValuesObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/DefaultValuesObjectGraphVisitor.cs
@@ -20,6 +20,7 @@
 // SOFTWARE.
 
 using System;
+using System.Collections;
 using System.ComponentModel;
 using YamlDotNet.Core;
 
@@ -57,6 +58,20 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
                         return false;
                     }
                     break;
+
+                case DefaultValuesHandling.OmitDefaultsOrEmpty:
+                    if (value.Value is null)
+                    {
+                        // Null is default for enumerable so it falls into OmitDefaults
+                        return false;
+                    }
+
+                    if (value.Value is IEnumerable enumerable && !enumerable.GetEnumerator().MoveNext())
+                    {
+                        return false;
+                    }
+
+                    goto case DefaultValuesHandling.OmitDefaults;
 
                 case DefaultValuesHandling.OmitDefaults:
                     var defaultValue = key.GetCustomAttribute<DefaultValueAttribute>()?.Value ?? GetDefault(key.Type);

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/DefaultValuesObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/DefaultValuesObjectGraphVisitor.cs
@@ -58,7 +58,7 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
                 }
             }
 
-            if ((configuration & DefaultValuesHandling.OmitEmpty) != 0)
+            if ((configuration & DefaultValuesHandling.OmitEmptyCollections) != 0)
             {
                 if (value.Value is IEnumerable enumerable)
                 {

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/DefaultValuesObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/DefaultValuesObjectGraphVisitor.cs
@@ -60,12 +60,6 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
                     break;
 
                 case DefaultValuesHandling.OmitDefaultsOrEmpty:
-                    if (value.Value is null)
-                    {
-                        // Null is default for enumerable so it falls into OmitDefaults
-                        return false;
-                    }
-
                     if (value.Value is IEnumerable enumerable && !enumerable.GetEnumerator().MoveNext())
                     {
                         return false;

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/DefaultValuesObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/DefaultValuesObjectGraphVisitor.cs
@@ -59,13 +59,13 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
                     }
                     break;
 
-                case DefaultValuesHandling.OmitDefaultsOrEmpty:
+                case DefaultValuesHandling.OmitNullOrEmpty:
                     if (value.Value is IEnumerable enumerable && !enumerable.GetEnumerator().MoveNext())
                     {
                         return false;
                     }
 
-                    goto case DefaultValuesHandling.OmitDefaults;
+                    goto case DefaultValuesHandling.OmitNull;
 
                 case DefaultValuesHandling.OmitDefaults:
                     var defaultValue = key.GetCustomAttribute<DefaultValueAttribute>()?.Value ?? GetDefault(key.Type);
@@ -74,6 +74,14 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
                         return false;
                     }
                     break;
+
+                case DefaultValuesHandling.OmitDefaultsOrEmpty:
+                    if (value.Value is IEnumerable ienumerable && !ienumerable.GetEnumerator().MoveNext())
+                    {
+                        return false;
+                    }
+
+                    goto case DefaultValuesHandling.OmitDefaults;
             }
 
             return base.EnterMapping(key, value, context);


### PR DESCRIPTION
**Motivation**
Sometimes, you cannot cannot afford to null your enumerables but you don't want them in your YAML.
This default value handling policy allows to prevent serialization of empty arrays/lists/dictionaries into
```yaml
value: []
```

**Change**
Added 2 new options: 
- `DefaultValuesHandling.OmitDefaultsOrEmpty`
- `DefaultValuesHandling.OmitNullOrEmpty`
which turns on omitting of empty collections.
