### PR TITLE
Add basic support to populate pre-existing C# objects when deserializing

### DIFF
--- a/YamlDotNet.Samples/ValidatingDuringDeserialization.cs
+++ b/YamlDotNet.Samples/ValidatingDuringDeserialization.cs
@@ -43,9 +43,9 @@ namespace YamlDotNet.Samples
                 this.nodeDeserializer = nodeDeserializer;
             }
 
-            public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object> nestedObjectDeserializer, out object value)
+            public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object, object> nestedObjectDeserializer, out object value, object result)
             {
-                if (nodeDeserializer.Deserialize(parser, expectedType, nestedObjectDeserializer, out value))
+                if (nodeDeserializer.Deserialize(parser, expectedType, nestedObjectDeserializer, out value, result))
                 {
                     var context = new ValidationContext(value, null, null);
                     Validator.ValidateObject(value, context, true);

--- a/YamlDotNet.Test/Serialization/PopulateObjectTests.cs
+++ b/YamlDotNet.Test/Serialization/PopulateObjectTests.cs
@@ -425,6 +425,93 @@ three: 30";
                 { "three", 30 }
             });
         }
+        #endregion
+
+        #region Edge cases
+        class GenericListButNotNonGenericList<T> : IList<T>
+        {
+            public T this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public int Count => throw new NotImplementedException();
+
+            public bool IsReadOnly => throw new NotImplementedException();
+
+            public void Add(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Contains(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            public int IndexOf(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Insert(int index, T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void RemoveAt(int index)
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public void PopulateList_WithTypeNotSupportedForPopulating_CreateNew()
+        {
+            var list = new GenericListButNotNonGenericList<string>();
+
+            Action action = () => DeserializerBuilder
+                .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.CreateNew)
+                .Build()
+                .PopulateObject("- one", list);
+
+            action.ShouldThrow<YamlException>().WithInnerException<NotImplementedException>();
+        }
+
+        [Fact]
+        public void PopulateList_WithTypeNotSupportedForPopulating_AddItems()
+        {
+            var list = new GenericListButNotNonGenericList<string>();
+
+            Action action = () => DeserializerBuilder
+                .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.AddItems)
+                .Build()
+                .PopulateObject("- one", list);
+
+            action.ShouldThrow<YamlException>().WithInnerException<NotSupportedException>();
+        }
 
         class GenericDictionaryButNotNonGenericDictionary<TKey, TValue> : IDictionary<TKey, TValue>
         {

--- a/YamlDotNet.Test/Serialization/PopulateObjectTests.cs
+++ b/YamlDotNet.Test/Serialization/PopulateObjectTests.cs
@@ -1,0 +1,526 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.Test.Serialization
+{
+    public class PopulateObjectTests : SerializationTestHelper
+    {
+        #region Simple objects
+
+        class SimpleClass
+        {
+            public int Int { get; set; }
+            public string String { get; set; }
+        }
+
+        class SimpleParentClass
+        {
+            public int Int { get; set; }
+            public string String { get; set; }
+            public SimpleClass Child { get; set; }
+        }
+
+        [Fact]
+        public void PopulateSimpleObject()
+        {
+            var target = new SimpleClass { Int = 1, String = "one" };
+
+            var result = Deserializer.PopulateObject(@"Int: 2", target);
+
+            Assert.Same(result, target);
+
+            result.Int.Should().Be(2);
+            result.String.Should().Be("one");
+        }
+
+        [Fact]
+        public void PopulateSimpleObjectGraph()
+        {
+            var child = new SimpleClass { Int = 1, String = "one" };
+            var target = new SimpleParentClass()
+            {
+                Int = 10,
+                String = "ten",
+                Child = child
+            };
+
+            var yaml = @"
+Int: 20
+Child:
+    String: two";
+
+            var result = Deserializer.PopulateObject(yaml, target);
+
+            result.Int.Should().Be(20);
+
+            Assert.Same(result.Child, child);
+
+            result.Child.Int.Should().Be(1);
+            result.Child.String.Should().Be("two");
+        }
+        #endregion
+
+        #region Simple structs
+        struct SimpleStruct
+        {
+            public int Int { get; set; }
+            public string String { get; set; }
+        }
+
+        [Fact]
+        public void PopulateSimpleStruct()
+        {
+            var target = new SimpleStruct { Int = 1, String = "one" };
+
+            var result = Deserializer.PopulateObject(@"Int: 2", target);
+
+            result.Int.Should().Be(2);
+            result.String.Should().Be("one");
+        }
+        #endregion
+
+        #region Populate collections
+        #region Populate collections: Arrays of value types
+        class IntArrayContainer
+        {
+            public int[] Ints { get; set; }
+        }
+
+        [Fact]
+        public void PopulateArray_OfValueType_AsNestedNode_CreateNew()
+        {
+            var intArray = new int[] { 1, 2 };
+            var container = new IntArrayContainer { Ints = intArray };
+
+            var yaml = @"
+Ints:
+- 10";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.CreateNew)
+                .Build()
+                .PopulateObject(yaml, container);
+
+            // original array should remain unchanged
+            Assert.NotSame(result.Ints, intArray);
+            intArray.ShouldBeEquivalentTo(new[] { 1, 2 });
+
+            result.Ints.ShouldBeEquivalentTo(new[] { 10 });
+        }
+
+        [Fact]
+        public void PopulateArray_OfValueType_AsNestedNode_FillExisting()
+        {
+            var intArray = new int[] { 1, 2 };
+            var container = new IntArrayContainer { Ints = intArray };
+
+            var yaml = @"
+Ints:
+- 10";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.FillExisting)
+                .Build()
+                .PopulateObject(yaml, container);
+
+            Assert.Same(result.Ints, intArray);
+
+            result.Ints.ShouldBeEquivalentTo(new[] { 10, 2 });
+        }
+
+        [Fact]
+        public void PopulateArray_OfValueType_AsNestedNode_FillExisting_WithInsufficientSize()
+        {
+            var intArray = new int[] { 1, 2 };
+            var container = new IntArrayContainer { Ints = intArray };
+
+            var yaml = @"
+Ints:
+- 10
+- 20
+- 30";
+
+            Action action = () => DeserializerBuilder
+                  .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.FillExisting)
+                  .Build()
+                  .PopulateObject(yaml, container);
+
+            action.ShouldThrow<YamlException>().Where(ex => ex.Message.Contains("exceed size"));
+        }
+
+        [Fact]
+        public void PopulateArray_OfValueType_AsRootNode_CreateNew()
+        {
+            var intArray = new int[] { 1, 2 };
+
+            var yaml = @"- 10";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.CreateNew)
+                .Build()
+                .PopulateObject(yaml, intArray);
+
+            // original array should remain unchanged
+            Assert.NotSame(result, intArray);
+            intArray.ShouldAllBeEquivalentTo(new[] { 1, 2 });
+
+            result.ShouldBeEquivalentTo(new[] { 10 });
+        }
+
+        [Fact]
+        public void PopulateArray_OfValueType_AsRootNode_FillExisting()
+        {
+            var intArray = new int[] { 1, 2 };
+
+            var yaml = @"- 10";
+
+            var result = DeserializerBuilder
+                 .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.FillExisting)
+                 .Build()
+                 .PopulateObject(yaml, intArray);
+
+            Assert.Same(result, intArray);
+
+            result.ShouldBeEquivalentTo(new[] { 10, 2 });
+        }
+        #endregion
+
+        #region Populate collections: Collections (lists) of value types
+        public class IntGenericCollectionContainer
+        {
+            public IList<int> Ints { get; set; }
+        }
+
+        [Fact]
+        public void PopulateCollection_OfValueType_AsNestedNode_CreateNew()
+        {
+            var intCollection = new List<int> { 1, 2 };
+            var container = new IntGenericCollectionContainer { Ints = intCollection };
+
+            var yaml = @"
+Ints:
+- 10";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(collectionStrategy: PreexistingCollectionPopulationStrategy.CreateNew)
+                .Build()
+                .PopulateObject(yaml, container);
+
+            Assert.NotSame(result.Ints, intCollection);
+            result.Ints.ShouldBeEquivalentTo(new[] { 10 });
+        }
+
+        [Fact]
+        public void PopulateCollection_OfValueType_AsNestedNode_AddItems()
+        {
+            var intCollection = new List<int> { 1, 2 };
+            var container = new IntGenericCollectionContainer { Ints = intCollection };
+
+            var yaml = @"
+Ints:
+- 10";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(collectionStrategy: PreexistingCollectionPopulationStrategy.AddItems)
+                .Build()
+                .PopulateObject(yaml, container);
+
+            Assert.Same(result.Ints, intCollection);
+            result.Ints.ShouldBeEquivalentTo(new[] { 1, 2, 10 });
+        }
+
+        [Fact]
+        public void PopulateCollection_OfValueType_AsRootNode_CreateNew()
+        {
+            var intCollection = new List<int> { 1, 2 };
+
+            var yaml = @"- 10";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(collectionStrategy: PreexistingCollectionPopulationStrategy.CreateNew)
+                .Build()
+                .PopulateObject(yaml, intCollection);
+
+            Assert.NotSame(result, intCollection);
+            result.ShouldBeEquivalentTo(new[] { 10 });
+        }
+
+        [Fact]
+        public void PopulateCollection_OfValueType_AsRootNode_AddItems()
+        {
+            var intCollection = new List<int> { 1, 2 };
+
+            var yaml = @"- 10";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(collectionStrategy: PreexistingCollectionPopulationStrategy.AddItems)
+                .Build()
+                .PopulateObject(yaml, intCollection);
+
+            Assert.Same(result, intCollection);
+            result.ShouldBeEquivalentTo(new[] { 1, 2, 10 });
+        }
+        #endregion
+
+        #region Populate collections: Dictionaries of value types
+        class StringIntDictionaryContainer
+        {
+            public Dictionary<string, int> StringInts { get; set; }
+        }
+
+        [Fact]
+        public void PopulateDictionary_OfValueTypes_AsNestedNode_CreateNew()
+        {
+            var stringInts = new Dictionary<string, int>
+            {
+                { "one", 1 },
+                { "two", 2 },
+            };
+            var container = new StringIntDictionaryContainer { StringInts = stringInts };
+
+            var yaml = @"
+StringInts:
+    one: 10
+    three: 30";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.CreateNew)
+                .Build()
+                .PopulateObject(yaml, container);
+
+            Assert.NotSame(result.StringInts, stringInts);
+            container.StringInts.ShouldBeEquivalentTo(new Dictionary<string, int> {
+                { "one", 10 },
+                { "three", 30 }
+            });
+        }
+
+        [Fact]
+        public void PopulateDictionary_OfValueTypes_AsNestedNode_AddItemsReplaceExistingKeys()
+        {
+            var stringInts = new Dictionary<string, int>
+            {
+                { "one", 1 },
+                { "two", 2 },
+            };
+            var container = new StringIntDictionaryContainer { StringInts = stringInts };
+
+            var yaml = @"
+StringInts:
+    one: 10
+    three: 30";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.AddItemsReplaceExistingKeys)
+                .Build()
+                .PopulateObject(yaml, container);
+
+            Assert.Same(result.StringInts, stringInts);
+            container.StringInts.ShouldBeEquivalentTo(new Dictionary<string, int> {
+                { "one", 10 },
+                { "two", 2 },
+                { "three", 30 }
+            });
+        }
+
+        [Fact]
+        public void PopulateDictionary_OfValueTypes_AsNestedNode_AddItemsThrowOnExistingKeys()
+        {
+            var stringInts = new Dictionary<string, int>
+            {
+                { "one", 1 },
+                { "two", 2 },
+            };
+            var container = new StringIntDictionaryContainer { StringInts = stringInts };
+
+            var yaml = @"
+StringInts:
+    one: 10
+    three: 30";
+
+            Action action = () => DeserializerBuilder
+                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.AddItemsThrowOnExistingKeys)
+                .Build()
+                .PopulateObject(yaml, container);
+
+            action.ShouldThrow<YamlException>().WithInnerException<ArgumentException>().Where(ex => ex.InnerException.Message.Contains("same key"));
+        }
+
+
+        [Fact]
+        public void PopulateDictionary_OfValueTypes_AsRootNode_CreateNew()
+        {
+            var stringInts = new Dictionary<string, int>
+            {
+                { "one", 1 },
+                { "two", 2 },
+            };
+
+            var yaml = @"
+one: 10
+three: 30";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.CreateNew)
+                .Build()
+                .PopulateObject(yaml, stringInts);
+
+            Assert.NotSame(result, stringInts);
+            result.ShouldBeEquivalentTo(new Dictionary<string, int> {
+                { "one", 10 },
+                { "three", 30 }
+            });
+        }
+
+        [Fact]
+        public void PopulateDictionary_OfValueTypes_AsRootNode_AddItemsReplaceExistingKeys()
+        {
+            var stringInts = new Dictionary<string, int>
+            {
+                { "one", 1 },
+                { "two", 2 },
+            };
+
+            var yaml = @"
+one: 10
+three: 30";
+
+            var result = DeserializerBuilder
+                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.AddItemsReplaceExistingKeys)
+                .Build()
+                .PopulateObject(yaml, stringInts);
+
+            Assert.Same(result, stringInts);
+            result.ShouldBeEquivalentTo(new Dictionary<string, int> {
+                { "one", 10 },
+                { "two", 2 },
+                { "three", 30 }
+            });
+        }
+
+        class GenericDictionaryButNotNonGenericDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+        {
+            public TValue this[TKey key] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public ICollection<TKey> Keys => throw new NotImplementedException();
+
+            public ICollection<TValue> Values => throw new NotImplementedException();
+
+            public int Count => throw new NotImplementedException();
+
+            public bool IsReadOnly => throw new NotImplementedException();
+
+            public void Add(TKey key, TValue value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Add(KeyValuePair<TKey, TValue> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Contains(KeyValuePair<TKey, TValue> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool ContainsKey(TKey key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(TKey key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(KeyValuePair<TKey, TValue> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public void PopulateDictionary_WithTypeNotSupportingPopulation_CreateNew()
+        {
+            var dictionary = new GenericDictionaryButNotNonGenericDictionary<string, string>();
+
+            Action action = () => DeserializerBuilder
+                    .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.CreateNew)
+                    .Build()
+                    .PopulateObject("one: ten", dictionary);
+
+            action.ShouldThrow<YamlException>().WithInnerException<NotImplementedException>();
+        }
+
+        [Fact]
+        public void PopulateDictionary_WithTypeNotSupportingPopulation_AddItemsReplaceExistingKeys()
+        {
+            var dictionary = new GenericDictionaryButNotNonGenericDictionary<string, string>();
+
+            Action action = () => DeserializerBuilder
+                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.AddItemsReplaceExistingKeys)
+                .Build()
+                .PopulateObject("one: ten", dictionary);
+
+            action.ShouldThrow<YamlException>().WithInnerException<NotSupportedException>().Where(ex => ex.InnerException.Message.Contains("Types implementing generic interface")); ;
+        }
+        #endregion
+        #endregion
+    }
+}

--- a/YamlDotNet.Test/Serialization/PopulateObjectTests.cs
+++ b/YamlDotNet.Test/Serialization/PopulateObjectTests.cs
@@ -126,7 +126,7 @@ Ints:
 - 10";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.CreateNew)
+                .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.CreateNew)
                 .Build()
                 .PopulateObject(yaml, container);
 
@@ -148,7 +148,7 @@ Ints:
 - 10";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.FillExisting)
+                .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.FillExisting)
                 .Build()
                 .PopulateObject(yaml, container);
 
@@ -170,7 +170,7 @@ Ints:
 - 30";
 
             Action action = () => DeserializerBuilder
-                  .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.FillExisting)
+                  .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.FillExisting)
                   .Build()
                   .PopulateObject(yaml, container);
 
@@ -185,7 +185,7 @@ Ints:
             var yaml = @"- 10";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.CreateNew)
+                .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.CreateNew)
                 .Build()
                 .PopulateObject(yaml, intArray);
 
@@ -204,7 +204,7 @@ Ints:
             var yaml = @"- 10";
 
             var result = DeserializerBuilder
-                 .WithCollectionPopulationOptions(arrayStrategy: PreexistingArrayPopulationStrategy.FillExisting)
+                 .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.FillExisting)
                  .Build()
                  .PopulateObject(yaml, intArray);
 
@@ -231,7 +231,7 @@ Ints:
 - 10";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(collectionStrategy: PreexistingCollectionPopulationStrategy.CreateNew)
+                .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.CreateNew)
                 .Build()
                 .PopulateObject(yaml, container);
 
@@ -250,7 +250,7 @@ Ints:
 - 10";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(collectionStrategy: PreexistingCollectionPopulationStrategy.AddItems)
+                .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.AddItems)
                 .Build()
                 .PopulateObject(yaml, container);
 
@@ -266,7 +266,7 @@ Ints:
             var yaml = @"- 10";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(collectionStrategy: PreexistingCollectionPopulationStrategy.CreateNew)
+                .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.CreateNew)
                 .Build()
                 .PopulateObject(yaml, intCollection);
 
@@ -282,7 +282,7 @@ Ints:
             var yaml = @"- 10";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(collectionStrategy: PreexistingCollectionPopulationStrategy.AddItems)
+                .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.AddItems)
                 .Build()
                 .PopulateObject(yaml, intCollection);
 
@@ -313,7 +313,7 @@ StringInts:
     three: 30";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.CreateNew)
+                .WithPopulatingOptions(dictionaryStrategy: DictionaryPopulatingStrategy.CreateNew)
                 .Build()
                 .PopulateObject(yaml, container);
 
@@ -340,7 +340,7 @@ StringInts:
     three: 30";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.AddItemsReplaceExistingKeys)
+                .WithPopulatingOptions(dictionaryStrategy: DictionaryPopulatingStrategy.AddItemsReplaceExistingKeys)
                 .Build()
                 .PopulateObject(yaml, container);
 
@@ -368,13 +368,12 @@ StringInts:
     three: 30";
 
             Action action = () => DeserializerBuilder
-                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.AddItemsThrowOnExistingKeys)
+                .WithPopulatingOptions(dictionaryStrategy: DictionaryPopulatingStrategy.AddItemsThrowOnExistingKeys)
                 .Build()
                 .PopulateObject(yaml, container);
 
             action.ShouldThrow<YamlException>().WithInnerException<ArgumentException>().Where(ex => ex.InnerException.Message.Contains("same key"));
         }
-
 
         [Fact]
         public void PopulateDictionary_OfValueTypes_AsRootNode_CreateNew()
@@ -390,7 +389,7 @@ one: 10
 three: 30";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.CreateNew)
+                .WithPopulatingOptions(dictionaryStrategy: DictionaryPopulatingStrategy.CreateNew)
                 .Build()
                 .PopulateObject(yaml, stringInts);
 
@@ -415,7 +414,7 @@ one: 10
 three: 30";
 
             var result = DeserializerBuilder
-                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.AddItemsReplaceExistingKeys)
+                .WithPopulatingOptions(dictionaryStrategy: DictionaryPopulatingStrategy.AddItemsReplaceExistingKeys)
                 .Build()
                 .PopulateObject(yaml, stringInts);
 
@@ -496,12 +495,12 @@ three: 30";
         }
 
         [Fact]
-        public void PopulateDictionary_WithTypeNotSupportingPopulation_CreateNew()
+        public void PopulateDictionary_WithTypeNotSupportedForPopulating_CreateNew()
         {
             var dictionary = new GenericDictionaryButNotNonGenericDictionary<string, string>();
 
             Action action = () => DeserializerBuilder
-                    .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.CreateNew)
+                    .WithPopulatingOptions(dictionaryStrategy: DictionaryPopulatingStrategy.CreateNew)
                     .Build()
                     .PopulateObject("one: ten", dictionary);
 
@@ -509,16 +508,16 @@ three: 30";
         }
 
         [Fact]
-        public void PopulateDictionary_WithTypeNotSupportingPopulation_AddItemsReplaceExistingKeys()
+        public void PopulateDictionary_WithTypeNotSupportedForPopulating_AddItemsReplaceExistingKeys()
         {
             var dictionary = new GenericDictionaryButNotNonGenericDictionary<string, string>();
 
             Action action = () => DeserializerBuilder
-                .WithCollectionPopulationOptions(dictionaryStrategy: PreexistingDictionaryPopulationStrategy.AddItemsReplaceExistingKeys)
+                .WithPopulatingOptions(dictionaryStrategy: DictionaryPopulatingStrategy.AddItemsReplaceExistingKeys)
                 .Build()
                 .PopulateObject("one: ten", dictionary);
 
-            action.ShouldThrow<YamlException>().WithInnerException<NotSupportedException>().Where(ex => ex.InnerException.Message.Contains("Types implementing generic interface")); ;
+            action.ShouldThrow<YamlException>().WithInnerException<NotSupportedException>();
         }
         #endregion
         #endregion

--- a/YamlDotNet.Test/Serialization/PopulateObjectTests.cs
+++ b/YamlDotNet.Test/Serialization/PopulateObjectTests.cs
@@ -23,8 +23,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Text;
 using FluentAssertions;
 using Xunit;
 using YamlDotNet.Core;
@@ -109,6 +107,304 @@ Child:
         #endregion
 
         #region Populate collections
+        #region Populate collections: Reference types
+        [Fact]
+        public void PopulateArray_OfReferenceType_DeserializeSameSize()
+        {
+            var array = new[]
+            {
+                new SimpleClass { Int = 1, String = "one" },
+                new SimpleClass { Int = 2, String = "two" }
+            };
+
+            var firstItem = array[0];
+
+            var yaml = @"
+-
+    Int: 10
+-
+    String: TWO
+";
+
+            var result = DeserializerBuilder
+               .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.PopulateItems)
+               .Build()
+               .PopulateObject(yaml, array);
+
+            Assert.Same(result, array);
+            Assert.Same(result[0], firstItem);
+
+            result.Length.Should().Be(2);
+
+            result[0].Int.Should().Be(10);
+            result[0].String.Should().Be("one");
+
+            result[1].Int.Should().Be(2);
+            result[1].String.Should().Be("TWO");
+        }
+
+        [Fact]
+        public void PopulateArray_OfReferenceType_DeserializeSmallerSize()
+        {
+            var array = new[]
+            {
+                new SimpleClass { Int = 1, String = "one" },
+                new SimpleClass { Int = 2, String = "two" }
+            };
+
+            var firstItem = array[0];
+
+            var yaml = @"
+-
+    Int: 10
+";
+
+            var result = DeserializerBuilder
+               .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.PopulateItems)
+               .Build()
+               .PopulateObject(yaml, array);
+
+            Assert.Same(result, array);
+            Assert.Same(result[0], firstItem);
+
+            result.Length.Should().Be(2);
+
+            result[0].Int.Should().Be(10);
+            result[0].String.Should().Be("one");
+
+            result[1].Int.Should().Be(2);
+            result[1].String.Should().Be("two");
+        }
+
+        [Fact]
+        public void PopulateArray_OfReferenceType_DeserializeBiggerSize()
+        {
+            var array = new[]
+            {
+                new SimpleClass { Int = 1, String = "one" },
+                new SimpleClass { Int = 2, String = "two" }
+            };
+
+            var firstItem = array[0];
+
+            var yaml = @"
+-
+    Int: 10
+-
+    String: TWO
+-
+    Int: 30
+    String: THREE
+";
+
+            var result = DeserializerBuilder
+               .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.PopulateItems)
+               .Build()
+               .PopulateObject(yaml, array);
+
+            Assert.NotSame(result, array);
+            Assert.Same(result[0], firstItem);
+
+            result.Length.Should().Be(3);
+
+            result[0].Int.Should().Be(10);
+            result[0].String.Should().Be("one");
+
+            result[1].Int.Should().Be(2);
+            result[1].String.Should().Be("two");
+
+            result[2].Int.Should().Be(30);
+            result[2].String.Should().Be("THREE");
+        }
+
+        [Fact]
+        public void PopulateArray_OfReferenceType_DeserializeBiggerSize_PopulateItemsAllowGrowingArray()
+        {
+            var array = new[]
+            {
+                new SimpleClass { Int = 1, String = "one" },
+                new SimpleClass { Int = 2, String = "two" }
+            };
+
+            var firstItem = array[0];
+
+            var yaml = @"
+-
+    Int: 10
+-
+    String: TWO
+-
+    Int: 30
+    String: THREE
+";
+
+            var result = DeserializerBuilder
+               .WithPopulatingOptions(arrayStrategy: ArrayPopulatingStrategy.PopulateItemsAllowGrowingArray)
+               .Build()
+               .PopulateObject(yaml, array);
+
+            Assert.NotSame(result, array);
+            Assert.Same(result[0], firstItem);
+
+            result.Length.Should().Be(3);
+
+            result[0].Int.Should().Be(10);
+            result[0].String.Should().Be("one");
+
+            result[1].Int.Should().Be(2);
+            result[1].String.Should().Be("TWO");
+
+            result[2].Int.Should().Be(30);
+            result[2].String.Should().Be("THREE");
+        }
+
+        [Fact]
+        public void PopulateList_OfReferenceType_DeserializeBiggerSize_PopulateOrAddItems()
+        {
+            var list = new List<SimpleClass>(new[]
+            {
+                new SimpleClass { Int = 1, String = "one" },
+                new SimpleClass { Int = 2, String = "two" }
+            });
+
+            var firstItem = list[0];
+
+            var yaml = @"
+-
+    Int: 10
+-
+    String: TWO
+-
+    Int: 30
+    String: THREE
+";
+
+            var result = DeserializerBuilder
+               .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.PopulateOrAddItems)
+               .Build()
+               .PopulateObject(yaml, list);
+
+            Assert.Same(result, list);
+            Assert.Same(result[0], firstItem);
+
+            result.Count.Should().Be(3);
+
+            result[0].Int.Should().Be(10);
+            result[0].String.Should().Be("one");
+
+            result[1].Int.Should().Be(2);
+            result[1].String.Should().Be("TWO");
+
+            result[2].Int.Should().Be(30);
+            result[2].String.Should().Be("THREE");
+        }
+
+        [Fact]
+        public void PopulateList_OfReferenceType_DeserializeEqualSize_PopulateOrAddItems()
+        {
+            var list = new List<SimpleClass>(new[]
+            {
+                new SimpleClass { Int = 1, String = "one" },
+                new SimpleClass { Int = 2, String = "two" }
+            });
+
+            var firstItem = list[0];
+
+            var yaml = @"
+-
+    Int: 10
+-
+    String: TWO
+";
+
+            var result = DeserializerBuilder
+               .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.PopulateOrAddItems)
+               .Build()
+               .PopulateObject(yaml, list);
+
+            Assert.Same(result, list);
+            Assert.Same(result[0], firstItem);
+
+            result.Count.Should().Be(2);
+
+            result[0].Int.Should().Be(10);
+            result[0].String.Should().Be("one");
+
+            result[1].Int.Should().Be(2);
+            result[1].String.Should().Be("TWO");
+        }
+
+        [Fact]
+        public void PopulateList_OfReferenceType_DeserializeSmallerSize_PopulateOrAddItems()
+        {
+            var list = new List<SimpleClass>(new[]
+            {
+                new SimpleClass { Int = 1, String = "one" },
+                new SimpleClass { Int = 2, String = "two" }
+            });
+
+            var firstItem = list[0];
+
+            var yaml = @"
+-
+    Int: 10
+";
+
+            var result = DeserializerBuilder
+               .WithPopulatingOptions(collectionStrategy: CollectionPopulatingStrategy.PopulateOrAddItems)
+               .Build()
+               .PopulateObject(yaml, list);
+
+            Assert.Same(result, list);
+            Assert.Same(result[0], firstItem);
+
+            result.Count.Should().Be(2);
+
+            result[0].Int.Should().Be(10);
+            result[0].String.Should().Be("one");
+
+            result[1].Int.Should().Be(2);
+            result[1].String.Should().Be("two");
+        }
+        /*
+        [Fact]
+        public void PopulateReferenceTypeCollections()
+        {
+            var listOfDicts = new Dictionary<string, Dictionary<string, string>>()
+            {
+                { "A",  new Dictionary<string, string>()
+                {
+                    { "A1", "1" },
+                    { "A2", "2" }
+                }
+                }
+            };
+
+            var a = listOfDicts["A"];
+
+            var yaml = @"
+A:
+    A1: 10
+    C1: 30
+B:
+    B1: 100
+";
+
+            var result = DeserializerBuilder
+                .WithPopulatingOptions(ArrayPopulatingStrategy.PopulateItems)
+                .Build()
+                .PopulateObject(yaml, listOfDicts);
+
+            Assert.Same(result, listOfDicts);
+            Assert.Same(result["A"], a);
+            result["A"].Count.Should().Be(3);
+            result["A"]["A1"].Should().Be("10");
+            result.Count.Should().Be(2);
+            result["B"]["B1"].Should().Be("100");
+        }
+        */
+        #endregion
+
         #region Populate collections: Arrays of value types
         class IntArrayContainer
         {

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -20,6 +20,7 @@
 // SOFTWARE.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization.NamingConventions;
@@ -360,6 +361,25 @@ namespace YamlDotNet.Serialization
         public DeserializerBuilder IgnoreUnmatchedProperties()
         {
             ignoreUnmatched = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures how pre-existing collections are handled when using <see cref="Deserializer.PopulateObject{T}(IParser, T)"/> and overloads.
+        /// </summary>
+        /// <param name="arrayStrategy"></param>
+        /// <param name="collectionStrategy"></param>
+        /// <param name="dictionaryStrategy"></param>
+        /// <returns></returns>
+        public DeserializerBuilder WithCollectionPopulationOptions(
+            PreexistingArrayPopulationStrategy arrayStrategy = PreexistingArrayPopulationStrategy.CreateNew,
+            PreexistingCollectionPopulationStrategy collectionStrategy = PreexistingCollectionPopulationStrategy.CreateNew,
+            PreexistingDictionaryPopulationStrategy dictionaryStrategy = PreexistingDictionaryPopulationStrategy.CreateNew)
+        {
+            nodeDeserializerFactories.Replace(typeof(ArrayNodeDeserializer), _ => new ArrayNodeDeserializer(arrayStrategy));
+            nodeDeserializerFactories.Replace(typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value, dictionaryStrategy));
+            nodeDeserializerFactories.Replace(typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value, collectionStrategy));
+
             return this;
         }
 

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -371,10 +371,10 @@ namespace YamlDotNet.Serialization
         /// <param name="collectionStrategy"></param>
         /// <param name="dictionaryStrategy"></param>
         /// <returns></returns>
-        public DeserializerBuilder WithCollectionPopulationOptions(
-            PreexistingArrayPopulationStrategy arrayStrategy = PreexistingArrayPopulationStrategy.CreateNew,
-            PreexistingCollectionPopulationStrategy collectionStrategy = PreexistingCollectionPopulationStrategy.CreateNew,
-            PreexistingDictionaryPopulationStrategy dictionaryStrategy = PreexistingDictionaryPopulationStrategy.CreateNew)
+        public DeserializerBuilder WithPopulatingOptions(
+            ArrayPopulatingStrategy arrayStrategy = ArrayPopulatingStrategy.CreateNew,
+            CollectionPopulatingStrategy collectionStrategy = CollectionPopulatingStrategy.CreateNew,
+            DictionaryPopulatingStrategy dictionaryStrategy = DictionaryPopulatingStrategy.CreateNew)
         {
             nodeDeserializerFactories.Replace(typeof(ArrayNodeDeserializer), _ => new ArrayNodeDeserializer(arrayStrategy));
             nodeDeserializerFactories.Replace(typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value, dictionaryStrategy));

--- a/YamlDotNet/Serialization/IDeserializer.cs
+++ b/YamlDotNet/Serialization/IDeserializer.cs
@@ -48,7 +48,7 @@ namespace YamlDotNet.Serialization
 
         /// <summary>
         /// Populates a pre-existing object. Values of fields/properties missing in the given YAML remain unchanged.
-        /// Use <see cref="DeserializerBuilder.WithCollectionPopulationOptions(PreexistingArrayPopulationStrategy, PreexistingCollectionPopulationStrategy, PreexistingDictionaryPopulationStrategy)"/> to configure how pre-existing collections are handled.
+        /// Use <see cref="DeserializerBuilder.WithPopulatingOptions(ArrayPopulatingStrategy, CollectionPopulatingStrategy, DictionaryPopulatingStrategy)"/> to configure how pre-existing collections are handled.
         /// </summary>
         /// <typeparam name="T">The type of the target object.</typeparam>
         /// <param name="parser">The <see cref="IParser" /> from where to deserialize the object.</param>

--- a/YamlDotNet/Serialization/IDeserializer.cs
+++ b/YamlDotNet/Serialization/IDeserializer.cs
@@ -42,5 +42,18 @@ namespace YamlDotNet.Serialization
         /// <param name="type">The static type of the object to deserialize.</param>
         /// <returns>Returns the deserialized object.</returns>
         object? Deserialize(IParser parser, Type type);
+
+        T PopulateObject<T>(string input, T target);
+        T PopulateObject<T>(TextReader input, T target);
+
+        /// <summary>
+        /// Populates a pre-existing object. Values of fields/properties missing in the given YAML remain unchanged.
+        /// Use <see cref="DeserializerBuilder.WithCollectionPopulationOptions(PreexistingArrayPopulationStrategy, PreexistingCollectionPopulationStrategy, PreexistingDictionaryPopulationStrategy)"/> to configure how pre-existing collections are handled.
+        /// </summary>
+        /// <typeparam name="T">The type of the target object.</typeparam>
+        /// <param name="parser">The <see cref="IParser" /> from where to deserialize the object.</param>
+        /// <param name="target">The target object to be populated.</param>
+        /// <returns>Returns the target object with values populated from the deserialized YAML.</returns>
+        T PopulateObject<T>(IParser parser, T target);
     }
 }

--- a/YamlDotNet/Serialization/INodeDeserializer.cs
+++ b/YamlDotNet/Serialization/INodeDeserializer.cs
@@ -26,6 +26,6 @@ namespace YamlDotNet.Serialization
 {
     public interface INodeDeserializer
     {
-        bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value);
+        bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?, object?> nestedObjectDeserializer, out object? value, object? currentValue);
     }
 }

--- a/YamlDotNet/Serialization/IValueDeserializer.cs
+++ b/YamlDotNet/Serialization/IValueDeserializer.cs
@@ -27,6 +27,6 @@ namespace YamlDotNet.Serialization
 {
     public interface IValueDeserializer
     {
-        object? DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer);
+        object? DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer, object? result);
     }
 }

--- a/YamlDotNet/Serialization/LazyComponentRegistrationList.cs
+++ b/YamlDotNet/Serialization/LazyComponentRegistrationList.cs
@@ -71,12 +71,23 @@ namespace YamlDotNet.Serialization
 
         public void Remove(Type componentType)
         {
+            var index = IndexOf(componentType);
+            entries.RemoveAt(index);
+        }
+
+        public void Replace(Type componentType, Func<TArgument, TComponent> factory)
+        {
+            var index = IndexOf(componentType);
+            entries[index] = new LazyComponentRegistration(componentType, factory);
+        }
+
+        private int IndexOf(Type componentType)
+        {
             for (var i = 0; i < entries.Count; ++i)
             {
                 if (entries[i].ComponentType == componentType)
                 {
-                    entries.RemoveAt(i);
-                    return;
+                    return i;
                 }
             }
 

--- a/YamlDotNet/Serialization/NodeDeserializers/ArrayNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ArrayNodeDeserializer.cs
@@ -27,11 +27,11 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 {
     public sealed class ArrayNodeDeserializer : INodeDeserializer
     {
-        private readonly PreexistingArrayPopulationStrategy populationStrategy;
+        private readonly ArrayPopulatingStrategy populatingStrategy;
 
-        public ArrayNodeDeserializer(PreexistingArrayPopulationStrategy populationStrategy = PreexistingArrayPopulationStrategy.CreateNew)
+        public ArrayNodeDeserializer(ArrayPopulatingStrategy populatingStrategy = ArrayPopulatingStrategy.CreateNew)
         {
-            this.populationStrategy = populationStrategy;
+            this.populatingStrategy = populatingStrategy;
         }
 
         bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?, object?> nestedObjectDeserializer, out object? value, object? currentValue)
@@ -47,7 +47,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             var items = new ArrayList();
             CollectionNodeDeserializer.DeserializeHelper(itemType, parser, nestedObjectDeserializer, items, true);
 
-            if (currentValue != null && populationStrategy == PreexistingArrayPopulationStrategy.FillExisting)
+            if (currentValue != null && populatingStrategy == ArrayPopulatingStrategy.FillExisting)
             {
                 if (((Array)currentValue).Length < items.Count)
                 {
@@ -55,7 +55,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                 }
             }
 
-            var array = (currentValue == null || populationStrategy == PreexistingArrayPopulationStrategy.CreateNew) ? Array.CreateInstance(itemType, items.Count) : currentValue;
+            var array = (currentValue == null || populatingStrategy == ArrayPopulatingStrategy.CreateNew) ? Array.CreateInstance(itemType, items.Count) : currentValue;
             items.CopyTo((Array)array, 0);
 
             value = array;

--- a/YamlDotNet/Serialization/NodeDeserializers/EnumerableNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/EnumerableNodeDeserializer.cs
@@ -29,7 +29,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 {
     public sealed class EnumerableNodeDeserializer : INodeDeserializer
     {
-        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?, object?> nestedObjectDeserializer, out object? value, object? currentValue)
         {
             Type itemsType;
             if (expectedType == typeof(IEnumerable))
@@ -49,7 +49,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             }
 
             var collectionType = typeof(List<>).MakeGenericType(itemsType);
-            value = nestedObjectDeserializer(parser, collectionType);
+            value = nestedObjectDeserializer(parser, collectionType, null);
             return true;
         }
     }

--- a/YamlDotNet/Serialization/NodeDeserializers/NullNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/NullNodeDeserializer.cs
@@ -27,7 +27,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 {
     public sealed class NullNodeDeserializer : INodeDeserializer
     {
-        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?, object?> nestedObjectDeserializer, out object? value, object? currentValue)
         {
             value = null;
             if (parser.Accept<NodeEvent>(out var evt))

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -34,7 +34,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
         private const string BooleanTruePattern = "^(true|y|yes|on)$";
         private const string BooleanFalsePattern = "^(false|n|no|off)$";
 
-        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?, object?> nestedObjectDeserializer, out object? value, object? currentValue)
         {
             if (!parser.TryConsume<Scalar>(out var scalar))
             {

--- a/YamlDotNet/Serialization/NodeDeserializers/TypeConverterNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/TypeConverterNodeDeserializer.cs
@@ -35,7 +35,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             this.converters = converters ?? throw new ArgumentNullException(nameof(converters));
         }
 
-        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?, object?> nestedObjectDeserializer, out object? value, object? currentValue)
         {
             var converter = converters.FirstOrDefault(c => c.Accepts(expectedType));
             if (converter == null)

--- a/YamlDotNet/Serialization/NodeDeserializers/YamlConvertibleNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/YamlConvertibleNodeDeserializer.cs
@@ -33,12 +33,12 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             this.objectFactory = objectFactory;
         }
 
-        public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?, object?> nestedObjectDeserializer, out object? value, object? currentValue)
         {
             if (typeof(IYamlConvertible).IsAssignableFrom(expectedType))
             {
                 var convertible = (IYamlConvertible)objectFactory.Create(expectedType);
-                convertible.Read(parser, expectedType, type => nestedObjectDeserializer(parser, type));
+                convertible.Read(parser, expectedType, type => nestedObjectDeserializer(parser, type, null));
                 value = convertible;
                 return true;
             }

--- a/YamlDotNet/Serialization/NodeDeserializers/YamlSerializableNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/YamlSerializableNodeDeserializer.cs
@@ -33,7 +33,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             this.objectFactory = objectFactory;
         }
 
-        public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?, object?> nestedObjectDeserializer, out object? value, object? currentValue)
         {
 #pragma warning disable 0618 // IYamlSerializable is obsolete
             if (typeof(IYamlSerializable).IsAssignableFrom(expectedType))

--- a/YamlDotNet/Serialization/PopulatingStrategies.cs
+++ b/YamlDotNet/Serialization/PopulatingStrategies.cs
@@ -40,7 +40,9 @@ namespace YamlDotNet.Serialization
         /// If the pre-existing array does not have sufficient length, a <see cref="YamlException"/> will be thrown.
         /// If the array does not exist yet, an instance will be created and populated.
         /// </summary>
-        FillExisting
+        FillExisting,
+        PopulateItems,
+        PopulateItemsAllowGrowingArray
     }
 
     /// <summary>
@@ -56,7 +58,12 @@ namespace YamlDotNet.Serialization
         /// Add items to the pre-existing collection.
         /// If the collection does not exist yet, an instance will be created and populated.
         /// </summary>
-        AddItems
+        AddItems,
+        /// <summary>
+        /// Populate pre-existing items, create and add new items where there is no pre-existing target.
+        /// If the collection does not exist yet, an instance will be created and populated.
+        /// </summary>
+        PopulateOrAddItems
     }
 
     /// <summary>

--- a/YamlDotNet/Serialization/PopulatingStrategies.cs
+++ b/YamlDotNet/Serialization/PopulatingStrategies.cs
@@ -29,7 +29,7 @@ namespace YamlDotNet.Serialization
     /// <summary>
     /// Defines how arrays will be treated during deserialization when populating a pre-existing object (via <see cref="Deserializer.PopulateObject{T}(IParser, T)"/> and overloads)
     /// </summary>
-    public enum PreexistingArrayPopulationStrategy
+    public enum ArrayPopulatingStrategy
     {
         /// <summary>
         /// Always create a new instance.
@@ -46,7 +46,7 @@ namespace YamlDotNet.Serialization
     /// <summary>
     /// Defines how types inherting from <see cref="ICollection"/> and <see cref="ICollection{T}"/> will be treated during deserialization when populating a pre-existing object (via <see cref="Deserializer.PopulateObject{T}(IParser, T)"/> and overloads)
     /// </summary>
-    public enum PreexistingCollectionPopulationStrategy
+    public enum CollectionPopulatingStrategy
     {
         /// <summary>
         /// Always create a new instance.
@@ -62,7 +62,7 @@ namespace YamlDotNet.Serialization
     /// <summary>
     /// Defines how types inherting from <see cref="IDictionary"/> and <see cref="IDictionary{TKey, TValue}"/> will be treated during  deserialization when populating a pre-existing object (via <see cref="Deserializer.PopulateObject{T}(IParser, T)"/> and overloads)
     /// </summary>
-    public enum PreexistingDictionaryPopulationStrategy
+    public enum DictionaryPopulatingStrategy
     {
         /// <summary>
         /// Always create a new instance.

--- a/YamlDotNet/Serialization/PopulationStrategies.cs
+++ b/YamlDotNet/Serialization/PopulationStrategies.cs
@@ -1,0 +1,83 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Serialization
+{
+    /// <summary>
+    /// Defines how arrays will be treated during deserialization when populating a pre-existing object (via <see cref="Deserializer.PopulateObject{T}(IParser, T)"/> and overloads)
+    /// </summary>
+    public enum PreexistingArrayPopulationStrategy
+    {
+        /// <summary>
+        /// Always create a new instance.
+        /// </summary>
+        CreateNew,
+        /// <summary>
+        /// Fill the pre-existing array, overwriting items. Pre-existing values that do not get overwritten will be kept.
+        /// If the pre-existing array does not have sufficient length, a <see cref="YamlException"/> will be thrown.
+        /// If the array does not exist yet, an instance will be created and populated.
+        /// </summary>
+        FillExisting
+    }
+
+    /// <summary>
+    /// Defines how types inherting from <see cref="ICollection"/> and <see cref="ICollection{T}"/> will be treated during deserialization when populating a pre-existing object (via <see cref="Deserializer.PopulateObject{T}(IParser, T)"/> and overloads)
+    /// </summary>
+    public enum PreexistingCollectionPopulationStrategy
+    {
+        /// <summary>
+        /// Always create a new instance.
+        /// </summary>
+        CreateNew,
+        /// <summary>
+        /// Add items to the pre-existing collection.
+        /// If the collection does not exist yet, an instance will be created and populated.
+        /// </summary>
+        AddItems
+    }
+
+    /// <summary>
+    /// Defines how types inherting from <see cref="IDictionary"/> and <see cref="IDictionary{TKey, TValue}"/> will be treated during  deserialization when populating a pre-existing object (via <see cref="Deserializer.PopulateObject{T}(IParser, T)"/> and overloads)
+    /// </summary>
+    public enum PreexistingDictionaryPopulationStrategy
+    {
+        /// <summary>
+        /// Always create a new instance.
+        /// </summary>
+        CreateNew,
+        /// <summary>
+        /// Add items to the pre-existing dictionary.
+        /// If the key is already present in the pre-existing collection, an <see cref="ArgumentException"/> will be thrown.
+        /// If the dictionary does not exist yet, an instance will be created and populated.
+        /// </summary>
+        AddItemsThrowOnExistingKeys,
+        /// <summary>
+        /// Add items to the pre-existing dictionary, replacing values with pre-existing keys.
+        /// If the dictionary does not exist yet, an instance will be created and populated.
+        /// </summary>
+        AddItemsReplaceExistingKeys
+    }
+}

--- a/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/AliasValueDeserializer.cs
@@ -96,7 +96,7 @@ namespace YamlDotNet.Serialization.ValueDeserializers
             }
         }
 
-        public object? DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
+        public object? DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer, object? currentValue)
         {
             object? value;
             if (parser.TryConsume<AnchorAlias>(out var alias))
@@ -121,7 +121,7 @@ namespace YamlDotNet.Serialization.ValueDeserializers
                 }
             }
 
-            value = innerDeserializer.DeserializeValue(parser, expectedType, state, nestedObjectDeserializer);
+            value = innerDeserializer.DeserializeValue(parser, expectedType, state, nestedObjectDeserializer, currentValue);
 
             if (!anchor.IsEmpty)
             {

--- a/YamlDotNet/Serialization/ValueDeserializers/NodeValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/NodeValueDeserializer.cs
@@ -38,7 +38,7 @@ namespace YamlDotNet.Serialization.ValueDeserializers
             this.typeResolvers = typeResolvers ?? throw new ArgumentNullException(nameof(typeResolvers));
         }
 
-        public object? DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
+        public object? DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer, object? currentValue)
         {
             parser.Accept<NodeEvent>(out var nodeEvent);
             var nodeType = GetTypeFromEvent(nodeEvent, expectedType);
@@ -47,7 +47,7 @@ namespace YamlDotNet.Serialization.ValueDeserializers
             {
                 foreach (var deserializer in deserializers)
                 {
-                    if (deserializer.Deserialize(parser, nodeType, (r, t) => nestedObjectDeserializer.DeserializeValue(r, t, state, nestedObjectDeserializer), out var value))
+                    if (deserializer.Deserialize(parser, nodeType, (r, t, o) => nestedObjectDeserializer.DeserializeValue(r, t, state, nestedObjectDeserializer, o), out var value, currentValue))
                     {
                         return TypeConverter.ChangeType(value, expectedType);
                     }


### PR DESCRIPTION
Add `IDeserializer.PopulateObject()` APIs
Add `currentValue` parameter to `INodeDeserializer`s and `IValueDeserializer`s
Add checks to only create a new instance if `currentValue` is empty
Add ways to allow the user to configure population of pre-existing collections: `DeserializerBuilder.WithCollectionPopulationOptions()`

Note: Pre-existing collection _items_ do _not_ get populated. Pre-existing collections can be re-used though, see `DeserializerBuilder.WithCollectionPopulationOptions()`

Todo: Allow to populate pre-existing collection items. This needs some refactoring of the way the `Array`-, `Collection`- and `DictionaryNodeDeserializer` work.

#130