### PR TITLE
Introduce StringBuilderPool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ samples/dotnet/project.lock.json
 YamlDotNet/Properties/AssemblyInfo.Generated.cs
 
 .vs
+.idea
+
 /YamlDotNet/Properties/AssemblyInfo.cs
 BenchmarkDotNet.Artifacts
 

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using YamlDotNet.Core.Events;
+using YamlDotNet.Helpers;
 using ParsingEvent = YamlDotNet.Core.Events.ParsingEvent;
 using TagDirective = YamlDotNet.Core.Tokens.TagDirective;
 using VersionDirective = YamlDotNet.Core.Tokens.VersionDirective;
@@ -1860,11 +1861,12 @@ namespace YamlDotNet.Core
             isIndentation = false;
         }
 
-        private string UrlEncode(string text)
+        private static string UrlEncode(string text)
         {
             return UriReplacer.Replace(text, delegate (Match match)
             {
-                var buffer = new StringBuilder();
+                using var bufferBuilder = StringBuilderPool.Rent();
+                var buffer = bufferBuilder.Builder;
                 foreach (var toEncode in Encoding.UTF8.GetBytes(match.Value))
                 {
                     buffer.AppendFormat("%{0:X02}", toEncode);

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -25,6 +25,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using YamlDotNet.Core.Tokens;
+using YamlDotNet.Helpers;
 
 namespace YamlDotNet.Core
 {
@@ -35,7 +36,7 @@ namespace YamlDotNet.Core
     {
         private const int MaxVersionNumberLength = 9;
 
-        private static readonly IDictionary<char, char> SimpleEscapeCodes = new SortedDictionary<char, char>
+        private static readonly SortedDictionary<char, char> SimpleEscapeCodes = new SortedDictionary<char, char>
         {
             { '0', '\0' },
             { 'a', '\x07' },
@@ -607,7 +608,8 @@ namespace YamlDotNet.Core
                     Skip();
                 }
 
-                var text = new StringBuilder();
+                using var textBuilder = StringBuilderPool.Rent();
+                var text = textBuilder.Builder;
                 while (!analyzer.IsBreakOrZero())
                 {
                     text.Append(ReadCurrentCharacter());
@@ -1260,7 +1262,8 @@ namespace YamlDotNet.Core
             //     '[', ']', '{', '}' and ','
             // ref: https://yaml.org/spec/1.2/spec.html#id2785586
 
-            var value = new StringBuilder();
+            using var valueBuilder = StringBuilderPool.Rent();
+            var value = valueBuilder.Builder;
             while (!analyzer.IsWhiteBreakOrZero())
             {
                 // Anchor: read all allowed characters
@@ -1437,9 +1440,14 @@ namespace YamlDotNet.Core
 
         Token ScanBlockScalar(bool isLiteral)
         {
-            var value = new StringBuilder();
-            var leadingBreak = new StringBuilder();
-            var trailingBreaks = new StringBuilder();
+            using var valueBuilder = StringBuilderPool.Rent();
+            var value = valueBuilder.Builder;
+
+            using var leadingBreakBuilder = StringBuilderPool.Rent();
+            var leadingBreak = leadingBreakBuilder.Builder;
+
+            using var trailingBreaksBuilder = StringBuilderPool.Rent();
+            var trailingBreaks = trailingBreaksBuilder.Builder;
 
             var chomping = 0;
             var increment = 0;
@@ -1758,10 +1766,18 @@ namespace YamlDotNet.Core
 
             // Consume the content of the quoted scalar.
 
-            var value = new StringBuilder();
-            var whitespaces = new StringBuilder();
-            var leadingBreak = new StringBuilder();
-            var trailingBreaks = new StringBuilder();
+            using var valueBuilder = StringBuilderPool.Rent();
+            var value = valueBuilder.Builder;
+
+            using var whitespacesBuilder = StringBuilderPool.Rent();
+            var whitespaces = whitespacesBuilder.Builder;
+
+            using var leadingBreakBuilder = StringBuilderPool.Rent();
+            var leadingBreak = leadingBreakBuilder.Builder;
+
+            using var trailingBreaksBuilder = StringBuilderPool.Rent();
+            var trailingBreaks = trailingBreaksBuilder.Builder;
+
             var hasLeadingBlanks = false;
 
             while (true)
@@ -2009,10 +2025,17 @@ namespace YamlDotNet.Core
 
         private Scalar ScanPlainScalar(ref bool isMultiline)
         {
-            var value = new StringBuilder();
-            var whitespaces = new StringBuilder();
-            var leadingBreak = new StringBuilder();
-            var trailingBreaks = new StringBuilder();
+            using var valueBuilder = StringBuilderPool.Rent();
+            var value = valueBuilder.Builder;
+
+            using var whitespacesBuilder = StringBuilderPool.Rent();
+            var whitespaces = whitespacesBuilder.Builder;
+
+            using var leadingBreakBuilder = StringBuilderPool.Rent();
+            var leadingBreak = leadingBreakBuilder.Builder;
+
+            using var trailingBreaksBuilder = StringBuilderPool.Rent();
+            var trailingBreaks = trailingBreaksBuilder.Builder;
 
             var hasLeadingBlanks = false;
             var currentIndent = indent + 1;
@@ -2209,7 +2232,8 @@ namespace YamlDotNet.Core
         /// </summary>
         private string ScanDirectiveName(Mark start)
         {
-            var name = new StringBuilder();
+            using var nameBuilder = StringBuilderPool.Rent();
+            var name = nameBuilder.Builder;
 
             // Consume the directive name.
 
@@ -2320,7 +2344,9 @@ namespace YamlDotNet.Core
 
         private string ScanTagUri(string? head, Mark start)
         {
-            var tag = new StringBuilder();
+            using var tagBuilder = StringBuilderPool.Rent();
+            var tag = tagBuilder.Builder;
+
             if (head != null && head.Length > 1)
             {
                 tag.Append(head.Substring(1));
@@ -2453,7 +2479,8 @@ namespace YamlDotNet.Core
 
             // Copy the '!' character.
 
-            var tagHandle = new StringBuilder();
+            using var tagHandleBuilder = StringBuilderPool.Rent();
+            var tagHandle = tagHandleBuilder.Builder;
             tagHandle.Append(ReadCurrentCharacter());
 
             // Copy all subsequent alphabetical and numerical characters.

--- a/YamlDotNet/Helpers/ConcurrentObjectPool.cs
+++ b/YamlDotNet/Helpers/ConcurrentObjectPool.cs
@@ -1,0 +1,198 @@
+// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+// Adapter from Microsoft code which is
+// Copyright (c) Microsoft.
+// All Rights Reserved.  Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace YamlDotNet.Helpers
+{
+    /// <summary>
+    /// Generic implementation of object pooling pattern with predefined pool size limit. The main
+    /// purpose is that limited number of frequently used objects can be kept in the pool for
+    /// further recycling.
+    ///
+    /// Notes:
+    /// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
+    ///    is no space in the pool, extra returned objects will be dropped.
+    ///
+    /// 2) it is implied that if object was obtained from a pool, the caller will return it back in
+    ///    a relatively short time. Keeping checked out objects for long durations is ok, but
+    ///    reduces usefulness of pooling. Just new up your own.
+    ///
+    /// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice.
+    /// Rationale:
+    ///    If there is no intent for reusing the object, do not use pool - just use "new".
+    /// </summary>
+    internal sealed class ConcurrentObjectPool<T> where T : class
+    {
+        [DebuggerDisplay("{value,nq}")]
+        private struct Element
+        {
+            internal T? value;
+        }
+
+        /// <remarks>
+        /// Not using System.Func{T} because this file is linked into the (debugger) Formatter,
+        /// which does not have that type (since it compiles against .NET 2.0).
+        /// </remarks>
+        internal delegate T Factory();
+
+        // Storage for the pool objects. The first item is stored in a dedicated field because we
+        // expect to be able to satisfy most requests from it.
+        private T? firstItem;
+        private readonly Element[] items;
+
+        // factory is stored for the lifetime of the pool. We will call this only when pool needs to
+        // expand. compared to "new T()", Func gives more flexibility to implementers and faster
+        // than "new T()".
+        private readonly Factory factory;
+
+        internal ConcurrentObjectPool(Factory factory)
+            : this(factory, Environment.ProcessorCount * 2)
+        {
+        }
+
+        internal ConcurrentObjectPool(Factory factory, int size)
+        {
+            Debug.Assert(size >= 1);
+            this.factory = factory;
+            items = new Element[size - 1];
+        }
+
+        private T CreateInstance()
+        {
+            var inst = factory();
+            return inst;
+        }
+
+        /// <summary>
+        /// Produces an instance.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically
+        /// reducing how far we will typically search.
+        /// </remarks>
+        internal T Allocate()
+        {
+            // PERF: Examine the first element. If that fails, AllocateSlow will look at the remaining elements.
+            // Note that the initial read is optimistically not synchronized. That is intentional.
+            // We will interlock only when we have a candidate. in a worst case we may miss some
+            // recently returned objects. Not a big deal.
+            var inst = firstItem;
+            if (inst == null || inst != Interlocked.CompareExchange(ref firstItem, null, inst))
+            {
+                inst = AllocateSlow();
+            }
+
+            return inst;
+        }
+
+        private T AllocateSlow()
+        {
+            var elements = items;
+
+            for (var i = 0; i < elements.Length; i++)
+            {
+                // Note that the initial read is optimistically not synchronized. That is intentional.
+                // We will interlock only when we have a candidate. in a worst case we may miss some
+                // recently returned objects. Not a big deal.
+                var inst = elements[i].value;
+                if (inst != null)
+                {
+                    if (inst == Interlocked.CompareExchange(ref elements[i].value, null, inst))
+                    {
+                        return inst;
+                    }
+                }
+            }
+
+            return CreateInstance();
+        }
+
+        /// <summary>
+        /// Returns objects to the pool.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically
+        /// reducing how far we will typically search in Allocate.
+        /// </remarks>
+        internal void Free(T obj)
+        {
+            Validate(obj);
+
+            if (firstItem == null)
+            {
+                // Intentionally not using interlocked here.
+                // In a worst case scenario two objects may be stored into same slot.
+                // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                firstItem = obj;
+            }
+            else
+            {
+                FreeSlow(obj);
+            }
+        }
+
+        private void FreeSlow(T obj)
+        {
+            var elements = items;
+            for (var i = 0; i < elements.Length; i++)
+            {
+                if (elements[i].value == null)
+                {
+                    // Intentionally not using interlocked here.
+                    // In a worst case scenario two objects may be stored into same slot.
+                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                    elements[i].value = obj;
+                    break;
+                }
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void Validate(object obj)
+        {
+            Debug.Assert(obj != null, "freeing null?");
+
+            Debug.Assert(firstItem != obj, "freeing twice?");
+
+            var elements = items;
+            for (var i = 0; i < elements.Length; i++)
+            {
+                var value = elements[i].value;
+                if (value == null)
+                {
+                    return;
+                }
+
+                Debug.Assert(value != obj, "freeing twice?");
+            }
+        }
+    }
+}

--- a/YamlDotNet/Helpers/OrderedDictionary.cs
+++ b/YamlDotNet/Helpers/OrderedDictionary.cs
@@ -29,7 +29,7 @@ using System.Runtime.Serialization;
 namespace YamlDotNet.Helpers
 {
     [Serializable]
-    internal class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, TValue>
+    internal sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, TValue>
         where TKey : notnull
     {
         [NonSerialized]

--- a/YamlDotNet/Helpers/StringBuilderPool.cs
+++ b/YamlDotNet/Helpers/StringBuilderPool.cs
@@ -1,0 +1,76 @@
+// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace YamlDotNet.Helpers
+{
+    /// <summary>
+    /// Pooling of StringBuilder instances.
+    /// </summary>
+    internal static class StringBuilderPool
+    {
+        private static readonly ConcurrentObjectPool<StringBuilder> Pool;
+
+        static StringBuilderPool()
+        {
+            Pool = new ConcurrentObjectPool<StringBuilder>(() => new StringBuilder());
+        }
+
+        public static BuilderWrapper Rent()
+        {
+            var builder = Pool.Allocate();
+            Debug.Assert(builder.Length == 0);
+            return new BuilderWrapper(builder, Pool);
+        }
+
+        internal readonly struct BuilderWrapper : IDisposable
+        {
+            public readonly StringBuilder Builder;
+            private readonly ConcurrentObjectPool<StringBuilder> _pool;
+
+            public BuilderWrapper(StringBuilder builder, ConcurrentObjectPool<StringBuilder> pool)
+            {
+                Builder = builder;
+                _pool = pool;
+            }
+
+            public override string ToString()
+            {
+                return Builder.ToString();
+            }
+
+            public void Dispose()
+            {
+                var builder = Builder;
+
+                // do not store builders that are too large.
+                if (builder.Capacity <= 1024)
+                {
+                    builder.Length = 0;
+                    _pool.Free(builder);
+                }
+            }
+        }
+    }
+}

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -21,7 +21,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Helpers;
@@ -35,7 +34,7 @@ namespace YamlDotNet.RepresentationModel
     /// </summary>
     public sealed class YamlMappingNode : YamlNode, IEnumerable<KeyValuePair<YamlNode, YamlNode>>, IYamlConvertible
     {
-        private readonly IOrderedDictionary<YamlNode, YamlNode> children = new OrderedDictionary<YamlNode, YamlNode>();
+        private readonly OrderedDictionary<YamlNode, YamlNode> children = new OrderedDictionary<YamlNode, YamlNode>();
 
         /// <summary>
         /// Gets the children of the current node.
@@ -347,7 +346,9 @@ namespace YamlDotNet.RepresentationModel
                 return MaximumRecursionLevelReachedToStringValue;
             }
 
-            var text = new StringBuilder("{ ");
+            using var textBuilder = StringBuilderPool.Rent();
+            var text = textBuilder.Builder;
+            text.Append("{ ");
 
             foreach (var child in children)
             {

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -22,9 +22,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
+using YamlDotNet.Helpers;
 using YamlDotNet.Serialization;
 using static YamlDotNet.Core.HashCode;
 
@@ -251,7 +251,9 @@ namespace YamlDotNet.RepresentationModel
                 return MaximumRecursionLevelReachedToStringValue;
             }
 
-            var text = new StringBuilder("[ ");
+            using var textBuilder = StringBuilderPool.Rent();
+            var text = textBuilder.Builder;
+            text.Append("[ ");
 
             foreach (var child in children)
             {

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -21,10 +21,10 @@
 
 using System;
 using System.Globalization;
-using System.Text;
 using System.Text.RegularExpressions;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
+using YamlDotNet.Helpers;
 using YamlDotNet.Serialization.Utilities;
 
 namespace YamlDotNet.Serialization.NodeDeserializers
@@ -129,9 +129,10 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             return result;
         }
 
-        private object DeserializeIntegerHelper(TypeCode typeCode, string value)
+        private static object DeserializeIntegerHelper(TypeCode typeCode, string value)
         {
-            var numberBuilder = new StringBuilder();
+            using var numberBuilderStringBuilder = StringBuilderPool.Rent();
+            var numberBuilder = numberBuilderStringBuilder.Builder;
             var currentIndex = 0;
             var isNegative = false;
             int numberBase;


### PR DESCRIPTION
To reduce memory allocations and improve scanning speed (less GC) I've introduced `StringBuilder` pooling. This is basically the same code we've used successfully in [Jint](https://github.com/sebastienros/jint) and [Esprima](https://github.com/sebastienros/esprima-dotnet).

`StringBuilderPool` returns a disposable read-only struct that tracks lifetime and we access the rented builder from it.

I also sealed `OrderedDictionary` and made sure it's accessed via concrete type in fields to avoid interface dispatch.

## Benchmark Code

Uses the large YAML from issue https://github.com/aaubry/YamlDotNet/issues/519 . I noticed you don't have a benchmark project currently so I'm running my local one.

```csharp
[MemoryDiagnoser]
public class YamlStreamBenchmark
{
    private string yamlString = "";

    [GlobalSetup]
    public void Setup()
    {
        yamlString = File.ReadAllText(@"c:\work\saltern.yml");
    }

    [Benchmark]
    public void Load()
    {
        var yamlStream = new YamlStream();
        yamlStream.Load(new StringReader(yamlString));
    }
}
```

## Results

``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
```

### YamlStreamBenchmark

| **Diff**|Method|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |Load|97.21 ms|0.592 ms|5833.3333|2833.3333|1000.0000|81 MB|
| **New** |	| **83.64 ms (-14%)** | **0.319 ms** | **3500.0000 (-40%)** | **1500.0000 (-47%)** | **500.0000 (-50%)** | **53 MB (-35%)** |


