### PR TITLE
Asset store update

### DIFF
--- a/YamlDotNet.Samples/ConvertYamlToJson.cs
+++ b/YamlDotNet.Samples/ConvertYamlToJson.cs
@@ -20,7 +20,6 @@
 // SOFTWARE.
 
 using System.IO;
-using Xunit.Abstractions;
 using YamlDotNet.Samples.Helpers;
 using YamlDotNet.Serialization;
 

--- a/YamlDotNet.Samples/DeserializeObjectGraph.cs
+++ b/YamlDotNet.Samples/DeserializeObjectGraph.cs
@@ -22,7 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Xunit.Abstractions;
+
 using YamlDotNet.Samples.Helpers;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;

--- a/YamlDotNet.Samples/DeserializingMultipleDocuments.cs
+++ b/YamlDotNet.Samples/DeserializingMultipleDocuments.cs
@@ -21,7 +21,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using Xunit.Abstractions;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Samples.Helpers;

--- a/YamlDotNet.Samples/LoadingAYamlStream.cs
+++ b/YamlDotNet.Samples/LoadingAYamlStream.cs
@@ -20,7 +20,6 @@
 // SOFTWARE.
 
 using System.IO;
-using Xunit.Abstractions;
 using YamlDotNet.RepresentationModel;
 using YamlDotNet.Samples.Helpers;
 

--- a/YamlDotNet.Samples/SerializeObjectGraph.cs
+++ b/YamlDotNet.Samples/SerializeObjectGraph.cs
@@ -20,7 +20,6 @@
 // SOFTWARE.
 
 using System;
-using Xunit.Abstractions;
 using YamlDotNet.Samples.Helpers;
 using YamlDotNet.Serialization;
 
@@ -92,33 +91,33 @@ namespace YamlDotNet.Samples
     public class Address
     {
         public string street { get; set; }
-        public string city { get; set; }
-        public string state { get; set; }
+        public string city   { get; set; }
+        public string state  { get; set; }
     }
 
     public class Receipt
     {
-        public string receipt { get; set; }
-        public DateTime date { get; set; }
-        public Customer customer { get; set; }
-        public Item[] items { get; set; }
-        public Address bill_to { get; set; }
-        public Address ship_to { get; set; }
-        public string specialDelivery { get; set; }
+        public string   receipt         { get; set; }
+        public DateTime date            { get; set; }
+        public Customer customer        { get; set; }
+        public Item[]   items           { get; set; }
+        public Address  bill_to         { get; set; }
+        public Address  ship_to         { get; set; }
+        public string   specialDelivery { get; set; }
     }
 
     public class Customer
     {
-        public string given { get; set; }
+        public string given  { get; set; }
         public string family { get; set; }
     }
 
     public class Item
     {
-        public string part_no { get; set; }
-        public string descrip { get; set; }
-        public decimal price { get; set; }
-        public int quantity { get; set; }
+        public string  part_no  { get; set; }
+        public string  descrip  { get; set; }
+        public decimal price    { get; set; }
+        public int     quantity { get; set; }
     }
 #pragma warning restore IDE1006 // Naming Styles
 }

--- a/YamlDotNet/Core/ParserExtensions.cs
+++ b/YamlDotNet/Core/ParserExtensions.cs
@@ -51,7 +51,7 @@ namespace YamlDotNet.Core
         /// </summary>
         /// <typeparam name="T">Type of the <see cref="ParsingEvent"/>.</typeparam>
         /// <returns>Returns true if the current event is of type T; otherwise returns null.</returns>
-        public static bool TryConsume<T>(this IParser parser, [MaybeNullWhen(false)] out T @event) where T : ParsingEvent
+        public static bool TryConsume<T>(this IParser parser, out T @event) where T : ParsingEvent
         {
             if (parser.Accept(out @event!))
             {
@@ -86,7 +86,7 @@ namespace YamlDotNet.Core
         /// </summary>
         /// <typeparam name="T">Type of the event.</typeparam>
         /// <returns>Returns true if the current event is of type <typeparamref name="T"/>. Otherwise returns false.</returns>
-        public static bool Accept<T>(this IParser parser, [MaybeNullWhen(false)] out T @event) where T : ParsingEvent
+        public static bool Accept<T>(this IParser parser, out T @event) where T : ParsingEvent
         {
             if (parser.Current == null)
             {
@@ -129,13 +129,13 @@ namespace YamlDotNet.Core
         }
 
         [Obsolete("Please use TryConsume<T>(out var evt) instead")]
-        public static T? Allow<T>(this IParser parser) where T : ParsingEvent
+        public static T Allow<T>(this IParser parser) where T : ParsingEvent
         {
             return parser.TryConsume<T>(out var @event) ? @event : default;
         }
 
         [Obsolete("Please use Accept<T>(out var evt) instead")]
-        public static T? Peek<T>(this IParser parser) where T : ParsingEvent
+        public static T Peek<T>(this IParser parser) where T : ParsingEvent
         {
             return parser.Accept<T>(out var @event) ? @event : default;
         }

--- a/YamlDotNet/Helpers/ExpressionExtensions.cs
+++ b/YamlDotNet/Helpers/ExpressionExtensions.cs
@@ -47,7 +47,7 @@ namespace YamlDotNet.Helpers
             return property;
         }
 
-        private static TMemberInfo? TryGetMemberExpression<TMemberInfo>(LambdaExpression lambdaExpression)
+        private static TMemberInfo TryGetMemberExpression<TMemberInfo>(LambdaExpression lambdaExpression)
             where TMemberInfo : MemberInfo
         {
             if (lambdaExpression.Parameters.Count != 1)

--- a/YamlDotNet/Helpers/OrderedDictionary.cs
+++ b/YamlDotNet/Helpers/OrderedDictionary.cs
@@ -140,7 +140,7 @@ namespace YamlDotNet.Helpers
 #pragma warning disable 8767 // Nullability of reference types in type of parameter ... doesn't match implicitly implemented member
 #endif
 
-        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) =>
+        public bool TryGetValue(TKey key, out TValue value) =>
             dictionary.TryGetValue(key, out value);
 
 #if !(NETCOREAPP3_1)

--- a/YamlDotNet/RepresentationModel/DocumentLoadingState.cs
+++ b/YamlDotNet/RepresentationModel/DocumentLoadingState.cs
@@ -81,7 +81,7 @@ namespace YamlDotNet.RepresentationModel
         /// <param name="anchor">The anchor.</param>
         /// <param name="node">The node that was retrieved.</param>
         /// <returns>true if the anchor was found; otherwise false.</returns>
-        public bool TryGetNode(AnchorName anchor, [NotNullWhen(true)] out YamlNode? node)
+        public bool TryGetNode(AnchorName anchor, out YamlNode? node)
         {
             return anchors.TryGetValue(anchor, out node);
         }

--- a/YamlDotNet/RepresentationModel/YamlNodeIdentityEqualityComparer.cs
+++ b/YamlDotNet/RepresentationModel/YamlNodeIdentityEqualityComparer.cs
@@ -32,7 +32,7 @@ namespace YamlDotNet.RepresentationModel
         #region IEqualityComparer<YamlNode> Members
 
         /// <summary />
-        public bool Equals([AllowNull] YamlNode x, [AllowNull] YamlNode y)
+        public bool Equals(YamlNode x, YamlNode y)
         {
             return ReferenceEquals(x, y);
         }

--- a/YamlDotNet/Serialization/ITypeInspector.cs
+++ b/YamlDotNet/Serialization/ITypeInspector.cs
@@ -49,6 +49,6 @@ namespace YamlDotNet.Serialization
         /// found in <paramref name="type"/>
         /// </param>
         /// <returns></returns>
-        IPropertyDescriptor GetProperty(Type type, object? container, string name, [MaybeNullWhen(true)] bool ignoreUnmatched);
+        IPropertyDescriptor GetProperty(Type type, object? container, string name, bool ignoreUnmatched);
     }
 }

--- a/YamlDotNet/Serialization/TypeInspectors/TypeInspectorSkeleton.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/TypeInspectorSkeleton.cs
@@ -31,7 +31,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
     {
         public abstract IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container);
 
-        public IPropertyDescriptor GetProperty(Type type, object? container, string name, [MaybeNullWhen(true)] bool ignoreUnmatched)
+        public IPropertyDescriptor GetProperty(Type type, object? container, string name, bool ignoreUnmatched)
         {
             var candidates = GetProperties(type, container)
                 .Where(p => p.Name == name);

--- a/YamlDotNet/Serialization/Utilities/ObjectAnchorCollection.cs
+++ b/YamlDotNet/Serialization/Utilities/ObjectAnchorCollection.cs
@@ -50,7 +50,7 @@ namespace YamlDotNet.Serialization.Utilities
         /// <param name="object">The object.</param>
         /// <param name="anchor">The anchor.</param>
         /// <returns></returns>
-        public bool TryGetAnchor(object @object, [MaybeNullWhen(false)] out string? anchor)
+        public bool TryGetAnchor(object @object, out string? anchor)
         {
             return anchorsByObject.TryGetValue(@object, out anchor);
         }

--- a/YamlDotNet/Serialization/YamlAttributeOverrides.cs
+++ b/YamlDotNet/Serialization/YamlAttributeOverrides.cs
@@ -107,7 +107,7 @@ namespace YamlDotNet.Serialization
 
         private readonly Dictionary<AttributeKey, List<AttributeMapping>> overrides = new Dictionary<AttributeKey, List<AttributeMapping>>();
 
-        public T? GetAttribute<T>(Type type, string member) where T : Attribute
+        public T GetAttribute<T>(Type type, string member) where T : Attribute
         {
             if (overrides.TryGetValue(new AttributeKey(typeof(T), member), out var mappings))
             {


### PR DESCRIPTION
Hey Antoine!
This is not a pull request that I actually want you to merge anywhere,
but I'm in need of a little bit of code review. I've held back on updating
the Unity Asset Store version of YamlDotNet, because C# 8 features were being used
after version 6.1.2.   But now that Unity has a much upgraded compiler that
supports C# 8, I was making another attempt, just to stay on par with your
progress. Unity now supports .net standard 2.0. There were a few
things in YamlDotNet 11.2.1 that required .net standard 2.1, but I think it's
pretty close.

So what this is, is just me asking if you could review my branch unity_compatible,
and see if you think I broke anything. I don't have a proper IDE set up for
the project, and I'm not able to run the test suite. It would be a really big job
for me just to run the tests, but if it's easier for you, could you do a quick review
and maybe a sanity check (if I've misunderstood the .net standard 2.1 features
or something.). The sample code seems to run alright in Unity, but I haven't
checked the output properly.

If you think it looks ok, I'll go ahead and package it up for the asset store, and
probably also figure out which exact Unity version is recent enough for this updated
code.