### PR TITLE
Avoid extra allocations in YamlScalarNode GetHashCode

### DIFF
--- a/YamlDotNet/Core/HashCode.cs
+++ b/YamlDotNet/Core/HashCode.cs
@@ -42,16 +42,6 @@ namespace YamlDotNet.Core
             return CombineHashCodes(h1, GetHashCode(o2));
         }
 
-        public static int CombineHashCodes(object? first, params object?[] others)
-        {
-            var hashCode = GetHashCode(first);
-            foreach (var other in others)
-            {
-                hashCode = CombineHashCodes(hashCode, other);
-            }
-            return hashCode;
-        }
-
         private static int GetHashCode(object? obj)
         {
             return obj != null ? obj.GetHashCode() : 0;

--- a/YamlDotNet/Core/TagName.cs
+++ b/YamlDotNet/Core/TagName.cs
@@ -23,7 +23,7 @@ using System;
 
 namespace YamlDotNet.Core
 {
-    public struct TagName : IEquatable<TagName>
+    public readonly struct TagName : IEquatable<TagName>
     {
         public static readonly TagName Empty = default;
 

--- a/YamlDotNet/RepresentationModel/YamlScalarNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlScalarNode.cs
@@ -125,7 +125,7 @@ namespace YamlDotNet.RepresentationModel
         /// </returns>
         public override int GetHashCode()
         {
-            return CombineHashCodes(Tag, Value);
+            return CombineHashCodes(Tag.GetHashCode(), Value);
         }
 
         /// <summary>


### PR DESCRIPTION
`YamlScalarNode` calls `CombineHashCodes(Tag, Value)` which is the only call in library that chooses the params array method. No need to allocate array for this so changed method signature to take the second object as parameter.

**EDIT**

Then found out that the first parameter is actuall struct (`TagName Tag`) so causes boxing, is wiser to call hash code directly and now remove the `CombineHashCodes` overload that is no longer needed at all.

Also marked `TagName` as read-only struct. Should also use `ThrowHelper` here, but didn't duplicate introduction work from other PR.

## Benchmark Code

Uses the large YAML from issue https://github.com/aaubry/YamlDotNet/issues/519 . I noticed you don't have a benchmark project currently so I'm running my local one.

```csharp
[MemoryDiagnoser]
public class YamlStreamBenchmark
{
    private string yamlString = "";

    [GlobalSetup]
    public void Setup()
    {
        yamlString = File.ReadAllText(@"c:\work\saltern.yml");
    }

    [Benchmark]
    public void Load()
    {
        var yamlStream = new YamlStream();
        yamlStream.Load(new StringReader(yamlString));
    }
}
```

## Results

``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
```

### YamlStreamBenchmark

| **Diff**|Method|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |Load|96.60 ms|1.183 ms|5833.3333|2833.3333|1000.0000|81 MB|
| **New** |	| **95.72 ms (-1%)** | **1.659 ms** | **5666.6667 (-3%)** | **2500.0000 (-12%)** | **1000.0000 (0%)** | **78 MB (-4%)** |





