### PR TITLE
Introduce support for deserializing via annotated constructor

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerReadOnlyTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerReadOnlyTest.cs
@@ -1,0 +1,323 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+#nullable enable
+namespace YamlDotNet.Test.Serialization
+{
+    public class DeserializerReadOnlyTest
+    {
+        [Fact]
+        public void Deserialize_YamlWithInterfaceTypeAndMapping_ReturnsModel()
+        {
+            var yaml = @"
+name: Jack
+momentOfBirth: 1983-04-21T20:21:03.0041599Z
+cars:
+- name: Mercedes
+  year: 2018
+- year: 2021
+  name: Honda
+";
+
+            var sut = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithTypeMapping<ICar, Car>()
+                .Build();
+
+            var person = sut.Deserialize<Person>(yaml);
+            person.Name.Should().Be("Jack");
+            person.MomentOfBirth.Kind.Should().Be(DateTimeKind.Utc);
+            person.MomentOfBirth.ToUniversalTime().Year.Should().Be(1983);
+            person.MomentOfBirth.ToUniversalTime().Month.Should().Be(4);
+            person.MomentOfBirth.ToUniversalTime().Day.Should().Be(21);
+            person.MomentOfBirth.ToUniversalTime().Hour.Should().Be(20);
+            person.MomentOfBirth.ToUniversalTime().Minute.Should().Be(21);
+            person.MomentOfBirth.ToUniversalTime().Second.Should().Be(3);
+            person.Cars.Should().HaveCount(2);
+            person.Cars[0].Name.Should().Be("Mercedes");
+            person.Cars[0].Spec.Should().BeNull();
+            person.Cars[1].Name.Should().Be("Honda");
+            person.Cars[1].Spec.Should().BeNull();
+        }
+
+        [Fact]
+        public void Deserialize_YamlWithTwoInterfaceTypesAndMappings_ReturnsModel()
+        {
+            var yaml = @"
+name: Jack
+momentOfBirth: 1983-04-21T20:21:03.0041599Z
+cars:
+- name: Mercedes
+  year: 2018
+  spec:
+    engineType: V6
+    driveType: AWD
+- name: Honda
+  year: 2021
+  spec:
+    engineType: V4
+    driveType: FWD
+";
+
+            var sut = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithTypeMapping<ICar, Car>()
+                .WithTypeMapping<IModelSpec, ModelSpec>()
+                .Build();
+
+            var person = sut.Deserialize<Person>(yaml);
+            person.Name.Should().Be("Jack");
+            person.MomentOfBirth.Kind.Should().Be(DateTimeKind.Utc);
+            person.MomentOfBirth.ToUniversalTime().Year.Should().Be(1983);
+            person.MomentOfBirth.ToUniversalTime().Month.Should().Be(4);
+            person.MomentOfBirth.ToUniversalTime().Day.Should().Be(21);
+            person.MomentOfBirth.ToUniversalTime().Hour.Should().Be(20);
+            person.MomentOfBirth.ToUniversalTime().Minute.Should().Be(21);
+            person.MomentOfBirth.ToUniversalTime().Second.Should().Be(3);
+            person.Cars.Should().HaveCount(2);
+            person.Cars[0].Name.Should().Be("Mercedes");
+            person.Cars[0].Spec.Should().NotBeNull();
+            person.Cars[0].Spec!.EngineType.Should().Be("V6");
+            person.Cars[0].Spec!.DriveType.Should().Be("AWD");
+            person.Cars[1].Name.Should().Be("Honda");
+            person.Cars[1].Spec.Should().NotBeNull();
+            person.Cars[1].Spec!.EngineType.Should().Be("V4");
+            person.Cars[1].Spec!.DriveType.Should().Be("FWD");
+        }
+
+        [Fact]
+        public void Deserialize_YamlWithMissingParameter_ThrowsError()
+        {
+            var yaml = "{ x: 1 }";
+            var sut = new DeserializerBuilder().Build();
+
+            Action action = () => sut.Deserialize<RequiresTwoParameters>(yaml);
+            action.ShouldThrow<YamlException>();
+        }
+
+        [Fact]
+        public void Deserialize_YamlWithOutOfOrderParameters_ReturnsModel()
+        {
+            var yaml = "{ y: 2, x: 1 }";
+            var sut = new DeserializerBuilder().Build();
+
+            var actual = sut.Deserialize<OrderIndependentParams>(yaml);
+            actual.x.Should().Be(1);
+            actual.y.Should().Be(2);
+        }
+
+        [Fact]
+        public void Deserialize_YamlWithExtraParametersAndIgnoreUnmatched_ReturnsModel()
+        {
+            var yaml = "{ y: 2, x: 1, z: 3 }";
+            var sut = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
+
+            var actual = sut.Deserialize<OrderIndependentParams>(yaml);
+            actual.x.Should().Be(1);
+            actual.y.Should().Be(2);
+        }
+
+        [Fact]
+        public void Deserialize_YamlWithExtraParametersAndNoIgnoreUnmatched_ThrowsError()
+        {
+            var yaml = "{ y: 2, x: 1, z: 3 }";
+            var sut = new DeserializerBuilder().Build();
+
+            Action action = () => sut.Deserialize<OrderIndependentParams>(yaml);
+            action.ShouldThrow<YamlException>();
+        }
+
+        [Fact]
+        public void Deserialize_WithConstructorThrowingExceptionWrapsAndDescribes()
+        {
+            var yaml = "{ anInt: 2, aString: TheString }";
+            var sut = new DeserializerBuilder().Build();
+
+            Action action = () => sut.Deserialize<ConstructorThrowsException>(yaml);
+            action.ShouldThrow<YamlException>();
+        }
+
+        [Fact]
+        public void Deserialize_YamlWithOptionalParameterMissing_ReturnsModel()
+        {
+            var yaml = @"
+requiredInt: 42
+";
+            var sut = new DeserializerBuilder().Build();
+
+            var actual = sut.Deserialize<OptionalConstructorParams>(yaml);
+            actual.requiredInt.Should().Be(42);
+            actual.optionalString.Should().Be("default value");
+            actual.optionalFloat.Should().NotHaveValue();
+        }
+
+        [Fact]
+        public void Deserialize_YamlWithOptionalParameterPresent_ReturnsModel()
+        {
+            var yaml = @"
+requiredInt: 42
+optionalString: present
+optionalFloat: 3.14
+";
+            var sut = new DeserializerBuilder().Build();
+
+            var actual = sut.Deserialize<OptionalConstructorParams>(yaml);
+            actual.requiredInt.Should().Be(42);
+            actual.optionalString.Should().Be("present");
+            actual.optionalFloat.Should().Be(3.14f);
+        }
+
+        private class Person
+        {
+            public string Name { get; }
+
+            public DateTime MomentOfBirth { get; }
+
+            public IList<ICar> Cars { get; }
+
+            [YamlConstructor]
+            public Person(string name, DateTime momentOfBirth, IList<ICar> cars)
+            {
+                Name = name;
+                MomentOfBirth = momentOfBirth;
+                Cars = cars;
+            }
+        }
+
+        private class Car : ICar
+        {
+            public string Name { get; }
+
+            public int Year { get; }
+
+            public IModelSpec? Spec { get; }
+
+            [YamlConstructor]
+            public Car(string name, int year, IModelSpec? spec = null)
+            {
+                Name = name;
+                Year = year;
+                Spec = spec;
+            }
+        }
+
+        private interface ICar
+        {
+            string Name { get; }
+
+            int Year { get; }
+            IModelSpec? Spec { get; }
+        }
+
+        private class ModelSpec : IModelSpec
+        {
+            public string EngineType { get; }
+
+            public string DriveType { get; }
+
+            [YamlConstructor]
+            public ModelSpec(string engineType, string driveType)
+            {
+                EngineType = engineType;
+                DriveType = driveType;
+            }
+        }
+
+        private interface IModelSpec
+        {
+            string EngineType { get; }
+
+            string DriveType { get; }
+        }
+
+        private class RequiresTwoParameters
+        {
+            public readonly int x;
+
+            public readonly int y;
+
+            [YamlConstructor]
+            public RequiresTwoParameters(int x, int y)
+            {
+                this.x = x;
+                this.y = y;
+            }
+        }
+
+        private class OrderIndependentParams
+        {
+            public readonly int x;
+
+            public readonly int y;
+
+            [YamlConstructor]
+            public OrderIndependentParams(int x, int y)
+            {
+                this.x = x;
+                this.y = y;
+            }
+        }
+
+        private class OptionalConstructorParams
+        {
+            public readonly int requiredInt;
+
+            public readonly string? optionalString;
+
+            public readonly float? optionalFloat;
+
+            [YamlConstructor]
+            public OptionalConstructorParams(int requiredInt, string? optionalString = "default value", float? optionalFloat = float.NaN)
+            {
+                this.requiredInt = requiredInt;
+                this.optionalString = optionalString;
+                if (optionalFloat.HasValue && !float.IsNaN(optionalFloat.Value))
+                {
+                    this.optionalFloat = optionalFloat;
+                }
+            }
+        }
+
+        private class ConstructorThrowsException
+        {
+            public readonly int anInt;
+
+            public readonly string aString;
+
+            [YamlConstructor]
+            public ConstructorThrowsException(int anInt, string aString)
+            {
+                this.anInt = anInt;
+                this.aString = aString;
+                throw new Exception("Throw to test exception wrapping");
+            }
+        }
+
+    }
+}

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -84,6 +84,7 @@ namespace YamlDotNet.Serialization
                 { typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value) },
                 { typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value) },
                 { typeof(EnumerableNodeDeserializer), _ => new EnumerableNodeDeserializer() },
+                { typeof(AnnotatedConstructorObjectNodeDeserializer), _ => new AnnotatedConstructorObjectNodeDeserializer(ignoreUnmatched) },
                 { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(objectFactory.Value, BuildTypeInspector(), ignoreUnmatched) }
             };
 

--- a/YamlDotNet/Serialization/NodeDeserializers/AnnotatedConstructorObjectNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/AnnotatedConstructorObjectNodeDeserializer.cs
@@ -1,0 +1,167 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization.Utilities;
+
+namespace YamlDotNet.Serialization.NodeDeserializers
+{
+    /// Construct objects when a single constructor is annotated with <see cref="YamlConstructorAttribute"/>.
+    public sealed class AnnotatedConstructorObjectNodeDeserializer : INodeDeserializer
+    {
+        private readonly bool ignoreUnmatched;
+
+        public AnnotatedConstructorObjectNodeDeserializer(bool ignoreUnmatched)
+        {
+            this.ignoreUnmatched = ignoreUnmatched;
+        }
+
+        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        {
+            // Strip off the nullable type, if present. This is needed for nullable structs.
+            var implementationType = Nullable.GetUnderlyingType(expectedType) ?? expectedType;
+
+            // Use reflection to look for annotated constructor to determine whether should continue
+            if (!implementationType.TryGetFirstConstructorWithAttribute<YamlConstructorAttribute>(out var constructorInfo, out _))
+            {
+                value = null;
+                return false;
+            }
+
+            if (!parser.TryConsume<MappingStart>(out _))
+            {
+                value = null;
+                return false;
+            }
+
+            ParameterInfo[] parameters = constructorInfo.GetParameters();
+            var parametersMap = ParseYamlIntoDictionary(parser, nestedObjectDeserializer, implementationType, parameters);
+            var parametersList = LookUpParametersInDictionary(parameters, parametersMap, implementationType);
+
+            // Actually construct while catching and describing any problems
+            try
+            {
+                value = constructorInfo.Invoke(parametersList.ToArray());
+            }
+            catch (Exception ex)
+            {
+                throw new YamlException($"Exception while deserializing {implementationType.FullName} via constructor {constructorInfo} with [{string.Join(", ", parametersList.Select(p => p?.ToString()).ToArray())}]", ex);
+            }
+            return true;
+        }
+
+        /// Parse the YAML using the constructor's parameters to determine expected type based upon name-matching.
+        private Dictionary<string, object?> ParseYamlIntoDictionary(IParser parser, Func<IParser, Type, object?> nestedObjectDeserializer, Type implementationType, ParameterInfo[] parameters)
+        {
+            var parametersMap = new Dictionary<string, object?>();
+            while (!parser.TryConsume<MappingEnd>(out _))
+            {
+                var propertyName = parser.Consume<Scalar>();
+                try
+                {
+                    var parameterInfo = GetParameterInfoByParameterName(propertyName.Value, parameters);
+                    if (parameterInfo == null)
+                    {
+                        if (!ignoreUnmatched)
+                        {
+                            throw new YamlException(propertyName.Start, propertyName.End, $"Constructor for type '{implementationType.FullName}' does not use {propertyName.Value}");
+                        }
+
+                        parser.SkipThisAndNestedEvents();
+                        continue;
+                    }
+
+                    var propertyValue = nestedObjectDeserializer(parser, parameterInfo.ParameterType);
+                    if (propertyValue is IValuePromise propertyValuePromise)
+                    {
+                        propertyValuePromise.ValueAvailable += v =>
+                        {
+                            var convertedValue = TypeConverter.ChangeType(v, parameterInfo.ParameterType);
+                            parametersMap[propertyName.Value] = convertedValue;
+                        };
+                    }
+                    else
+                    {
+                        var convertedValue = TypeConverter.ChangeType(propertyValue, parameterInfo.ParameterType);
+                        parametersMap[propertyName.Value] = convertedValue;
+                    }
+                }
+                catch (SerializationException ex)
+                {
+                    throw new YamlException(propertyName.Start, propertyName.End, ex.Message);
+                }
+                catch (YamlException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new YamlException(propertyName.Start, propertyName.End, "Exception during deserialization", ex);
+                }
+            }
+
+            return parametersMap;
+        }
+
+        private static ParameterInfo? GetParameterInfoByParameterName(string paramName, ParameterInfo[] parameters)
+        {
+            return parameters.FirstOrDefault(p => p.Name == paramName);
+        }
+
+        private List<object?> LookUpParametersInDictionary(ParameterInfo[] parameters, Dictionary<string, object?> parametersMap, Type implementationType)
+        {
+            var parametersList = new List<object?>();
+            foreach (var p in parameters)
+            {
+                if (p.Name == null)
+                {
+                    continue;
+                }
+
+                // Only collect parameters we have
+                if (parametersMap.TryGetValue(p.Name, out var paramValue))
+                {
+                    parametersList.Add(paramValue);
+                }
+                else if (p.IsOptional)
+                {
+                    // Optional parameters should supply `Missing` to use default values if available
+                    // Per https://stackoverflow.com/a/9916197/814523
+                    parametersList.Add(Type.Missing);
+                }
+                else if (!ignoreUnmatched)
+                {
+                    throw new YamlException($"Value for parameter '{p.Name}' not found in deserialized data for type '{implementationType.FullName}'.");
+                }
+                // else try ignoring and see what happens.
+            }
+
+            return parametersList;
+        }
+
+    }
+}

--- a/YamlDotNet/Serialization/Utilities/ReflectionUtility.cs
+++ b/YamlDotNet/Serialization/Utilities/ReflectionUtility.cs
@@ -21,6 +21,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace YamlDotNet.Serialization.Utilities
 {
@@ -50,5 +52,35 @@ namespace YamlDotNet.Serialization.Utilities
                 yield return implementedInterface;
             }
         }
+
+        public static T? GetCustomAttribute<T>(this ConstructorInfo constructorInfo) where T : Attribute
+        {
+            return (T?)constructorInfo.GetCustomAttributes(typeof(T), false).FirstOrDefault();
+        }
+
+        public static bool TryGetFirstConstructorWithAttribute<T>(
+            this Type type,
+            out ConstructorInfo constructorInfo,
+            out T attribute
+        )
+            where T : Attribute
+        {
+            var constructors = type.GetConstructors();
+            foreach (var constructor in constructors)
+            {
+                var attr = constructor.GetCustomAttribute<T>();
+                if (null != attr)
+                {
+                    attribute = attr;
+                    constructorInfo = constructor;
+                    return true;
+                }
+            }
+
+            constructorInfo = null!;
+            attribute = null!;
+            return false;
+        }
+
     }
 }

--- a/YamlDotNet/Serialization/YamlConstructorAttribute.cs
+++ b/YamlDotNet/Serialization/YamlConstructorAttribute.cs
@@ -1,0 +1,34 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+
+namespace YamlDotNet.Serialization
+{
+    /// <summary>
+    /// Indicates that the annotated constructor will be use for deserialization.
+    /// The deserialized values will be passed as the constructor's parameters.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false)]
+    public sealed class YamlConstructorAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
Introduce support for deserializing via annotated constructor call to allow read-only fields and properties.

Annotate a constructor with the new `YamlConstructorAttribute` and it will be used in preference to property and field setting.

Unit test added.  It's largely copied from `ObjectNodeDeserializer` plus some tests to prove certain desirable behaviours.  It's showing 81% coverage of the new code `AnnotatedConstructorObjectNodeDeserializer`.  Missed lines are all corner cases (errors, the `IValuePromise` bits and non-use code-paths).