### PR TITLE
Fix/comment indents (and other comment-related issues)

### DIFF
--- a/YamlDotNet.Test/Serialization/YamlCommentTests.cs
+++ b/YamlDotNet.Test/Serialization/YamlCommentTests.cs
@@ -56,6 +56,14 @@ namespace YamlDotNet.Test.Serialization
             lines.Should().Contain("# or:");
             lines.Should().Contain("# This person owns the car");
         }
+
+        [Fact]
+        public void SerializationWithBlockComments_NullValue()
+        {
+            var serializer = new Serializer();
+            Action action = () => serializer.Serialize(new NullComment());
+            action.ShouldNotThrow();
+        }
         #endregion
 
         #region Indentation of block comments
@@ -213,6 +221,12 @@ namespace YamlDotNet.Test.Serialization
         {
             [YamlMember(Description = "The car parked in the garage")]
             public Car Car;
+        }
+
+        class NullComment
+        {
+            [YamlMember(Description = null)]
+            public int Foo { get; set; }
         }
 
         private static string[] SplitByLines(string result)

--- a/YamlDotNet.Test/Serialization/YamlCommentTests.cs
+++ b/YamlDotNet.Test/Serialization/YamlCommentTests.cs
@@ -40,21 +40,24 @@ namespace YamlDotNet.Test.Serialization
         [Fact]
         public void SerializationWithBlockComments_Multiline()
         {
-            var person = new Car();
+            var multilineComment = new MultilineComment();
 
             var serializer = new Serializer();
-            var result = serializer.Serialize(person);
+            var result = serializer.Serialize(multilineComment);
             Output.WriteLine(result);
 
             var deserializer = new Deserializer();
-            Action action = () => deserializer.Deserialize<Car>(result);
+            Action action = () => deserializer.Deserialize<MultilineComment>(result);
             action.ShouldNotThrow();
 
             var lines = SplitByLines(result);
 
-            lines.Should().Contain("# The car's rightful owner");
-            lines.Should().Contain("# or:");
-            lines.Should().Contain("# This person owns the car");
+            lines[0].Should().Be("# This");
+            lines[1].Should().Be("# is");
+            lines[2].Should().Be("# multiline");
+
+            lines[4].Should().Be("# This is");
+            lines[5].Should().Be("# too");
         }
 
         [Fact]
@@ -111,8 +114,6 @@ namespace YamlDotNet.Test.Serialization
             var indent2 = GetIndent(2);
 
             lines.Should().Contain(indent1 + "# The car's rightful owner");
-            lines.Should().Contain(indent1 + "# or:");
-            lines.Should().Contain(indent1 + "# This person owns the car");
             lines.Should().Contain(indent2 + "# The person's name");
             lines.Should().Contain(indent2 + "# The person's age");
         }
@@ -221,7 +222,7 @@ namespace YamlDotNet.Test.Serialization
 
         class Car
         {
-            [YamlMember(Description = "The car's rightful owner\nor:\nThis person owns the car")]
+            [YamlMember(Description = "The car's rightful owner")]
             public Person Owner { get; set; }
             public Person[] Passengers { get; set; }
         }
@@ -236,6 +237,16 @@ namespace YamlDotNet.Test.Serialization
         {
             [YamlMember(Description = null)]
             public int Foo { get; set; }
+        }
+
+        class MultilineComment
+        {
+            [YamlMember(Description = "This\nis\nmultiline")]
+            public int Foo { get; set; }
+
+            [YamlMember(Description = @"This is
+too")]
+            public int Bar { get; set; }
         }
 
         private static string[] SplitByLines(string result)

--- a/YamlDotNet.Test/Serialization/YamlCommentTests.cs
+++ b/YamlDotNet.Test/Serialization/YamlCommentTests.cs
@@ -166,7 +166,7 @@ namespace YamlDotNet.Test.Serialization
             };
 
             var serializer = new SerializerBuilder()
-                .WithEventEmitter(e => new FlowPersonEmitter(e))
+                .WithEventEmitter(e => new FlowEmitter(e, typeof(Person)))
                 .Build();
             var result = serializer.Serialize(garage);
             Output.WriteLine(result);
@@ -185,17 +185,26 @@ namespace YamlDotNet.Test.Serialization
         }
 
         /// <summary>
-        /// This emits Person objects as flow mappings
+        /// This emits objects of given types as flow mappings
         /// </summary>
-        public class FlowPersonEmitter : ChainedEventEmitter
+        public class FlowEmitter : ChainedEventEmitter
         {
-            public FlowPersonEmitter(IEventEmitter nextEmitter) : base(nextEmitter) { }
+            private readonly Type[] types;
+
+            public FlowEmitter(IEventEmitter nextEmitter, params Type[] types) : base(nextEmitter)
+            {
+                this.types = types;
+            }
 
             public override void Emit(MappingStartEventInfo eventInfo, IEmitter emitter)
             {
-                if (eventInfo.Source.Type == typeof(Person))
+                foreach (var type in types)
                 {
-                    eventInfo.Style = MappingStyle.Flow;
+                    if (eventInfo.Source.Type == type)
+                    {
+                        eventInfo.Style = MappingStyle.Flow;
+                        break;
+                    }
                 }
                 base.Emit(eventInfo, emitter);
             }

--- a/YamlDotNet.Test/Serialization/YamlCommentTests.cs
+++ b/YamlDotNet.Test/Serialization/YamlCommentTests.cs
@@ -1,6 +1,11 @@
-﻿using Xunit;
+﻿using System;
+using FluentAssertions;
+using Xunit;
 using Xunit.Abstractions;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.EventEmitters;
 
 namespace YamlDotNet.Test.Serialization
 {
@@ -12,30 +17,219 @@ namespace YamlDotNet.Test.Serialization
             Output = helper;
         }
 
+        #region Simple block comments
         [Fact]
-        public void SerializationWithComment()
+        public void SerializationWithBlockComments()
         {
-            var person = new Person();
-            person.Name = "PandaTea";
-            person.Age = 100;
-            person.Sex = "male";
+            var person = new Person { Name = "PandaTea", Age = 100 };
 
-            Serializer serializer = new Serializer();
-            string result = serializer.Serialize(person);
+            var serializer = new Serializer();
+            var result = serializer.Serialize(person);
+            Output.WriteLine(result);
 
-            Assert.Contains("# this is a yaml comment about name property", result);
-            Assert.Contains("# this is age", result);
-            Assert.Contains("# male or female", result);
+            var deserializer = new Deserializer();
+            Action action = () => deserializer.Deserialize<Person>(result);
+            action.ShouldNotThrow();
+
+            var lines = SplitByLines(result);
+
+            lines.Should().Contain("# The person's name");
+            lines.Should().Contain("# The person's age");
         }
+
+        [Fact]
+        public void SerializationWithBlockComments_Multiline()
+        {
+            var person = new Car();
+
+            var serializer = new Serializer();
+            var result = serializer.Serialize(person);
+            Output.WriteLine(result);
+
+            var deserializer = new Deserializer();
+            Action action = () => deserializer.Deserialize<Car>(result);
+            action.ShouldNotThrow();
+
+            var lines = SplitByLines(result);
+
+            lines.Should().Contain("# The car's rightful owner");
+            lines.Should().Contain("# or:");
+            lines.Should().Contain("# This person owns the car");
+        }
+        #endregion
+
+        #region Indentation of block comments
+        [Fact]
+        public void SerializationWithBlockComments_IndentedInSequence()
+        {
+            var person = new Person { Name = "PandaTea", Age = 100 };
+
+            var serializer = new Serializer();
+            var result = serializer.Serialize(new Person[] { person });
+            Output.WriteLine(result);
+
+            var deserializer = new Deserializer();
+            Action action = () => deserializer.Deserialize<Person[]>(result);
+            action.ShouldNotThrow();
+
+            var lines = SplitByLines(result);
+            var indent = GetIndent(1);
+
+            lines.Should().Contain("- # The person's name");
+            lines.Should().Contain(indent + "# The person's age");
+        }
+
+        [Fact]
+        public void SerializationWithBlockComments_IndentedInBlock()
+        {
+            var garage = new Garage
+            {
+                Car = new Car
+                {
+                    Owner = new Person { Name = "PandaTea", Age = 100 }
+                }
+            };
+
+            var serializer = new Serializer();
+            var result = serializer.Serialize(garage);
+            Output.WriteLine(result);
+
+            var deserializer = new Deserializer();
+            Action action = () => deserializer.Deserialize<Garage>(result);
+            action.ShouldNotThrow();
+
+            var lines = SplitByLines(result);
+            var indent1 = GetIndent(1);
+            var indent2 = GetIndent(2);
+
+            lines.Should().Contain(indent1 + "# The car's rightful owner");
+            lines.Should().Contain(indent1 + "# or:");
+            lines.Should().Contain(indent1 + "# This person owns the car");
+            lines.Should().Contain(indent2 + "# The person's name");
+            lines.Should().Contain(indent2 + "# The person's age");
+        }
+
+        [Fact]
+        public void SerializationWithBlockComments_IndentedInBlockAndSequence()
+        {
+            var garage = new Garage
+            {
+                Car = new Car
+                {
+                    Passengers = new[]
+                    {
+                        new Person { Name = "PandaTea", Age = 100 }
+                    }
+                }
+            };
+
+            var serializer = new Serializer();
+            var result = serializer.Serialize(garage);
+            Output.WriteLine(result);
+
+            var deserializer = new Deserializer();
+            Action action = () => deserializer.Deserialize<Garage>(result);
+            action.ShouldNotThrow();
+
+            var lines = SplitByLines(result);
+            var indent1 = GetIndent(1);
+            var indent2 = GetIndent(2);
+
+            lines.Should().Contain(indent1 + "# The car's rightful owner");
+            lines.Should().Contain(indent1 + "- # The person's name");
+            lines.Should().Contain(indent2 + "# The person's age");
+        }
+        #endregion
+
+        #region Flow mapping
+        [Fact]
+        public void SerializationWithBlockComments_IndentedInBlockAndSequence_WithFlowMapping()
+        {
+            var garage = new Garage
+            {
+                Car = new Car
+                {
+                    Owner = new Person { Name = "Paul", Age = 50 },
+                    Passengers = new[]
+                    {
+                        new Person { Name = "PandaTea", Age = 100 }
+                    }
+                }
+            };
+
+            var serializer = new SerializerBuilder()
+                .WithEventEmitter(e => new FlowPersonEmitter(e))
+                .Build();
+            var result = serializer.Serialize(garage);
+            Output.WriteLine(result);
+
+            var deserializer = new Deserializer();
+            Action action = () => deserializer.Deserialize<Garage>(result);
+            action.ShouldNotThrow();
+
+            var lines = SplitByLines(result);
+            var indent1 = GetIndent(1);
+
+            lines.Should().Contain("# The car parked in the garage");
+            lines.Should().Contain(indent1 + "# The car's rightful owner");
+            result.Should().NotContain("The person's name", "because the person's properties are inside of a flow map now");
+            result.Should().NotContain("The person's age", "because the person's properties are inside of a flow map now");
+        }
+
+        /// <summary>
+        /// This emits Person objects as flow mappings
+        /// </summary>
+        public class FlowPersonEmitter : ChainedEventEmitter
+        {
+            public FlowPersonEmitter(IEventEmitter nextEmitter) : base(nextEmitter) { }
+
+            public override void Emit(MappingStartEventInfo eventInfo, IEmitter emitter)
+            {
+                if (eventInfo.Source.Type == typeof(Person))
+                {
+                    eventInfo.Style = MappingStyle.Flow;
+                }
+                base.Emit(eventInfo, emitter);
+            }
+        }
+        #endregion
 
         class Person
         {
-            [YamlMember(Description = "this is a yaml comment about name property")]
+            [YamlMember(Description = "The person's name")]
             public string Name { get; set; }
-            [YamlMember(Description = "this is age")]
+            [YamlMember(Description = "The person's age")]
             public int Age { get; set; }
-            [YamlMember(Description = "male or female")]
-            public string Sex { get; set; }
+        }
+
+        class Car
+        {
+            [YamlMember(Description = "The car's rightful owner\nor:\nThis person owns the car")]
+            public Person Owner { get; set; }
+            public Person[] Passengers { get; set; }
+        }
+
+        class Garage
+        {
+            [YamlMember(Description = "The car parked in the garage")]
+            public Car Car;
+        }
+
+        private static string[] SplitByLines(string result)
+        {
+            return result.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+        }
+
+        private static string GetIndent(int depth)
+        {
+            var indentWidth = EmitterSettings.Default.BestIndent;
+            var indent = "";
+            while (indent.Length < indentWidth * depth)
+            {
+                indent += " ";
+            }
+
+            return indent;
         }
     }
 }

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -654,7 +654,7 @@ namespace YamlDotNet.Core
 
             if (comment.IsInline)
             {
-                Write(' ');
+                Write(" # ");
                 Write(string.Join(" ", lines));
             }
             else

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -642,6 +642,12 @@ namespace YamlDotNet.Core
 
         private void EmitComment(Comment comment)
         {
+            // If we're in flow mode or about to enter it: Skip comments.
+            if (flowLevel > 0 || state == EmitterState.FlowMappingFirstKey || state == EmitterState.FlowSequenceFirstItem)
+            {
+                return;
+            }
+
             if (comment.IsInline)
             {
                 Write(' ');

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -655,7 +655,7 @@ namespace YamlDotNet.Core
             if (comment.IsInline)
             {
                 Write(' ');
-                Write(string.Join(' ', lines));
+                Write(string.Join(" ", lines));
             }
             else
             {


### PR DESCRIPTION
This fixes incorrect comment indents (#662), see the updated `YamlCommentTests`.

It also fixes incorrect YAML output when using newline-characters inside of the `YamlMemberAttribute.Description` (#663): Now the Emitter simply writes multiple comment lines.

Also adds some support for flow mapping: Comments get stripped when inside a flow block.

#### Notes about inline comments
Also, as it is pretty related: I've added some code regarding writing inline comments, but they are not really supported as of now anyway: There's no easy to use public API.
In my branch (https://github.com/krisrok/YamlDotNet/tree/feature/serialize-inline-comments) there is some preliminary support for inline comments but I could not come up with a complete solution: Inline comments on non-emtpy sequences still land on the next line.
