### PR TITLE
Allow quoting of specialized strings like null/true/false/numbers etc

### DIFF
--- a/YamlDotNet.Test/Core/EventsHelper.cs
+++ b/YamlDotNet.Test/Core/EventsHelper.cs
@@ -299,7 +299,7 @@ namespace YamlDotNet.Test.Core
 
             foreach (var property in expected.GetType().GetTypeInfo().GetProperties())
             {
-                if (property.PropertyType == typeof(Mark) || !property.CanRead)
+                if (property.PropertyType == typeof(Mark) || !property.CanRead || property.Name == "IsKey")
                 {
                     continue;
                 }

--- a/YamlDotNet.Test/Core/ScannerTests.cs
+++ b/YamlDotNet.Test/Core/ScannerTests.cs
@@ -438,7 +438,7 @@ namespace YamlDotNet.Test.Core
 
             foreach (var property in expected.GetType().GetTypeInfo().GetProperties())
             {
-                if (property.PropertyType != typeof(Mark) && property.CanRead)
+                if (property.PropertyType != typeof(Mark) && property.CanRead && property.Name != "IsKey")
                 {
                     var value = property.GetValue(actual, null);
                     var expectedValue = property.GetValue(expected, null);

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -128,13 +128,28 @@ Value: bar
 True: null
 False: hello
 Null: true
+X:
 ";
             var obj = deserializer.Deserialize(yaml, typeof(object));
             var result = serializer.Serialize(obj);
             var dictionary = (Dictionary<object, object>)obj;
             var keys = dictionary.Keys.ToArray();
-            Assert.Equal(keys, new[] { "True", "False", "Null" });
-            Assert.Equal(dictionary.Values, new object[] { null, "hello", true });
+            Assert.Equal(keys, new[] { "True", "False", "Null", "X" });
+            Assert.Equal(dictionary.Values, new object[] { null, "hello", true, null });
+        }
+
+        [Fact]
+        public void EmptyQuotedStringsArentNull()
+        {
+            var deserializer = new DeserializerBuilder().WithAttemptingUnquotedStringTypeDeserialization().Build();
+            var yaml = "Value: \"\"";
+            var result = deserializer.Deserialize<Test>(yaml);
+            Assert.Equal(string.Empty, result.Value);
+        }
+
+        public class Test
+        {
+            public string Value { get; set; }
         }
 
         public class SetterOnly

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 using YamlDotNet.Serialization;
@@ -116,6 +117,24 @@ Value: bar
             var deserializer = new DeserializerBuilder().Build();
             var result = deserializer.Deserialize<SetterOnly>(yaml);
             result.Actual.Should().Be("bar");
+        }
+
+        [Fact]
+        public void KeysOnDynamicClassDontGetQuoted()
+        {
+            var serializer = new SerializerBuilder().WithQuotingNecessaryStrings().Build();
+            var deserializer = new DeserializerBuilder().WithAttemptingUnquotedStringTypeDeserialization().Build();
+            var yaml = @"
+True: null
+False: hello
+Null: true
+";
+            var obj = deserializer.Deserialize(yaml, typeof(object));
+            var result = serializer.Serialize(obj);
+            var dictionary = (Dictionary<object, object>)obj;
+            var keys = dictionary.Keys.ToArray();
+            Assert.Equal(keys, new[] { "True", "False", "Null" });
+            Assert.Equal(dictionary.Values, new object[] { null, "hello", true });
         }
 
         public class SetterOnly

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -829,6 +829,18 @@ y:
             result.MyString.Should().BeNull();
         }
 
+        [Fact]
+        public void NullsRoundTrip()
+        {
+            var writer = new StringWriter();
+            var obj = new Example { MyString = null };
+
+            SerializerBuilder.EnsureRoundtrip().Build().Serialize(writer, obj, typeof(Example));
+            var result = Deserializer.Deserialize<Example>(UsingReaderFor(writer));
+
+            result.MyString.Should().BeNull();
+        }
+
         [Theory]
         [InlineData(typeof(SByteEnum))]
         [InlineData(typeof(ByteEnum))]
@@ -1395,6 +1407,7 @@ y:
                         new FloatTestCase("float.NegativeInfinity", float.NegativeInfinity, "-.inf"),
                         new FloatTestCase("float.Epsilon", float.Epsilon, float.Epsilon.ToString("G", CultureInfo.InvariantCulture)),
                         new FloatTestCase("float.26.67", 26.67F, "26.67"),
+
 #if NETCOREAPP3_1_OR_GREATER
                         new FloatTestCase("double.MinValue", double.MinValue, double.MinValue.ToString("G", CultureInfo.InvariantCulture)),
                         new FloatTestCase("double.MaxValue", double.MaxValue, double.MaxValue.ToString("G", CultureInfo.InvariantCulture)),
@@ -2164,6 +2177,78 @@ Cycle: *o0");
             using var reader = new StringReader(serialized);
             var roundtrippedText = dut.Deserialize<StringContainer>(reader).Text.NormalizeNewLines();
             Assert.Equal(text, roundtrippedText);
+        }
+
+        [Theory]
+        [InlineData("NULL")]
+        [InlineData("Null")]
+        [InlineData("null")]
+        [InlineData("~")]
+        [InlineData("true")]
+        [InlineData("false")]
+        [InlineData("True")]
+        [InlineData("False")]
+        [InlineData("TRUE")]
+        [InlineData("FALSE")]
+        [InlineData("0o77")]
+        [InlineData("0x7A")]
+        [InlineData("+1e10")]
+        [InlineData("1E10")]
+        [InlineData("+.inf")]
+        [InlineData("-.inf")]
+        [InlineData(".inf")]
+        [InlineData(".nan")]
+        [InlineData(".NaN")]
+        [InlineData(".NAN")]
+        public void StringsThatMatchKeywordsAreQuoted(string input)
+        {
+            var serializer = new SerializerBuilder().WithQuotingNecessaryStrings().Build();
+            var o = new { text = input };
+            var yaml = serializer.Serialize(o);
+            Assert.Equal($"text: \"{input}\"{Environment.NewLine}", yaml);
+        }
+
+        [Fact]
+        public void KeysOnConcreteClassDontGetQuoted_TypeStringGetsQuoted()
+        {
+            var serializer = new SerializerBuilder().WithQuotingNecessaryStrings().Build();
+            var deserializer = new DeserializerBuilder().WithAttemptingUnquotedStringTypeDeserialization().Build();
+            var yaml = @"
+True: null
+False: hello
+Null: true
+";
+            var obj = deserializer.Deserialize<ReservedWordsTestClass<string>>(yaml);
+            var result = serializer.Serialize(obj);
+            obj.True.Should().BeNull();
+            obj.False.Should().Be("hello");
+            obj.Null.Should().Be("true");
+            result.Should().Be($"True: {Environment.NewLine}False: hello{Environment.NewLine}Null: \"true\"{Environment.NewLine}");
+        }
+
+        [Fact]
+        public void KeysOnConcreteClassDontGetQuoted_TypeBoolDoesNotGetQuoted()
+        {
+            var serializer = new SerializerBuilder().WithQuotingNecessaryStrings().Build();
+            var deserializer = new DeserializerBuilder().WithAttemptingUnquotedStringTypeDeserialization().Build();
+            var yaml = @"
+True: null
+False: hello
+Null: true
+";
+            var obj = deserializer.Deserialize<ReservedWordsTestClass<bool>>(yaml);
+            var result = serializer.Serialize(obj);
+            obj.True.Should().BeNull();
+            obj.False.Should().Be("hello");
+            obj.Null.Should().BeTrue();
+            result.Should().Be($"True: {Environment.NewLine}False: hello{Environment.NewLine}Null: true{Environment.NewLine}");
+        }
+
+        public class ReservedWordsTestClass<TNullType>
+        {
+            public string True { get; set; }
+            public string False { get; set; }
+            public TNullType Null { get; set; }
         }
 
         [TypeConverter(typeof(DoublyConvertedTypeConverter))]

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1370,6 +1370,16 @@ y:
             Assert.Equal(testCase.Value, deserializedValue);
         }
 
+        [Fact]
+        public void EmptyStringsAreQuoted()
+        {
+            var serializer = new SerializerBuilder().WithQuotingNecessaryStrings().Build();
+            var o = new { test = string.Empty };
+            var result = serializer.Serialize(o);
+            var expected = $"test: \"\"{Environment.NewLine}";
+            Assert.Equal(expected, result);
+        }
+
         public class FloatTestCase
         {
             private readonly string description;

--- a/YamlDotNet.Test/Spec/ParserSpecTests.cs
+++ b/YamlDotNet.Test/Spec/ParserSpecTests.cs
@@ -53,8 +53,12 @@ namespace YamlDotNet.Test.Spec
         };
 
         [Theory, ClassData(typeof(ParserSpecTestsData))]
-        public void ConformsWithYamlSpec(string name, string description, string inputFile, string expectedEventFile, bool error)
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+        public void ConformsWithYamlSpec(string name, string description, string inputFile, string expectedEventFile, bool error, bool quoting)
+#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
         {
+            // we don't care about quoting for this test.
+
             var expectedResult = File.ReadAllText(expectedEventFile)
                 .Replace("+MAP {}", "+MAP")
                 .Replace("+SEQ []", "+SEQ");

--- a/YamlDotNet.Test/Spec/SerializerSpecTests.cs
+++ b/YamlDotNet.Test/Spec/SerializerSpecTests.cs
@@ -64,12 +64,22 @@ namespace YamlDotNet.Test.Spec
             // no false-positives known as of https://github.com/yaml/yaml-test-suite/releases/tag/data-2020-02-11
         };
 
-        private readonly IDeserializer deserializer = new DeserializerBuilder().Build();
-        private readonly ISerializer serializer = new SerializerBuilder().Build();
 
         [Theory, ClassData(typeof(SerializerSpecTestsData))]
-        public void ConformsWithYamlSpec(string name, string description, string inputFile, string outputFile, bool error)
+        public void ConformsWithYamlSpec(string name, string description, string inputFile, string outputFile, bool error, bool quoting)
         {
+            var deserializerBuilder = new DeserializerBuilder();
+            var serializerBuilder = new SerializerBuilder();
+
+            if (quoting)
+            {
+                deserializerBuilder.WithAttemptingUnquotedStringTypeDeserialization();
+                serializerBuilder.WithQuotingNecessaryStrings();
+            }
+
+            var serializer = serializerBuilder.Build();
+            var deserializer = deserializerBuilder.Build();
+
             var expectedResult = File.ReadAllText(outputFile);
             using var writer = new StringWriter();
             try

--- a/YamlDotNet.Test/Spec/SpecTestData.cs
+++ b/YamlDotNet.Test/Spec/SpecTestData.cs
@@ -75,7 +75,17 @@ namespace YamlDotNet.Test.Spec
                     File.ReadAllText(descriptionFile).TrimEnd(),
                     inputFile,
                     (this is SerializerSpecTests.SerializerSpecTestsData) ? outputFile : expectedEventFile,
-                    hasErrorFile
+                    hasErrorFile,
+                    true //quoting enabled
+                };
+                yield return new object[]
+                {
+                    testName,
+                    File.ReadAllText(descriptionFile).TrimEnd(),
+                    inputFile,
+                    (this is SerializerSpecTests.SerializerSpecTestsData) ? outputFile : expectedEventFile,
+                    hasErrorFile,
+                    false //quoting not enabled
                 };
             }
         }

--- a/YamlDotNet/Core/Events/Scalar.cs
+++ b/YamlDotNet/Core/Events/Scalar.cs
@@ -60,6 +60,11 @@ namespace YamlDotNet.Core.Events
         public override bool IsCanonical => !IsPlainImplicit && !IsQuotedImplicit;
 
         /// <summary>
+        /// Gets whether this scalar event is a key
+        /// </summary>
+        public bool IsKey { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Scalar"/> class.
         /// </summary>
         /// <param name="anchor">The anchor.</param>
@@ -70,13 +75,15 @@ namespace YamlDotNet.Core.Events
         /// <param name="isQuotedImplicit">.</param>
         /// <param name="start">The start position of the event.</param>
         /// <param name="end">The end position of the event.</param>
-        public Scalar(AnchorName anchor, TagName tag, string value, ScalarStyle style, bool isPlainImplicit, bool isQuotedImplicit, Mark start, Mark end)
+        /// <param name="isKey">Whether or not this scalar event is for a key</param>
+        public Scalar(AnchorName anchor, TagName tag, string value, ScalarStyle style, bool isPlainImplicit, bool isQuotedImplicit, Mark start, Mark end, bool isKey = false)
             : base(anchor, tag, start, end)
         {
             this.Value = value;
             this.Style = style;
             this.IsPlainImplicit = isPlainImplicit;
             this.IsQuotedImplicit = isQuotedImplicit;
+            this.IsKey = isKey;
         }
 
         /// <summary>

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -559,7 +559,7 @@ namespace YamlDotNet.Core
                     state = states.Pop();
                     Skip();
 
-                    ParsingEvent evt = new Events.Scalar(anchorName, tagName, scalar.Value, scalar.Style, isPlainImplicit, isQuotedImplicit, start, scalar.End);
+                    ParsingEvent evt = new Events.Scalar(anchorName, tagName, scalar.Value, scalar.Style, isPlainImplicit, isQuotedImplicit, start, scalar.End, scalar.IsKey);
 
                     // Read next token to ensure the error case spec test 'CXX2':
                     // "Mapping with anchor on document start line".

--- a/YamlDotNet/Core/Tokens/Scalar.cs
+++ b/YamlDotNet/Core/Tokens/Scalar.cs
@@ -30,6 +30,11 @@ namespace YamlDotNet.Core.Tokens
     public sealed class Scalar : Token
     {
         /// <summary>
+        /// Gets or sets whether this scalar is a key
+        /// </summary>
+        public bool IsKey { get; set; }
+
+        /// <summary>
         /// Gets the value.
         /// </summary>
         /// <value>The value.</value>

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -47,6 +47,7 @@ namespace YamlDotNet.Serialization
         private readonly Dictionary<TagName, Type> tagMappings;
         private readonly Dictionary<Type, Type> typeMappings;
         private bool ignoreUnmatched;
+        private bool attemptUnknownTypeDeserialization;
 
         /// <summary>
         /// Initializes a new <see cref="DeserializerBuilder" /> using the default component registrations.
@@ -79,7 +80,7 @@ namespace YamlDotNet.Serialization
                 { typeof(YamlSerializableNodeDeserializer), _ => new YamlSerializableNodeDeserializer(objectFactory.Value) },
                 { typeof(TypeConverterNodeDeserializer), _ => new TypeConverterNodeDeserializer(BuildTypeConverters()) },
                 { typeof(NullNodeDeserializer), _ => new NullNodeDeserializer() },
-                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer() },
+                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization) },
                 { typeof(ArrayNodeDeserializer), _ => new ArrayNodeDeserializer() },
                 { typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value) },
                 { typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value) },
@@ -112,6 +113,16 @@ namespace YamlDotNet.Serialization
             }
 
             return typeInspectorFactories.BuildComponentChain(innerInspector);
+        }
+
+        /// <summary>
+        /// When deserializing it will attempt to convert unquoted strings to their correct datatype. If conversion is not sucessful, it will leave it as a string.
+        /// This option is only applicable when not specifying a type or specifying the object type during deserialization.
+        /// </summary>
+        public DeserializerBuilder WithAttemptingUnquotedStringTypeDeserialization()
+        {
+            attemptUnknownTypeDeserialization = true;
+            return this;
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -181,6 +181,11 @@ namespace YamlDotNet.Serialization.EventEmitters
 
         private bool IsSpecialStringValue(string value)
         {
+            if (value.Trim() == string.Empty)
+            {
+                return true;
+            }
+
             return Regex.IsMatch(
                 value,
                 IsSpecialStringValue_Regex);

--- a/YamlDotNet/Serialization/NodeDeserializers/NullNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/NullNodeDeserializer.cs
@@ -51,7 +51,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                 return true;
             }
 
-            if (nodeEvent is Scalar scalar && scalar.Style == Core.ScalarStyle.Plain)
+            if (nodeEvent is Scalar scalar && scalar.Style == Core.ScalarStyle.Plain && !scalar.IsKey)
             {
                 var value = scalar.Value;
                 return value == "" || value == "~" || value == "null" || value == "Null" || value == "NULL";

--- a/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -239,10 +239,9 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
             foreach (var propertyDescriptor in typeDescriptor.GetProperties(value.Type, source))
             {
                 var propertyValue = propertyDescriptor.Read(source);
-
                 if (visitor.EnterMapping(propertyDescriptor, propertyValue, context))
                 {
-                    Traverse(propertyDescriptor.Name, new ObjectDescriptor(propertyDescriptor.Name, typeof(string), typeof(string)), visitor, context, path);
+                    Traverse(propertyDescriptor.Name, new ObjectDescriptor(propertyDescriptor.Name, typeof(string), typeof(string), ScalarStyle.Plain), visitor, context, path);
                     Traverse(propertyDescriptor.Name, propertyValue, visitor, context, path);
                 }
             }

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -49,6 +49,7 @@ namespace YamlDotNet.Serialization
         private int maximumRecursion = 50;
         private EmitterSettings emitterSettings = EmitterSettings.Default;
         private DefaultValuesHandling defaultValuesHandlingConfiguration = DefaultValuesHandling.Preserve;
+        private bool quoteNecessaryStrings;
 
         public SerializerBuilder()
             : base(new DynamicTypeResolver())
@@ -85,13 +86,22 @@ namespace YamlDotNet.Serialization
 
             eventEmitterFactories = new LazyComponentRegistrationList<IEventEmitter, IEventEmitter>
             {
-                { typeof(TypeAssigningEventEmitter), inner => new TypeAssigningEventEmitter(inner, false, tagMappings) }
+                { typeof(TypeAssigningEventEmitter), inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings) }
             };
 
             objectGraphTraversalStrategyFactory = (typeInspector, typeResolver, typeConverters, maximumRecursion) => new FullObjectGraphTraversalStrategy(typeInspector, typeResolver, maximumRecursion, namingConvention);
         }
 
         protected override SerializerBuilder Self { get { return this; } }
+
+        /// <summary>
+        /// Put double quotes around strings that need it, for example Null, True, False, a number. This should be called before any other "With" methods if you want this feature enabled.
+        /// </summary>
+        public SerializerBuilder WithQuotingNecessaryStrings()
+        {
+            quoteNecessaryStrings = true;
+            return this;
+        }
 
         /// <summary>
         /// Sets the maximum recursion that is allowed while traversing the object graph. The default value is 50.
@@ -244,7 +254,7 @@ namespace YamlDotNet.Serialization
                 maximumRecursion,
                 namingConvention
             );
-            WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, true, tagMappings), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+            WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, true, tagMappings, quoteNecessaryStrings), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
             return WithTypeInspector(inner => new ReadableAndWritablePropertiesTypeInspector(inner), loc => loc.OnBottom());
         }
 


### PR DESCRIPTION
Title says it all :) It fixes a long running discussion in a non-breaking of existing behavior way. All tests passed as expected including new ones to account for the new functionality. I'm really excited about this one as it has been biting me for a long time with Kubernetes manifests.

Fixes
#611 
#591 
#526 
#387 

Uses parts of #532 
