### PR TITLE
Change the release notes link to use github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,4 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Release notes
 
-[Release notes for the latest version](RELEASE_NOTES.md)
+Please see the Releases at https://github.com/aaubry/YamlDotNet/releases


### PR DESCRIPTION
Fixes #658 