### PR TITLE
upgrade Bullseye from 3.6.0 to 4.0.0

### DIFF
--- a/tools/build/BuildDefinition.cs
+++ b/tools/build/BuildDefinition.cs
@@ -93,7 +93,7 @@ namespace build
         {
             switch (options.Host)
             {
-                case Host.Appveyor:
+                case Host.AppVeyor:
                     var buildNumber = Environment.GetEnvironmentVariable("APPVEYOR_BUILD_NUMBER");
                     Run("appveyor", $"UpdateBuild -Version {version.NuGetVersion}.{buildNumber}");
                     break;
@@ -142,7 +142,7 @@ namespace build
             {
                 Run("docker", $"run --rm -v {testsDir}:/build -w /build aaubry/mono-aot bash ./run.sh");
             }
-            catch (NonZeroExitCodeException ex) when (options.Host == Host.Appveyor && ex.ExitCode == -1)
+            catch (NonZeroExitCodeException ex) when (options.Host == Host.AppVeyor && ex.ExitCode == -1)
             {
                 // Appveyor fails with exit code -1 for some reason...
                 var realExitCode = int.Parse(File.ReadAllLines(Path.Combine(testsDir, "exitcode.txt")).First(), CultureInfo.InvariantCulture);
@@ -175,7 +175,7 @@ namespace build
 
             var isSandbox = options.Host switch
             {
-                Host.Appveyor => Environment.GetEnvironmentVariable("APPVEYOR_REPO_NAME") != "aaubry/YamlDotNet",
+                Host.AppVeyor => Environment.GetEnvironmentVariable("APPVEYOR_REPO_NAME") != "aaubry/YamlDotNet",
                 _ => false,
             };
 
@@ -447,7 +447,7 @@ namespace build
         private static string GitHubRepository =>
             Program.Host switch
             {
-                Host.Appveyor => Environment.GetEnvironmentVariable("APPVEYOR_REPO_NAME"),
+                Host.AppVeyor => Environment.GetEnvironmentVariable("APPVEYOR_REPO_NAME"),
                 _ => Environment.GetEnvironmentVariable("GITHUB_REPOSITORY")
             }
             ?? "aaubry/YamlDotNet.Sandbox";

--- a/tools/build/build.csproj
+++ b/tools/build/build.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bullseye" Version="3.6.0" />
+        <PackageReference Include="Bullseye" Version="4.0.0" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="SimpleExec" Version="6.4.0" />
     </ItemGroup>


### PR DESCRIPTION
I see you're using a few things from the `Bullseye.Internal` namespace—mainly `Palette` and `HostExtensions`. FYI I'm currently working on [making those public](https://github.com/adamralph/bullseye/pull/800) in Bullseye 4.1.0. One thing I'd like to confirm before releasing 4.1.0 is that the new API will remove the need for you to use the `Bullseye.Internal` namespace. But to do that, I think it's best if you've already moved to the Bullseye 4.0.0 API, so we can isolate the changes required for you to move from 4.0.0 to 4.1.0.