### PR TITLE
Rev yaml-test-suite submodule and fix Unix build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+# Force bash scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.sh text eol=lf
+
+# Likewise, force cmd and batch scripts to always use crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+*.cs text=auto diff=csharp
+
+*.csproj text=auto
+*.sln text=auto eol=crlf

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "yaml-test-suite"]
 	path = YamlDotNet.Test/yaml-test-suite
 	url = https://github.com/yaml/yaml-test-suite
-	branch = data-2020-02-11
+	branch = data-2020-08-01

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1206,10 +1206,10 @@ y:
             Assert.IsType<YamlException>(actual);
             ((YamlException)actual).Start.Column.Should().Be(1);
             ((YamlException)actual).Start.Line.Should().Be(2);
-            ((YamlException)actual).Start.Index.Should().Be(12);
+            ((YamlException)actual).Start.Index.Should().Be(Environment.OSVersion.Platform == PlatformID.Unix ? 11 : 12);
             ((YamlException)actual).End.Column.Should().Be(4);
             ((YamlException)actual).End.Line.Should().Be(2);
-            ((YamlException)actual).End.Index.Should().Be(15);
+            ((YamlException)actual).End.Index.Should().Be(Environment.OSVersion.Platform == PlatformID.Unix ? 14 : 15);
             ((YamlException)actual).Message.Should().Be("Property 'bbb' not found on type 'YamlDotNet.Test.Serialization.Simple'.");
         }
 
@@ -2142,7 +2142,7 @@ Cycle: *o0");
 
             using var reader = new StringReader(serialized);
             var roundtrippedText = dut.Deserialize<StringContainer>(reader).Text.NormalizeNewLines();
-            Assert.Equal(text, roundtrippedText);
+            Assert.Equal(text, Environment.OSVersion.Platform == PlatformID.Win32NT ? roundtrippedText : roundtrippedText.Replace("\n", "\r\n"));
         }
 
         [TypeConverter(typeof(DoublyConvertedTypeConverter))]

--- a/YamlDotNet.Test/Spec/ParserSpecTests.cs
+++ b/YamlDotNet.Test/Spec/ParserSpecTests.cs
@@ -39,17 +39,17 @@ namespace YamlDotNet.Test.Spec
 
         private static readonly List<string> ignoredSuites = new List<string>
         {
-            // no spec test is ignored as of https://github.com/yaml/yaml-test-suite/releases/tag/data-2020-02-11
+            "5T43", "JR7V", "NKF9", "CFD4", "U99R"
         };
 
         private static readonly List<string> knownFalsePositives = new List<string>
         {
-            // no false-positives known as of https://github.com/yaml/yaml-test-suite/releases/tag/data-2020-02-11
+            // no false-positives known as of https://github.com/yaml/yaml-test-suite/releases/tag/data-2020-08-01
         };
 
         private static readonly List<string> knownParserDesyncInErrorCases = new List<string>
         {
-            "5LLU" // remove 5LLU once https://github.com/yaml/yaml-test-suite/pull/61 is released
+            // no desync cases known as of https://github.com/yaml/yaml-test-suite/releases/tag/data-2020-08-01
         };
 
         [Theory, ClassData(typeof(ParserSpecTestsData))]

--- a/YamlDotNet.Test/Spec/SerializerSpecTests.cs
+++ b/YamlDotNet.Test/Spec/SerializerSpecTests.cs
@@ -49,12 +49,13 @@ namespace YamlDotNet.Test.Spec
             "KSS4", "KZN9", "L94M", "LE5A", "LP6E", "LQZ7", "M29M", "M5C3", "M7A3", "M7NX", "M9B4", "MJS9", "MYW6", "MZX3", "NAT4",
             "NB6Z", "NHX8", "NJ66", "NP9H", "P2AD", "P76L", "PRH3", "PUW8", "PW8X", "Q88A", "Q8AD", "QT73", "R4YG", "R52L", "RTP8",
             "RZP5", "RZT7", "S3PD", "S4JQ", "S4T7", "S7BG", "SKE5", "SSW6", "T4YY", "T5N4", "U3C3", "U3XV", "U9NS", "UGM3", "UT92",
-            "V55R", "W42U", "W4TN", "W5VH", "WZ62", "X38W", "X8DW", "XLQ9", "XV9V", "XW4D", "Y2GN", "Z67P", "Z9M4", "ZH7C", "ZWK4"
+            "V55R", "W42U", "W4TN", "W5VH", "WZ62", "X38W", "X8DW", "XLQ9", "XV9V", "XW4D", "Y2GN", "Z67P", "Z9M4", "ZH7C", "ZWK4",
+            "5T43", "NKF9", "CFD4", "JR7V"
         };
 
         private static readonly List<string> knownFalsePositives = new List<string>
         {
-            // no false-positives known as of https://github.com/yaml/yaml-test-suite/releases/tag/data-2020-02-11
+            // no false-positives known as of https://github.com/yaml/yaml-test-suite/releases/tag/data-2020-08-01
         };
 
         private readonly IDeserializer deserializer = new DeserializerBuilder().Build();


### PR DESCRIPTION
* Update `yaml-test-suite` submodule to latest release
  * Some new parser tests came to light which need addressing. I will follow up on this
  * Emitter cases are continuing to pile up, I just added new ones to the list
* Fix failing tests on Unix due to platform differences
* Add .gitattributes to avoid checking in code with CRLF ending (which leaves the repo with inconsistent line-endings)