### PR TITLE
Fix #361 - Extra Windows newline in folded scalar. 

### DIFF
--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -360,6 +360,7 @@ namespace YamlDotNet.Test.Core
 
         [Theory]
         [InlineData("b-carriage-return,b-line-feed\r\nlll", "b-carriage-return,b-line-feed\nlll")]
+        [InlineData("b-carriage-return,b-line-feed\r\n\r\nlll", "b-carriage-return,b-line-feed\n\nlll")]
         [InlineData("b-carriage-return\rlll", "b-carriage-return\nlll")]
         [InlineData("b-line-feed\nlll", "b-line-feed\nlll")]
         [InlineData("b-next-line\x85lll", "b-next-line\nlll")]
@@ -377,6 +378,28 @@ namespace YamlDotNet.Test.Core
                 LiteralScalar(expected),
                 DocumentEnd(Implicit),
                 StreamEnd);
+        }
+
+        [Theory]
+        [InlineData("b-carriage-return,b-line-feed\r\nlll", "b-carriage-return,b-line-feed\nlll")]
+        [InlineData("b-carriage-return,b-line-feed\r\n\r\nlll", "b-carriage-return,b-line-feed\n\nlll")]
+        [InlineData("b-carriage-return\rlll", "b-carriage-return\nlll")]
+        [InlineData("b-line-feed\nlll", "b-line-feed\nlll")]
+        [InlineData("b-next-line\x85lll", "b-next-line\nlll")]
+        [InlineData("b-line-separator\x2028lll", "b-line-separator\x2028lll")]
+        [InlineData("b-paragraph-separator\x2029lll", "b-paragraph-separator\x2029lll")]
+        public void NewLinesAreNotDuplicatedWhenEmittedInFoldedScalar(string input, string expected)
+        {
+            var yaml = EmittedTextFrom(StreamOf(DocumentWith(
+                                                             FoldedScalar(input)
+                                                            )));
+
+            AssertSequenceOfEventsFrom(Yaml.ParserForText(yaml),
+                                       StreamStart,
+                                       DocumentStart(Implicit),
+                                       FoldedScalar(expected),
+                                       DocumentEnd(Implicit),
+                                       StreamEnd);
         }
 
         [Theory]

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1994,7 +1994,7 @@ c: *anchor1");
 
             Assert.Equal(expected.NormalizeNewLines(), yaml.NormalizeNewLines().TrimNewLines());
         }
-       
+
         [Fact]
         public void ExampleFromSpecificationIsHandledCorrectlyWithLateDefine()
         {
@@ -2121,6 +2121,23 @@ Cycle: *o0");
             Assert.Same(obj, iterator);
         }
 
+        [Fact]
+        public void RoundtripWindowsNewlines()
+        {
+            var text = "Line1\r\nLine2\r\nLine3\r\n\r\nLine4";
+
+            var sut = new SerializerBuilder().Build();
+            var dut = new DeserializerBuilder().Build();
+
+            using var writer = new StringWriter { NewLine = Environment.NewLine };
+            sut.Serialize(writer, new StringContainer { Text = text });
+            var serialized = writer.ToString();
+
+            using var reader = new StringReader(serialized);
+            var roundtrippedText = dut.Deserialize<StringContainer>(reader).Text.NormalizeNewLines();
+            Assert.Equal(text, roundtrippedText);
+        }
+
         [TypeConverter(typeof(DoublyConvertedTypeConverter))]
         public class DoublyConverted
         {
@@ -2165,6 +2182,11 @@ Cycle: *o0");
         {
             public string WillThrow { get { throw new Exception(); } }
 
+            public string Text { get; set; }
+        }
+
+        public class StringContainer
+        {
             public string Text { get; set; }
         }
 

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -176,7 +176,7 @@ namespace YamlDotNet.Core
 
         /// <summary>
         /// Check if we need to accumulate more events before emitting.
-        /// 
+        ///
         /// We accumulate extra
         ///  - 1 event for DOCUMENT-START
         ///  - 2 events for SEQUENCE-START
@@ -1256,7 +1256,12 @@ namespace YamlDotNet.Core
                 var character = value[i];
                 if (IsBreak(character, out var breakCharacter))
                 {
-                    if (!previousBreak && !leadingSpaces && character == '\n')
+                    if (character == '\r' && (i + 1) < value.Length && value[i + 1] == '\n')
+                    {
+                        continue;
+                    }
+
+                    if (!previousBreak && !leadingSpaces && breakCharacter == '\n')
                     {
                         var k = 0;
                         while (i + k < value.Length && IsBreak(value[i + k], out _))
@@ -1268,6 +1273,7 @@ namespace YamlDotNet.Core
                             WriteBreak();
                         }
                     }
+
                     WriteBreak(breakCharacter);
                     isIndentation = true;
                     previousBreak = true;

--- a/YamlDotNet/Serialization/NodeTypeResolvers/MappingNodeTypeResolver.cs
+++ b/YamlDotNet/Serialization/NodeTypeResolvers/MappingNodeTypeResolver.cs
@@ -31,7 +31,10 @@ namespace YamlDotNet.Serialization.NodeTypeResolvers
 
         public MappingNodeTypeResolver(IDictionary<Type, Type> mappings)
         {
-            if (mappings == null) throw new ArgumentNullException(nameof(mappings));
+            if (mappings == null)
+            {
+                throw new ArgumentNullException(nameof(mappings));
+            }
 
             foreach (var pair in mappings)
             {


### PR DESCRIPTION
If "\r\n\r\n" was found in an input string, "\r\n\r\n\r\n" would be
output instead of "\r\n\r\n\r\n". Same fix was used as in #179 for
literal scalars.

Added to existing unit test for this case.
