### PR TITLE
Fix #638: Parser hangs on stream of `%Y`

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -217,6 +217,23 @@ namespace YamlDotNet.Test.Serialization
         }
 
         [Fact]
+        public void DeserializeIncompleteDirective()
+        {
+            Action action = () => Deserializer.Deserialize<object>(UsingReaderFor("%Y"));
+
+            action.ShouldThrow<SyntaxErrorException>()
+                .WithMessage("While scanning a directive, found unexpected end of stream.");
+        }
+
+        [Fact]
+        public void DeserializeSkippedReservedDirective()
+        {
+            Action action = () => Deserializer.Deserialize<object>(UsingReaderFor("%Y "));
+
+            action.ShouldNotThrow();
+        }
+
+        [Fact]
         public void DeserializeCustomTags()
         {
             var stream = Yaml.ReaderFrom("tags.yaml");

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -796,7 +796,7 @@ namespace YamlDotNet.Core
 
                 default:
                     // warning: skipping reserved directive line
-                    while (!analyzer.Check('#') && !analyzer.IsBreak())
+                    while (!analyzer.EndOfInput && !analyzer.Check('#') && !analyzer.IsBreak())
                     {
                         Skip();
                     }
@@ -2282,6 +2282,13 @@ namespace YamlDotNet.Core
             if (name.Length == 0)
             {
                 throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a directive, could not find expected directive name.");
+            }
+
+            // Check for end of stream
+
+            if (analyzer.EndOfInput)
+            {
+                throw new SyntaxErrorException(start, cursor.Mark(), "While scanning a directive, found unexpected end of stream.");
             }
 
             // Check for an blank character after the name.


### PR DESCRIPTION
1. `while` loop below is endless - analyzer uses buffer, that don't care about overflows and ranges.
```c#
while (!analyzer.Check('#') && !analyzer.IsBreak())
{
    Skip();
}
```
So check `!analyzer.EndOfInput` was added.
2. Another `analyzer.EndOfInput` check was added to detect unexpected end of stream as soon as possible for directive parsing case.