### PR TITLE
Added the deserialize fix and test for the UTC DateTime

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
@@ -34,6 +35,7 @@ namespace YamlDotNet.Test.Serialization
         {
             var yaml = @"
 name: Jack
+momentOfBirth: 1983-04-21T20:21:03.0041599Z
 cars:
 - name: Mercedes
   year: 2018
@@ -48,6 +50,13 @@ cars:
 
             var person = sut.Deserialize<Person>(yaml);
             person.Name.Should().Be("Jack");
+            person.MomentOfBirth.Kind.Should().Be(DateTimeKind.Utc);
+            person.MomentOfBirth.ToUniversalTime().Year.Should().Be(1983);
+            person.MomentOfBirth.ToUniversalTime().Month.Should().Be(4);
+            person.MomentOfBirth.ToUniversalTime().Day.Should().Be(21);
+            person.MomentOfBirth.ToUniversalTime().Hour.Should().Be(20);
+            person.MomentOfBirth.ToUniversalTime().Minute.Should().Be(21);
+            person.MomentOfBirth.ToUniversalTime().Second.Should().Be(3);
             person.Cars.Should().HaveCount(2);
             person.Cars[0].Name.Should().Be("Mercedes");
             person.Cars[0].Spec.Should().BeNull();
@@ -60,6 +69,7 @@ cars:
         {
             var yaml = @"
 name: Jack
+momentOfBirth: 1983-04-21T20:21:03.0041599Z
 cars:
 - name: Mercedes
   year: 2018
@@ -81,6 +91,13 @@ cars:
 
             var person = sut.Deserialize<Person>(yaml);
             person.Name.Should().Be("Jack");
+            person.MomentOfBirth.Kind.Should().Be(DateTimeKind.Utc);
+            person.MomentOfBirth.ToUniversalTime().Year.Should().Be(1983);
+            person.MomentOfBirth.ToUniversalTime().Month.Should().Be(4);
+            person.MomentOfBirth.ToUniversalTime().Day.Should().Be(21);
+            person.MomentOfBirth.ToUniversalTime().Hour.Should().Be(20);
+            person.MomentOfBirth.ToUniversalTime().Minute.Should().Be(21);
+            person.MomentOfBirth.ToUniversalTime().Second.Should().Be(3);
             person.Cars.Should().HaveCount(2);
             person.Cars[0].Name.Should().Be("Mercedes");
             person.Cars[0].Spec.EngineType.Should().Be("V6");
@@ -93,6 +110,8 @@ cars:
         public class Person
         {
             public string Name { get; private set; }
+
+            public DateTime MomentOfBirth { get; private set; }
 
             public IList<ICar> Cars { get; private set; }
         }

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -91,7 +91,10 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 
                 case TypeCode.DateTime:
                     // TODO: This is probably incorrect. Use the correct regular expression.
-                    value = DateTime.Parse(scalar.Value, CultureInfo.InvariantCulture);
+                    var style = scalar.Value.EndsWith("Z")
+                        ? DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal
+                        : scalar.Value.Length > 27 ? DateTimeStyles.AssumeLocal : DateTimeStyles.None;
+                    value = DateTime.Parse(scalar.Value, CultureInfo.InvariantCulture, style);
                     break;
 
                 default:

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -91,10 +91,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 
                 case TypeCode.DateTime:
                     // TODO: This is probably incorrect. Use the correct regular expression.
-                    var style = scalar.Value.EndsWith("Z")
-                        ? DateTimeStyles.RoundtripKind
-                        : scalar.Value.Length > 27 ? DateTimeStyles.AssumeLocal : DateTimeStyles.None;
-                    value = DateTime.Parse(scalar.Value, CultureInfo.InvariantCulture, style);
+                    value = DateTime.Parse(scalar.Value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
                     break;
 
                 default:

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -92,7 +92,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                 case TypeCode.DateTime:
                     // TODO: This is probably incorrect. Use the correct regular expression.
                     var style = scalar.Value.EndsWith("Z")
-                        ? DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal
+                        ? DateTimeStyles.RoundtripKind
                         : scalar.Value.Length > 27 ? DateTimeStyles.AssumeLocal : DateTimeStyles.None;
                     value = DateTime.Parse(scalar.Value, CultureInfo.InvariantCulture, style);
                     break;


### PR DESCRIPTION
Deserialize the datetime to correct timezone as described on the Microsoft documentation for the "o" Roundtrip

```
// The example displays the following output:
//    6/15/2009 1:45:30 PM (Unspecified) --> 2009-06-15T13:45:30.0000000
//    6/15/2009 1:45:30 PM (Utc) --> 2009-06-15T13:45:30.0000000Z
//    6/15/2009 1:45:30 PM (Local) --> 2009-06-15T13:45:30.0000000-07:00
```

https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip

