### PR TITLE
Adjust null warning in ScalarNodeDeserializer

### DIFF
--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -321,7 +321,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                 return value.Value;
             }
             var v = value.Value;
-            object result = null;
+            object? result;
 
             switch (v)
             {


### PR DESCRIPTION
Adjust `ScalarNodeDeserializer`  to allow nullable values in the deserializer in order to eliminate a warning. 

# Motivation

Modern C# nullables will emit warnings when nulls are not accounted for. The parse logic in `ScalarNodeDeserializer` is one case where those warnings are emitted. 
