### PR TITLE
Change Mark to be readonly struct

### DIFF
--- a/YamlDotNet/Core/AnchorNotFoundException.cs
+++ b/YamlDotNet/Core/AnchorNotFoundException.cs
@@ -40,7 +40,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="AnchorNotFoundException"/> class.
         /// </summary>
-        public AnchorNotFoundException(Mark start, Mark end, string message)
+        public AnchorNotFoundException(in Mark start, in Mark end, string message)
             : base(start, end, message)
         {
         }

--- a/YamlDotNet/Core/Events/DocumentStart.cs
+++ b/YamlDotNet/Core/Events/DocumentStart.cs
@@ -92,7 +92,7 @@ namespace YamlDotNet.Core.Events
         /// </summary>
         /// <param name="start">The start position of the event.</param>
         /// <param name="end">The end position of the event.</param>
-        public DocumentStart(Mark start, Mark end)
+        public DocumentStart(in Mark start, in Mark end)
             : this(null, null, true, start, end)
         {
         }

--- a/YamlDotNet/Core/Events/MappingEnd.cs
+++ b/YamlDotNet/Core/Events/MappingEnd.cs
@@ -43,7 +43,7 @@ namespace YamlDotNet.Core.Events
         /// </summary>
         /// <param name="start">The start position of the event.</param>
         /// <param name="end">The end position of the event.</param>
-        public MappingEnd(Mark start, Mark end)
+        public MappingEnd(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Events/ParsingEvent.cs
+++ b/YamlDotNet/Core/Events/ParsingEvent.cs
@@ -59,10 +59,10 @@ namespace YamlDotNet.Core.Events
         /// </summary>
         /// <param name="start">The start position of the event.</param>
         /// <param name="end">The end position of the event.</param>
-        internal ParsingEvent(Mark start, Mark end)
+        internal ParsingEvent(in Mark start, in Mark end)
         {
-            this.Start = start ?? throw new System.ArgumentNullException(nameof(start));
-            this.End = end ?? throw new System.ArgumentNullException(nameof(end));
+            this.Start = start;
+            this.End = end;
         }
     }
 }

--- a/YamlDotNet/Core/Events/SequenceEnd.cs
+++ b/YamlDotNet/Core/Events/SequenceEnd.cs
@@ -43,7 +43,7 @@ namespace YamlDotNet.Core.Events
         /// </summary>
         /// <param name="start">The start position of the event.</param>
         /// <param name="end">The end position of the event.</param>
-        public SequenceEnd(Mark start, Mark end)
+        public SequenceEnd(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Events/StreamEnd.cs
+++ b/YamlDotNet/Core/Events/StreamEnd.cs
@@ -55,7 +55,7 @@ namespace YamlDotNet.Core.Events
         /// </summary>
         /// <param name="start">The start position of the event.</param>
         /// <param name="end">The end position of the event.</param>
-        public StreamEnd(Mark start, Mark end)
+        public StreamEnd(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Events/StreamStart.cs
+++ b/YamlDotNet/Core/Events/StreamStart.cs
@@ -63,7 +63,7 @@ namespace YamlDotNet.Core.Events
         /// </summary>
         /// <param name="start">The start position of the event.</param>
         /// <param name="end">The end position of the event.</param>
-        public StreamStart(Mark start, Mark end)
+        public StreamStart(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/ForwardAnchorNotSupportedException.cs
+++ b/YamlDotNet/Core/ForwardAnchorNotSupportedException.cs
@@ -41,7 +41,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="AnchorNotFoundException"/> class.
         /// </summary>
-        public ForwardAnchorNotSupportedException(Mark start, Mark end, string message)
+        public ForwardAnchorNotSupportedException(in Mark start, in Mark end, string message)
             : base(start, end, message)
         {
         }

--- a/YamlDotNet/Core/Mark.cs
+++ b/YamlDotNet/Core/Mark.cs
@@ -20,18 +20,19 @@
 // SOFTWARE.
 
 using System;
+using YamlDotNet.Helpers;
 
 namespace YamlDotNet.Core
 {
     /// <summary>
     /// Represents a location inside a file
     /// </summary>
-    public sealed class Mark : IEquatable<Mark>, IComparable<Mark>, IComparable
+    public readonly struct Mark : IEquatable<Mark>, IComparable<Mark>, IComparable
     {
         /// <summary>
         /// Gets a <see cref="Mark"/> with empty values.
         /// </summary>
-        public static readonly Mark Empty = new Mark();
+        public static readonly Mark Empty = new Mark(0, 1, 1);
 
         /// <summary>
         /// Gets / sets the absolute offset in the file
@@ -48,25 +49,19 @@ namespace YamlDotNet.Core
         /// </summary>
         public int Column { get; }
 
-        public Mark()
-        {
-            Line = 1;
-            Column = 1;
-        }
-
         public Mark(int index, int line, int column)
         {
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(index), "Index must be greater than or equal to zero.");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(index), "Index must be greater than or equal to zero.");
             }
             if (line < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(line), "Line must be greater than or equal to 1.");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(line), "Line must be greater than or equal to 1.");
             }
             if (column < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(column), "Column must be greater than or equal to 1.");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(column), "Column must be greater than or equal to 1.");
             }
 
             Index = index;
@@ -88,14 +83,13 @@ namespace YamlDotNet.Core
         /// <summary />
         public override bool Equals(object? obj)
         {
-            return Equals(obj as Mark);
+            return Equals((Mark)(obj ?? Empty));
         }
 
         /// <summary />
-        public bool Equals(Mark? other)
+        public bool Equals(Mark other)
         {
-            return other != null
-                && Index == other.Index
+            return Index == other.Index
                 && Line == other.Line
                 && Column == other.Column;
         }
@@ -115,21 +109,12 @@ namespace YamlDotNet.Core
         /// <summary />
         public int CompareTo(object? obj)
         {
-            if (obj == null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-            return CompareTo(obj as Mark);
+            return CompareTo((Mark)(obj ?? Empty));
         }
 
         /// <summary />
-        public int CompareTo(Mark? other)
+        public int CompareTo(Mark other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
-
             var cmp = Line.CompareTo(other.Line);
             if (cmp == 0)
             {

--- a/YamlDotNet/Core/MaximumRecursionLevelReachedException.cs
+++ b/YamlDotNet/Core/MaximumRecursionLevelReachedException.cs
@@ -40,7 +40,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="MaximumRecursionLevelReachedException"/> class.
         /// </summary>
-        public MaximumRecursionLevelReachedException(Mark start, Mark end, string message)
+        public MaximumRecursionLevelReachedException(in Mark start, in Mark end, string message)
             : base(start, end, message)
         {
         }

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -419,7 +419,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Generate an empty scalar event.
         /// </summary>
-        private static ParsingEvent ProcessEmptyScalar(Mark position)
+        private static ParsingEvent ProcessEmptyScalar(in Mark position)
         {
             return new Events.Scalar(AnchorName.Empty, TagName.Empty, string.Empty, ScalarStyle.Plain, true, false, position, position);
         }

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -2207,7 +2207,7 @@ namespace YamlDotNet.Core
         ///      %TAG    !yaml!  tag:yaml.org,2002:  \n
         ///       ^^^
         /// </summary>
-        private string ScanDirectiveName(Mark start)
+        private string ScanDirectiveName(in Mark start)
         {
             var name = new StringBuilder();
 
@@ -2252,7 +2252,7 @@ namespace YamlDotNet.Core
         ///      %YAML   1.1     # a comment \n
         ///           ^^^^^^
         /// </summary>
-        private Token ScanVersionDirectiveValue(Mark start)
+        private Token ScanVersionDirectiveValue(in Mark start)
         {
             SkipWhitespaces();
 
@@ -2283,7 +2283,7 @@ namespace YamlDotNet.Core
         ///      %TAG    !yaml!  tag:yaml.org,2002:  \n
         ///          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         /// </summary>
-        private Token ScanTagDirectiveValue(Mark start)
+        private Token ScanTagDirectiveValue(in Mark start)
         {
             SkipWhitespaces();
 
@@ -2371,7 +2371,7 @@ namespace YamlDotNet.Core
         /// Decode an URI-escape sequence corresponding to a single UTF-8 character.
         /// </summary>
 
-        private string ScanUriEscapes(Mark start)
+        private string ScanUriEscapes(in Mark start)
         {
             // Decode the required number of characters.
 
@@ -2495,7 +2495,7 @@ namespace YamlDotNet.Core
         ///      %YAML   1.1     # a comment \n
         ///                ^
         /// </summary>
-        private int ScanVersionDirectiveNumber(Mark start)
+        private int ScanVersionDirectiveNumber(in Mark start)
         {
             var value = 0;
             var length = 0;

--- a/YamlDotNet/Core/SemanticErrorException.cs
+++ b/YamlDotNet/Core/SemanticErrorException.cs
@@ -40,7 +40,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="SemanticErrorException"/> class.
         /// </summary>
-        public SemanticErrorException(Mark start, Mark end, string message)
+        public SemanticErrorException(in Mark start, in Mark end, string message)
             : base(start, end, message)
         {
         }

--- a/YamlDotNet/Core/SyntaxErrorException.cs
+++ b/YamlDotNet/Core/SyntaxErrorException.cs
@@ -40,7 +40,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="SyntaxErrorException"/> class.
         /// </summary>
-        public SyntaxErrorException(Mark start, Mark end, string message)
+        public SyntaxErrorException(in Mark start, in Mark end, string message)
             : base(start, end, message)
         {
         }

--- a/YamlDotNet/Core/Tokens/BlockEnd.cs
+++ b/YamlDotNet/Core/Tokens/BlockEnd.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public BlockEnd(Mark start, Mark end)
+        public BlockEnd(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/BlockEntry.cs
+++ b/YamlDotNet/Core/Tokens/BlockEntry.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public BlockEntry(Mark start, Mark end)
+        public BlockEntry(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/BlockMappingStart.cs
+++ b/YamlDotNet/Core/Tokens/BlockMappingStart.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public BlockMappingStart(Mark start, Mark end)
+        public BlockMappingStart(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/BlockSequenceStart.cs
+++ b/YamlDotNet/Core/Tokens/BlockSequenceStart.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public BlockSequenceStart(Mark start, Mark end)
+        public BlockSequenceStart(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/DocumentEnd.cs
+++ b/YamlDotNet/Core/Tokens/DocumentEnd.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public DocumentEnd(Mark start, Mark end)
+        public DocumentEnd(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/DocumentStart.cs
+++ b/YamlDotNet/Core/Tokens/DocumentStart.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public DocumentStart(Mark start, Mark end)
+        public DocumentStart(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/FlowEntry.cs
+++ b/YamlDotNet/Core/Tokens/FlowEntry.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public FlowEntry(Mark start, Mark end)
+        public FlowEntry(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/FlowMappingEnd.cs
+++ b/YamlDotNet/Core/Tokens/FlowMappingEnd.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public FlowMappingEnd(Mark start, Mark end)
+        public FlowMappingEnd(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/FlowMappingStart.cs
+++ b/YamlDotNet/Core/Tokens/FlowMappingStart.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public FlowMappingStart(Mark start, Mark end)
+        public FlowMappingStart(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/FlowSequenceEnd.cs
+++ b/YamlDotNet/Core/Tokens/FlowSequenceEnd.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public FlowSequenceEnd(Mark start, Mark end)
+        public FlowSequenceEnd(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/FlowSequenceStart.cs
+++ b/YamlDotNet/Core/Tokens/FlowSequenceStart.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public FlowSequenceStart(Mark start, Mark end)
+        public FlowSequenceStart(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/Key.cs
+++ b/YamlDotNet/Core/Tokens/Key.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public Key(Mark start, Mark end)
+        public Key(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/StreamEnd.cs
+++ b/YamlDotNet/Core/Tokens/StreamEnd.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public StreamEnd(Mark start, Mark end)
+        public StreamEnd(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/StreamStart.cs
+++ b/YamlDotNet/Core/Tokens/StreamStart.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public StreamStart(Mark start, Mark end)
+        public StreamStart(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/Tokens/Token.cs
+++ b/YamlDotNet/Core/Tokens/Token.cs
@@ -19,8 +19,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
-
 namespace YamlDotNet.Core.Tokens
 {
     /// <summary>
@@ -43,10 +41,10 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        protected Token(Mark start, Mark end)
+        protected Token(in Mark start, in Mark end)
         {
-            this.Start = start ?? throw new ArgumentNullException(nameof(start));
-            this.End = end ?? throw new ArgumentNullException(nameof(end));
+            this.Start = start;
+            this.End = end;
         }
     }
 }

--- a/YamlDotNet/Core/Tokens/Value.cs
+++ b/YamlDotNet/Core/Tokens/Value.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core.Tokens
         /// </summary>
         /// <param name="start">The start position of the token.</param>
         /// <param name="end">The end position of the token.</param>
-        public Value(Mark start, Mark end)
+        public Value(in Mark start, in Mark end)
             : base(start, end)
         {
         }

--- a/YamlDotNet/Core/YamlException.cs
+++ b/YamlDotNet/Core/YamlException.cs
@@ -50,7 +50,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlException"/> class.
         /// </summary>
-        public YamlException(Mark start, Mark end, string message)
+        public YamlException(in Mark start, in Mark end, string message)
             : this(start, end, message, null)
         {
         }
@@ -58,7 +58,7 @@ namespace YamlDotNet.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlException"/> class.
         /// </summary>
-        public YamlException(Mark start, Mark end, string message, Exception? innerException)
+        public YamlException(in Mark start, in Mark end, string message, Exception? innerException)
             : base(message, innerException)
         {
             Start = start;

--- a/YamlDotNet/Helpers/ThrowHelper.cs
+++ b/YamlDotNet/Helpers/ThrowHelper.cs
@@ -1,0 +1,35 @@
+// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace YamlDotNet.Helpers
+{
+    internal static class ThrowHelper
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentOutOfRangeException(string paramName, string message)
+        {
+            throw new ArgumentOutOfRangeException(paramName, message);
+        }
+    }
+}


### PR DESCRIPTION
**!! This is binary breaking change !!**

To reduce memory allocations and improve scanning speed (less GC) I've changed `Mark` to be a read-only struct. In parsing test code profiling showed that over 20% of memory allocations were from constructing `Mark` instances. This is a binary breaking change, but I'd argue the performance benefits are quite good. The API itself didn't change

Using `in` modifier passing `Mark` instances around as struct size exceeds pointer size.

Also introduced `ThrowHelper` to allow inlining `Mark` constructor.

## Benchmark Code

Uses the large YAML from issue https://github.com/aaubry/YamlDotNet/issues/519 . I noticed you don't have a benchmark project currently so I'm running my local one.

```csharp
[MemoryDiagnoser]
public class YamlStreamBenchmark
{
    private string yamlString = "";

    [GlobalSetup]
    public void Setup()
    {
        yamlString = File.ReadAllText(@"c:\work\saltern.yml");
    }

    [Benchmark]
    public void Load()
    {
        var yamlStream = new YamlStream();
        yamlStream.Load(new StringReader(yamlString));
    }
}
```

## Results

``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
```

### YamlStreamBenchmark

| **Diff**|Method|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |Load|96.71 ms|1.551 ms|5833.3333|2833.3333|1000.0000|81 MB|
| **New** |	| **73.13 ms (-24%)** | **1.319 ms** | **4428.5714 (-24%)** | **2000.0000 (-29%)** | **714.2857 (-29%)** | **63 MB (-22%)** |

