### PR TITLE
Adds YamlPath Support

### DIFF
--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -28,10 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\YamlDotNet\YamlDotNet.csproj">
-      <Project>{BF32DE1B-6276-4341-B212-F8862ADBBA7A}</Project>
-      <Name>YamlDotNet</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\YamlDotNet.YamlPath\YamlDotNet.YamlPath.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -28,6 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\YamlDotNet\YamlDotNet.csproj">
+      <Project>{BF32DE1B-6276-4341-B212-F8862ADBBA7A}</Project>
+      <Name>YamlDotNet</Name>
+    </ProjectReference>
     <ProjectReference Include="..\YamlDotNet.YamlPath\YamlDotNet.YamlPath.csproj" />
   </ItemGroup>
 

--- a/YamlDotNet.Test/YamlPath/YamlPathTests.cs
+++ b/YamlDotNet.Test/YamlPath/YamlPathTests.cs
@@ -1,0 +1,385 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using YamlDotNet.RepresentationModel;
+using YamlDotNet.YamlPath;
+
+namespace YamlDotNet.Test.YamlPath
+{
+    public class YamlPathTests
+    {
+        private const string arrayTestData = 
+            @"some_array:
+        - 0
+        - 1
+        - 2
+        - 3";
+        [InlineData("some_array.[1:2]", 1, new int[]{1})]
+        [InlineData("/some_array[1:2]", 1, new int[]{1})]
+        [InlineData("/some_array/1", 1, new int[]{1})]
+        [InlineData("/some_array/[1:2]", 1, new int[]{1})]
+        [InlineData("/some_array/[1:4]", 3, new int[]{1, 2, 3})]
+        [InlineData("/some_array/5", 0, new int[]{})]
+        [InlineData("/some_array/[0:4]", 4, new int[]{0, 1, 2, 3})]
+        [InlineData("/some_array/[-3:-2]", 1, new int[]{1})]
+
+        [Theory]
+        public void TestArraySlicing(string yamlPath, int expectedNumMatches, int[] expectedFindings)
+        {
+            var yaml = new YamlStream();
+            yaml.Load(new StringReader(arrayTestData));
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+            var matching = mapping.Query(yamlPath);
+            Assert.Equal(expectedNumMatches, matching.Count());
+            foreach (var expectedFinding in expectedFindings)
+            {
+                Assert.True(matching.Any(x => x is YamlScalarNode ysc && int.TryParse(ysc.Value, out int ysv) && ysv == expectedFinding));
+            }
+        }
+        
+        private const string mapSliceTestData = 
+            @"hash_name:
+      a_key: 0
+      b_key: 1
+      c_key: 2
+      d_key: 3
+      e_key: 4";
+        [InlineData("hash_name.[a_key:b_key]", 2, new int[]{0, 1})]
+        [InlineData("/hash_name[a_key:b_key]", 2, new int[]{0, 1})]
+        [InlineData("/hash_name/d_key", 1, new int[]{3})]
+        [InlineData("/hash_name/[a_key:b_key]", 2, new int[]{0, 1})]
+        [InlineData("/hash_name/[a_key:d_key]", 4, new int[]{0, 1, 2, 3})]
+        [InlineData("/hash_name/f_key", 0, new int[]{})]
+        [InlineData("/hash_name/[a_key:f_key]", 0, new int[]{})]
+        [InlineData("/hash_name/[a_key:e_key]", 5, new int[]{0, 1, 2, 3, 4})]
+        [Theory]
+        public void TestMapSlicing(string yamlPath, int expectedNumMatches, int[] expectedFindings)
+        {
+            var yaml = new YamlStream();
+            yaml.Load(new StringReader(mapSliceTestData));
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+            var matching = mapping.Query(yamlPath);
+            Assert.Equal(expectedNumMatches, matching.Count());
+            foreach (var expectedFinding in expectedFindings)
+            {
+                Assert.True(matching.Any(x => x is YamlScalarNode ysc && int.TryParse(ysc.Value, out int ysv) && ysv == expectedFinding));
+            }
+        }
+        
+        private const string mapQueryTestData = 
+            @"products_hash:
+      doodad:
+        availability:
+          start:
+            date: 2020-10-10
+            time: 08:00
+          stop:
+            date: 2020-10-29
+            time: 17:00
+        dimensions:
+          width: 5
+          height: 5
+          depth: 5
+          weight: 10
+      doohickey:
+        availability:
+          start:
+            date: 2020-08-01
+            time: 10:00
+          stop:
+            date: 2020-09-25
+            time: 10:00
+        dimensions:
+          width: 1
+          height: 2
+          depth: 3
+          weight: 4
+      widget:
+        availability:
+          start:
+            date: 2020-01-01
+            time: 12:00
+          stop:
+            date: 2020-01-01
+            time: 16:00
+        dimensions:
+          width: 9
+          height: 10
+          depth: 1
+          weight: 4
+
+products_array:
+  - product: doodad
+    availability:
+      start:
+        date: 2020-10-10
+        time: 08:00
+      stop:
+        date: 2020-10-29
+        time: 17:00
+    dimensions:
+      width: 5
+      height: 5
+      depth: 5
+      weight: 10
+  - product: doohickey
+    availability:
+      start:
+        date: 2020-08-01
+        time: 10:00
+      stop:
+        date: 2020-09-25
+        time: 10:00
+    dimensions:
+      width: 1
+      height: 2
+      depth: 3
+      weight: 4
+  - product: widget
+    availability:
+      start:
+        date: 2020-01-01
+        time: 12:00
+      stop:
+        date: 2020-01-01
+        time: 16:00
+    dimensions:
+      width: 9
+      height: 10
+      depth: 1
+      weight: 4
+      tag with space: 7
+      value_with_space: value with space
+      other_values: 
+        - 0
+        - 5
+        - 10";
+        [InlineData("products_array.**.[has_child(dimensions)]", 3)]
+        [InlineData("products_array.**.dimensions['tag with space'==7]", 1)]
+        [InlineData("products_array.**.dimensions[value_with_space=='value with space']", 1)]
+        [InlineData("products_array.**.dimensions[other_values>=5]", 2)]
+        [InlineData("products_array.**.[other_values>=5]", 2)]
+        [InlineData("products_array.**.dimensions[other_values>=5]", 2)]
+        [InlineData("products_hash.**", 24)]
+        [InlineData("products_array.**", 32)]
+        [InlineData("products_array.[product=widget]", 1)]
+        [InlineData("products_array.[availability.start.time=12:00]", 1)]
+        [InlineData("products_array.[availability.start.missing=12:00]", 0)]
+        [InlineData("products_array.[missing=present].start.[time=12:00]", 0)]
+        [InlineData("products_array.*.dimensions[other_values>=5]", 2)]
+        [InlineData("products_array.*.dimensions[width=9]", 1)]
+        [InlineData("products_array.*.dimensions[weight=4]", 2)]
+        [InlineData("products_array.*.dimensions[weight==4]", 2)]
+        [InlineData("products_array.*.dimensions[weight == 4]", 2)]
+        [InlineData("products_array.*.dimensions[weight<5]", 2)]
+        [InlineData("products_array.*.dimensions[weight>4]", 1)]
+        [InlineData("products_array.*.dimensions[weight<=4]", 2)]
+        [InlineData("products_array.*.dimensions[weight>=4]", 3)]
+        [InlineData("products_array.*.availability.start[date^2020]", 3)]
+        [InlineData("products_array.*.availability.start[date$01]", 2)]
+        [InlineData("products_array.*.availability.start[date%-10-]", 1)]
+        [InlineData("products_hash.*.dimensions[width=9]", 1)]
+        [InlineData("products_hash.*.dimensions[weight=4]", 2)]
+        [InlineData("products_hash.*.dimensions[weight==4]", 2)]
+        [InlineData("products_hash.*.dimensions[weight == 4]", 2)]
+        [InlineData("products_hash.*.dimensions[weight<5]", 2)]
+        [InlineData("products_hash.*.dimensions[weight>4]", 1)]
+        [InlineData("products_hash.*.dimensions[weight<=4]", 2)]
+        [InlineData("products_hash.*.dimensions[weight>=4]", 3)]
+        [InlineData("products_hash.*.availability.start[date^2020]", 3)]
+        [InlineData("products_hash.*.availability.start[date$01]", 2)]
+        [InlineData("products_hash.*.availability.start[date%-10-]", 1)]
+        [InlineData("/products_hash/*/availability/start[date=~2020.*]", 3)]
+        [InlineData("products_hash.*.availability.start[date=~2020.*]", 3)]
+        [InlineData("products_hash.*.availability.start[!date=~2020-01.*]", 2)]
+        [InlineData("products_hash.*.availability.start[date!=~2020-01.*]", 2)]
+        [InlineData("products_hash.*.availability.start[date=~2020-01.*]", 1)]
+        [InlineData("products_hash.*.availability.start[date=~.*]", 3)]
+        [InlineData("products_hash.*.availability.[start.date=~.*]", 3)]
+        [InlineData("[products_hash.*.availability.start.date=~.*]", 3)]
+        [InlineData("products_hash.*.availability.sta*.[date=~.*]", 3)]
+        [InlineData("products_hash.*.availability.*rt.[date=~.*]", 3)]
+        [InlineData("products_hash.*.availability.*a*.[date=~.*]", 3)]
+        [InlineData("products_hash.*.availability.[start.missing=~.*]", 0)]
+        [InlineData("products_hash.*.availability.[parent()]", 3)]
+        [InlineData("products_array.*.availability.[parent()]", 3)]
+        [InlineData("products_hash.*.availability.[parent(2)]", 1)]
+        [InlineData("products_array.*.availability.[parent(2)]", 1)]
+        [InlineData("products_hash.*.availability.[parent()].[parent()]", 1)]
+        [InlineData("products_array.*.availability.[parent()].[parent()]", 1)]
+        [InlineData("products_hash.*.availability.[name()]", 3)]
+        [InlineData("products_array.*.availability.[name()]", 3)]
+
+        [Theory]
+        public void TestMapQuery(string yamlPath, int expectedNumMatches)
+        {
+            var yaml = new YamlStream();
+            yaml.Load(new StringReader(mapQueryTestData));
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+            var matching = mapping.Query(yamlPath);
+            Assert.Equal(expectedNumMatches, matching.Count());
+        }
+
+        private const string setTestValue = @"--- !!set
+    ? Ring
+    ? Necklace
+    ? Bracelet";
+        
+        [InlineData("/Ring", 1)]
+
+        [Theory]
+        public void TestSetQuery(string yamlPath, int expectedNumMatches)
+        {
+            var yaml = new YamlStream();
+            yaml.Load(new StringReader(setTestValue));
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+            var matching = mapping.Query(yamlPath);
+            Assert.Equal(expectedNumMatches, matching.Count());
+        }
+        
+        private const string escapedKeysData = 
+            @"hash_name:
+      a/key: 0
+      b.key: 1
+      c\\key: 2
+      d\\/key: 3
+      e\\.key: 4";
+        [InlineData("/hash_name/a\\/key", 1, new int[]{0})]
+        [InlineData("hash_name.a/key", 1, new int[]{0})]
+        [InlineData("/hash_name/b.key", 1, new int[]{1})]
+        [InlineData("hash_name.b\\.key", 1, new int[]{1})]
+        [InlineData("hash_name.c\\\\key", 1, new int[]{2})]
+        [InlineData("/hash_name/d\\\\\\/key", 1, new int[]{3})]
+        [InlineData("hash_name.e\\\\\\.key", 1, new int[]{4})]
+        [Theory]
+        public void EscapedKeysTests(string yamlPath, int expectedNumMatches, int[] expectedFindings)
+        {
+            var yaml = new YamlStream();
+            yaml.Load(new StringReader(escapedKeysData));
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+            var matching = mapping.Query(yamlPath);
+            Assert.Equal(expectedNumMatches, matching.Count());
+            foreach (var expectedFinding in expectedFindings)
+            {
+                Assert.True(matching.Any(x => x is YamlScalarNode ysc && int.TryParse(ysc.Value, out int ysv) && ysv == expectedFinding));
+            }
+        }
+
+        private const string anchorTests = @"---
+aliases:
+  - &reusable_value This value can be used multiple times
+
+anchored_hash: &anchor1
+  with: child
+  nodes: and values
+  including: *reusable_value
+
+non_anchored_hash:
+  <<: *anchor1
+  with: its
+  own: children";
+        [InlineData("aliases[&reusable_value]", 1, "This value can be used multiple times")]
+        [InlineData("/aliases[&reusable_value]", 1, "This value can be used multiple times")]
+        [InlineData("&anchor1.&reusable_value", 1, "This value can be used multiple times")]
+        [InlineData("/&anchor1/&reusable_value", 1, "This value can be used multiple times")]
+        [InlineData("non_anchored_hash.&reusable_value", 1, "This value can be used multiple times")]
+        [InlineData("/non_anchored_hash/&reusable_value", 1, "This value can be used multiple times")]
+        [InlineData("non_anchored_hash.&anchor1.&reusable_value", 1, "This value can be used multiple times")]
+        [InlineData("/non_anchored_hash/&anchor1/&reusable_value", 1, "This value can be used multiple times")]
+        [Theory]
+        public void AnchorLiteral(string yamlPath, int expectedNumMatches, string expectedFirstScalarNode)
+        {
+            var yaml = new YamlStream();
+            yaml.Load(new StringReader(anchorTests));
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+            var matching = mapping.Query(yamlPath).ToList();
+            Assert.Equal(expectedNumMatches, matching.Count());
+            Assert.True(matching.First() is YamlScalarNode);
+            if (matching.First() is YamlScalarNode yamlScalarNode)
+            {
+                Assert.Equal(expectedFirstScalarNode, yamlScalarNode.Value);
+            }
+        }
+        
+        
+        [InlineData("&anchor1", 1, "with")]
+        [InlineData("/&anchor1", 1, "with")]
+        [InlineData("non_anchored_hash.&anchor1", 1, "with")]
+        [InlineData("/non_anchored_hash/&anchor1", 1, "with")]
+        [Theory]
+        public void AnchorReference(string yamlPath, int expectedNumMatches, string expectedFirstScalarNode)
+        {
+            var yaml = new YamlStream();
+            yaml.Load(new StringReader(anchorTests));
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+            var matching = mapping.Query(yamlPath).ToList();
+            Assert.Equal(expectedNumMatches, matching.Count());
+            Assert.True(matching.First() is YamlMappingNode);
+            if (matching.First() is YamlMappingNode yamlMappingNode)
+            {
+                if (yamlMappingNode.First().Key is YamlScalarNode yamlScalarNode)
+                {
+                    Assert.Equal(expectedFirstScalarNode, yamlScalarNode.Value);
+                }
+            }
+        }
+
+        private const string minMaxData = @"---
+    # Consistent Data Types
+    prices_aoh:
+      - product: doohickey
+        price: 4.99
+      - product: fob
+        price: 4.99
+      - product: whatchamacallit
+        price: 9.95
+      - product: widget
+        price: 0.98
+      - product: unknown
+
+    prices_hash:
+      doohickey:
+        price: 4.99
+      fob:
+        price: 4.99
+      whatchamacallit:
+        price: 9.95
+      widget:
+        price: 0.98
+      unknown:
+
+    prices_array:
+      - 4.99
+      - 4.99
+      - 9.95
+      - 0.98
+      - null";
+        [InlineData("/prices_aoh[max(price)]/price", 1, new string[]{"9.95"})]
+        [InlineData("/prices_hash/[max(price)]/price", 1, new string[]{"9.95"})]
+        [InlineData("/prices_array/[max()]", 1, new string[]{"9.95"})]
+        [InlineData("/prices_aoh[min(price)]/price", 1, new string[]{"0.98"})]
+        [InlineData("/prices_hash[min(price)]/price", 1, new string[]{"0.98"})]
+        [InlineData("/prices_array/[min()]", 1, new string[]{"0.98"})]
+        [InlineData("/prices_aoh[!max(price)]/price", 3, new string[]{"0.98", "4.99", "4.99"})]
+        [InlineData("/prices_hash/[!max(price)]/price", 3, new string[]{"0.98", "4.99", "4.99"})]
+        [InlineData("/prices_array/[!max()]", 4, new string[]{"0.98", "4.99", "4.99"})]
+        [InlineData("/prices_aoh[!min(price)]/price", 3, new string[]{"9.95", "4.99", "4.99"})]
+        [InlineData("/prices_hash[!min(price)]/price", 3, new string[]{"9.95", "4.99", "4.99"})]
+        [InlineData("/prices_array/[!min()]", 4, new string[]{"9.95", "4.99", "4.99"})]
+        [Theory]
+        public void MinMaxTests(string yamlPath, int expectedNumMatches, string[] expectedFindings)
+        {
+            var yaml = new YamlStream();
+            yaml.Load(new StringReader(minMaxData));
+            var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+            var matching = mapping.Query(yamlPath);
+            Assert.Equal(expectedNumMatches, matching.Count());
+            foreach (var expectedFinding in expectedFindings)
+            {
+                Assert.True(matching.Any(x => x is YamlScalarNode ysc && decimal.TryParse(ysc.Value, out decimal ysv) && ysv == Decimal.Parse(expectedFinding)));
+            }
+        }
+    }
+}
+

--- a/YamlDotNet.YamlPath/YamlDotNet.YamlPath.csproj
+++ b/YamlDotNet.YamlPath/YamlDotNet.YamlPath.csproj
@@ -1,0 +1,171 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net35;net45;net47;net60</TargetFrameworks>
+
+    <PackageProjectUrl>https://github.com/aaubry/YamlDotNet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/aaubry/YamlDotNet</RepositoryUrl>
+    <Description>YamlDotNet.YamlPath adds Query extension methods to YamlNode objects to perform YamlPath queries.</Description>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <Copyright>Copyright (c) Antoine Aubry and contributors</Copyright>
+    <Configurations>Debug;Release</Configurations>
+    <AssemblyOriginatorKeyFile>..\YamlDotNet.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <DocumentationFile>bin\$(Configuration)\YamlDotNet.xml</DocumentationFile>
+    <NoWarn>1591;1574</NoWarn>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+
+    <NetStandard>false</NetStandard>
+    <RealTargetFramework>$(TargetFramework)</RealTargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net40'">
+    <RealTargetFramework>unitysubset3.5</RealTargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <!-- Since the BCL is not yet annotated in other platforms, disable the nullable warnings when compiling for those -->
+    <NoWarn>1591;1574;8600;8602;8604</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <NetStandard>true</NetStandard>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <NetStandard>true</NetStandard>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net60'">
+    <NetStandard>true</NetStandard>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Portability/**/*.cs" />
+    <Compile Remove="Portability/**/*.cs" />
+    <Compile Include="Portability/*$(RealTargetFramework)*/include/*.cs" />
+    <Compile Include="Portability/*/exclude/*.cs" />
+    <Compile Remove="Portability/*$(RealTargetFramework)*/exclude/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.ComponentModel.TypeConverter">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.ComponentModel.TypeConverter">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.ComponentModel.TypeConverter">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net60'">
+    <PackageReference Include="System.ComponentModel.TypeConverter">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <Import Project="../build/common.props" />
+
+  <PropertyGroup Condition="'$(RealTargetFramework)' == 'unitysubset3.5'">
+    <FrameworkPathOverride>$(MSBuildProjectDirectory)/../BuildUtils.UnityPrerequisites/Unity Subset v3.5</FrameworkPathOverride>
+    <DefineConstants>$(DefineConstants);UNITY</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DefineConstants>$(DefineConstants);RELEASE;TRACE;SIGNED</DefineConstants>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <!--
+    Remove implicit framework references, to prevent warning of missing System.Drawing
+    when targetting Unity.
+   -->
+  <PropertyGroup Condition="'$(NetStandard)' == 'false'">
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(NetStandard)' == 'false'">
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(NetStandard)' == 'false' And '$(TargetFramework)' != 'net20'">
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(NetStandard)' == 'true'">
+    <PackageReference Include="System.Runtime.Serialization.Formatters">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.ComponentModel.TypeConverter">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Diagnostics.Debug">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <Target Name="Info" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <Empty></Empty>
+    </PropertyGroup>
+    <Message Importance="high" Text=" " Condition="'$(RealTargetFramework)' != ''" />
+    <Message Importance="high" Text="==== Building $(RealTargetFramework) $(Empty.PadRight($([MSBuild]::Subtract(100, $(RealTargetFramework.Length))), '='))" Condition="'$(RealTargetFramework)' != ''" />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\YamlDotNet\YamlDotNet.csproj" />
+  </ItemGroup>
+</Project>

--- a/YamlDotNet.YamlPath/YamlPathExtensions.cs
+++ b/YamlDotNet.YamlPath/YamlPathExtensions.cs
@@ -1,4 +1,25 @@
-﻿using System;
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/YamlDotNet.sln
+++ b/YamlDotNet.sln
@@ -25,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YamlDotNet.Benchmark", "YamlDotNet.Benchmark\YamlDotNet.Benchmark.csproj", "{52D1E5F3-8337-48FC-AED5-968B51C7DAEB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YamlDotNet.YamlPath", "YamlDotNet.YamlPath\YamlDotNet.YamlPath.csproj", "{BD61F2BF-917D-4180-92D5-EF74E8A19B2C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{52D1E5F3-8337-48FC-AED5-968B51C7DAEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{52D1E5F3-8337-48FC-AED5-968B51C7DAEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{52D1E5F3-8337-48FC-AED5-968B51C7DAEB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD61F2BF-917D-4180-92D5-EF74E8A19B2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD61F2BF-917D-4180-92D5-EF74E8A19B2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD61F2BF-917D-4180-92D5-EF74E8A19B2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD61F2BF-917D-4180-92D5-EF74E8A19B2C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -64,11 +64,17 @@
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 
@@ -76,11 +82,17 @@
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net60'">
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 
@@ -138,6 +150,18 @@
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -64,17 +64,11 @@
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>
     </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0</Version>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 
@@ -82,17 +76,11 @@
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>
     </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0</Version>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net60'">
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 
@@ -150,18 +138,6 @@
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/YamlDotNet/YamlPath/YamlPathExtensions.cs
+++ b/YamlDotNet/YamlPath/YamlPathExtensions.cs
@@ -124,12 +124,15 @@ namespace YamlDotNet.YamlPath
         /// <param name="yamlPathPieces"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        /// TODO: Not comprehensive
         private static List<string> GetQueryProblems(List<string> yamlPathPieces)
         {
             var problems = new List<string>();
             foreach (var piece in yamlPathPieces)
             {
+                if (piece.StartsWith("("))
+                {
+                    problems.Add("Collector math is not supported");
+                }
                 if (piece.StartsWith("["))
                 {
                     if (!piece.EndsWith("]"))

--- a/YamlDotNet/YamlPath/YamlPathExtensions.cs
+++ b/YamlDotNet/YamlPath/YamlPathExtensions.cs
@@ -1,0 +1,1237 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace YamlDotNet.YamlPath
+{
+    /// <summary>
+    /// Extension methods to <see cref="YamlNode"/> to perform YamlPath queries.
+    /// </summary>
+    public static class YamlPathExtensions
+    {
+        private const char EscapeCharacter = '\\';
+
+        /// <summary>
+        ///     Mapping between the string literals for the search operators and their enums
+        /// </summary>
+        private static readonly Dictionary<string, SearchOperatorEnum> StringToOperatorMapping =
+            new Dictionary<string, SearchOperatorEnum>()
+            {
+                { "==", SearchOperatorEnum.Equals },
+                { "=", SearchOperatorEnum.Equals },
+                { "=~", SearchOperatorEnum.Regex },
+                { "<=", SearchOperatorEnum.LessThanOrEqual },
+                { ">=", SearchOperatorEnum.GreaterThanOrEqual },
+                { "<", SearchOperatorEnum.LessThan },
+                { ">", SearchOperatorEnum.GreaterThan },
+                { "^", SearchOperatorEnum.StartsWith },
+                { "$", SearchOperatorEnum.EndsWith },
+                { "%", SearchOperatorEnum.Contains }
+            };
+
+        /// <summary>
+        ///     Get all the <see cref="YamlNode" /> that match the provided yamlPath query.
+        ///     See https://github.com/wwkimball/yamlpath/wiki/Segments-of-a-YAML-Path for YamlPath documentation.
+        ///     Does not support Collectors.
+        /// </summary>
+        /// <param name="yamlNode">The YamlMappingNode to operate on</param>
+        /// <param name="yamlPath">The YamlPath query to use</param>
+        /// <returns>An <see cref="IEnumerable{YamlNode}" /> of the matching nodes</returns>
+        public static IEnumerable<YamlNode> Query(this YamlNode yamlNode, string yamlPath)
+        {
+            var navigationElements = GenerateNavigationElements(yamlPath);
+            var problems = GetQueryProblems(navigationElements);
+            if (problems.Count > 0)
+            {
+                throw new FormatException(
+                    $"Provided YamlPath {yamlPath} could not be validated. {problems.Count} problems. {string.Concat(problems)}");
+            }
+
+            // Holds the current state
+            var currentNodes = new Dictionary<(Mark, Mark),YamlNode> { { (yamlNode.Start, yamlNode.End), yamlNode } };
+
+            // Iteratively walk using the navigation 
+            for (var i = 0; i < navigationElements.Count; i++)
+            {
+                // The states we can transition to from the current state, given the current navigation element
+                var nextNodes = new Dictionary<(Mark, Mark), YamlNode>();
+                foreach (var currentNode in currentNodes)
+                {
+                    // https://github.com/wwkimball/yamlpath/wiki/Wildcard-Segments
+                    // The ** operator has two behaviors. If it is the last token it captures all Scalar Leaves recursively
+                    // If it is not the last token it matches any sequence of paths as long as subsequent tokens match
+                    if (navigationElements[i] == "**")
+                    {
+                        var nextPotential = i == navigationElements.Count - 1
+                            // If this is the last element then get all the leaves
+                            ? GetLeaves(currentNode.Value)
+                            // If its not the last, we instead advance the position to every child through all levels recursively
+                            // The later components will then be checked against each element we found
+                            : RecursiveGetAllNodes(currentNode.Value);
+                        foreach (var node in nextPotential)
+                        {
+                            var markPair = (node.Start, node.End);
+                            if (!nextNodes.ContainsKey(markPair))
+                            {
+                                nextNodes.Add(markPair, node);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        foreach (var node in AdvanceNode(currentNode.Value, navigationElements[i], yamlNode))
+                        {
+                            var markPair = (node.Start, node.End);
+                            if (!nextNodes.ContainsKey(markPair))
+                            {
+                                nextNodes.Add(markPair, node);
+                            }
+                        }
+                        // Advance the current node to all possible nodes matching the navigation element
+                    }
+                }
+
+                // Nothing matched the next sequence, so stop processing.
+                if (!nextNodes.Any())
+                {
+                    return new List<YamlNode>();
+                }
+
+                // Update the current nodes
+                currentNodes = nextNodes;
+            }
+
+            return currentNodes.Values;
+        }
+
+        /// <summary>
+        /// Check the query for problems
+        /// </summary>
+        /// <param name="yamlPath"></param>
+        /// <returns></returns>
+        public static List<string> GetQueryProblems(string yamlPath)
+        {
+            return GetQueryProblems(GenerateNavigationElements(yamlPath));
+        }
+
+        /// <summary>
+        /// Returns a list of string descriptions of problems with the provided yamlPath query, or an empty list if no problems detected.
+        /// </summary>
+        /// <param name="yamlPathPieces"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        /// TODO: Not comprehensive
+        private static List<string> GetQueryProblems(List<string> yamlPathPieces)
+        {
+            var problems = new List<string>();
+            foreach (var piece in yamlPathPieces)
+            {
+                if (piece.StartsWith("["))
+                {
+                    if (!piece.EndsWith("]"))
+                    {
+                        problems.Add($"'{piece}': Path component didn't close bracket");
+                    }
+
+                    if (piece.Count(x => x == '!') > 1)
+                    {
+                        problems.Add($"'{piece}': Multiple negations for one token is not valid.");
+                    }
+
+                    if (piece.Substring(1).StartsWith("&")) // Anchors are fine
+                    {
+                        continue;
+                    }
+
+                    var parsedOperation =
+                        ParseOperator(piece);
+
+                    if (parsedOperation.OperatorEnum == SearchOperatorEnum.Invalid)
+                    {
+                        problems.Add($"'{piece}': Operation is not supported.");
+                    }
+                }
+            }
+
+            return problems;
+        }
+
+        /// <summary>
+        ///     Select elements out of the mapping node based on a single path component
+        /// </summary>
+        /// <param name="yamlMappingNode">A mapping node to query</param>
+        /// <param name="yamlPathComponent">A single path component. <see cref="GenerateNavigationElements" /></param>
+        /// <param name="rootNode"></param>
+        /// <returns>
+        ///     A <see cref="List{YamlNode}" /> of the children of the provided <see cref="YamlMappingNode" /> which match the
+        ///     query.
+        /// </returns>
+        private static IEnumerable<YamlNode> MappingNodeQuery(this YamlMappingNode yamlMappingNode, string yamlPathComponent, YamlNode rootNode)
+        {
+            // Remove braces
+            var expr = yamlPathComponent.Trim('[', ']');
+
+            if (expr.StartsWith("&"))
+            {
+                return FollowAnchor(rootNode, expr);
+            }
+
+            // If it wasn't a slice it might be an expression
+            // https://github.com/wwkimball/yamlpath/wiki/Search-Expressions
+            if (yamlPathComponent.StartsWith("[") && yamlPathComponent.EndsWith("]"))
+            {
+                return PerformOperation(yamlMappingNode, yamlPathComponent, rootNode);
+            }
+
+            // If it wasn't a slice or an expression it might be a wildcard
+            // Wild Cards https://github.com/wwkimball/yamlpath/wiki/Wildcard-Segments
+            if (yamlPathComponent == "*")
+            {
+                return yamlMappingNode.Children.Values;
+            }
+
+            // If it was none of the above treat as a literal hash key name
+            // https://github.com/wwkimball/yamlpath/wiki/Segment:-Hash-Keys
+            return yamlMappingNode.Children.Where(x =>
+                    x.Key is YamlScalarNode yamlScalarNode && yamlScalarNode.Value == yamlPathComponent)
+                .Select(x => x.Value);
+        }
+
+        /// <summary>
+        /// Gets the nodes of a hash by range. The range is specified as names of keys.
+        /// </summary>
+        /// <param name="yamlMappingNode"></param>
+        /// <param name="start">The name of the key to start with</param>
+        /// <param name="end">The name of the key to end with</param>
+        /// <returns></returns>
+        private static IEnumerable<YamlNode> GetHashNodesByRange(YamlMappingNode yamlMappingNode, string start, string end)
+        {
+            // If we have found the start key yet
+            var foundStartKey = false;
+            var outNodes = new List<YamlNode>();
+            // This is an ordered set
+            foreach (var childPair in yamlMappingNode.Children)
+            {
+                if (!foundStartKey)
+                {
+                    // Find the start key
+                    if (childPair.Key is YamlScalarNode yamlScalarKey &&
+                        (yamlScalarKey.Value?.Equals(start) ?? false))
+                    {
+                        foundStartKey = true;
+                        outNodes.Add(childPair.Value);
+                    }
+                }
+                else
+                {
+                    outNodes.Add(childPair.Value);
+                    // If we find the end, we return
+                    if (childPair.Key is YamlScalarNode yamlScalarKey &&
+                        (yamlScalarKey.Value?.Equals(end) ?? false))
+                    {
+                        return outNodes;
+                    }
+                }
+            }
+
+            // If we get here we did not find the end, so the selection is not valid
+            return Enumerable.Empty<YamlNode>();
+        }
+
+        /// <summary>
+        /// Get the nodes of a sequence based on the range provided, start inclusive, end exclusive.
+        /// </summary>
+        /// <param name="yamlSequenceNode"></param>
+        /// <param name="start"></param>
+        /// <param name="end"></param>
+        /// <returns></returns>
+        private static IEnumerable<YamlNode> GetSequenceNodesByRange(YamlSequenceNode yamlSequenceNode, string start,
+            string end)
+        {
+            if (!int.TryParse(start, out var startIdx) || !int.TryParse(end, out var endIdx))
+            {
+                yield break;
+            }
+
+            var startIdxPositive = startIdx < 0 ? yamlSequenceNode.Children.Count + startIdx : startIdx;
+            var endIdxPositive = endIdx < 0 ? yamlSequenceNode.Children.Count + endIdx : endIdx;
+
+            (startIdxPositive, endIdxPositive) = (Math.Min(startIdxPositive, endIdxPositive),
+                Math.Max(startIdxPositive, endIdxPositive));
+            for (var i = startIdxPositive; i < endIdxPositive && i < yamlSequenceNode.Children.Count && i >= 0; i++)
+            {
+                yield return yamlSequenceNode.Children[i];
+            }
+        }
+
+        /// <summary>
+        /// Parse the <paramref name="yamlPathComponent"/> and execute the appropriate operation.
+        /// </summary>
+        /// <param name="yamlSequenceNode"></param>
+        /// <param name="yamlPathComponent"></param>
+        /// <param name="rootNode">The root node of the document</param>
+        /// <returns>The matching nodes</returns>
+        private static IEnumerable<YamlNode> PerformOperation(YamlSequenceNode yamlSequenceNode, string yamlPathComponent, YamlNode rootNode)
+        {
+            // Break break down the components:
+            // The Operation to perform
+            // The element name to perform it on
+            // The argument for the operation
+            // If it should be inverted
+            var parsedOperation =
+                ParseOperator(yamlPathComponent);
+            // The operand could itself be a path, if so we need to walk it to get the correct node to operate on
+            var pieces = GenerateNavigationElements(parsedOperation.Operand);
+            if (pieces.Count > 1)
+            {
+                IEnumerable<YamlNode> nodesToUse = yamlSequenceNode.Children;
+                // Advance along the path in the operand except the last
+                for(var i = 0; i < pieces.Count - 1; i++)
+                {
+                    nodesToUse = nodesToUse.SelectMany(x => AdvanceNode(x, pieces[i], rootNode)).ToList();
+                }
+
+                // The operand to use for the actual operation is then the last piece we haven't advanced
+                var operand = pieces.Last();
+
+                foreach (var nodeToUse in nodesToUse)
+                {
+                    switch (nodeToUse)
+                    {
+                        case YamlMappingNode mappingNode:
+                            foreach (var foundVal in PerformOperation(mappingNode, parsedOperation.OperatorEnum, operand, parsedOperation.Invert, parsedOperation.Term, rootNode))
+                            {
+                                yield return foundVal;
+                            }
+                            break;
+                        case YamlSequenceNode sequenceNode:
+                            foreach (var foundVal in PerformOperation(sequenceNode, parsedOperation.OperatorEnum, operand, parsedOperation.Invert, parsedOperation.Term, rootNode))
+                            {
+                                yield return foundVal;
+                            }
+                            break;
+                    }
+                }
+            }
+            else
+            {
+                foreach (var node in PerformOperation(yamlSequenceNode, parsedOperation.OperatorEnum, parsedOperation.Operand, parsedOperation.Invert, parsedOperation.Term, rootNode))
+                {
+                    yield return node;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Execute the the appropriate operation on the provided <paramref name="yamlSequenceNode"/> based on the
+        /// <paramref name="searchOperatorEnum"/>.
+        /// </summary>
+        /// <param name="yamlSequenceNode">The <see cref="YamlSequenceNode"/> to operate on</param>
+        /// <param name="searchOperatorEnum">The <see cref="SearchOperatorEnum"/> specifying the operation type</param>
+        /// <param name="operand">The operand, usually '.'</param>
+        /// <param name="invert">If the operation results should be inverted</param>
+        /// <param name="term">The term for the operation</param>
+        /// <param name="rootNode"></param>
+        /// <returns>The matching nodes</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If the operation requested by the Enum is not supported</exception>
+        private static IEnumerable<YamlNode> PerformOperation(YamlSequenceNode yamlSequenceNode,
+            SearchOperatorEnum searchOperatorEnum, string operand, bool invert, string term, YamlNode rootNode)
+        {
+            return searchOperatorEnum switch
+            {
+                SearchOperatorEnum.Equals => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    yamlScalarNode => yamlScalarNode.Value == term),
+                SearchOperatorEnum.LessThan => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    yamlScalarNode =>
+                        int.TryParse(yamlScalarNode.Value, out var value) && value < int.Parse(term)),
+                SearchOperatorEnum.GreaterThan => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    yamlScalarNode =>
+                        int.TryParse(yamlScalarNode.Value, out var value) && value > int.Parse(term)),
+                SearchOperatorEnum.LessThanOrEqual => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    yamlScalarNode =>
+                        int.TryParse(yamlScalarNode.Value, out var value) && value <= int.Parse(term)),
+                SearchOperatorEnum.GreaterThanOrEqual => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    yamlScalarNode =>
+                        int.TryParse(yamlScalarNode.Value, out var value) && value >= int.Parse(term)),
+                SearchOperatorEnum.StartsWith => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    // See GetNodesWithPredicate
+                    // Null checking is enforced before calling the predicate
+                    yamlScalarNode => yamlScalarNode.Value!.StartsWith(term)),
+                SearchOperatorEnum.EndsWith => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    yamlScalarNode => yamlScalarNode.Value!.EndsWith(term)),
+                SearchOperatorEnum.Contains => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    yamlScalarNode => yamlScalarNode.Value!.Contains(term)),
+                SearchOperatorEnum.Regex => GetNodesWithPredicate(yamlSequenceNode, invert, operand,
+                    yamlScalarNode => Regex.IsMatch(yamlScalarNode.Value!, term)),
+                SearchOperatorEnum.Range => GetSequenceNodesByRange(yamlSequenceNode, operand, term),
+                SearchOperatorEnum.MaxChild => GetMinOrMaxOfChild(yamlSequenceNode, operand, invert, false),
+                SearchOperatorEnum.MinChild => GetMinOrMaxOfChild(yamlSequenceNode, operand, invert, true),
+                SearchOperatorEnum.HasChild => yamlSequenceNode.Children.Any(x => x is YamlScalarNode ysn && ysn.Value == operand)
+                    ? new[] { yamlSequenceNode }
+                    : Enumerable.Empty<YamlNode>(),
+                SearchOperatorEnum.Name => GetName(rootNode, yamlSequenceNode),
+                SearchOperatorEnum.Parent => int.TryParse(operand, out var numberOfLevels) ?
+                    GetParent(rootNode, yamlSequenceNode, numberOfLevels) : GetParent(rootNode, yamlSequenceNode),
+                SearchOperatorEnum.Invalid => throw new ArgumentOutOfRangeException(nameof(searchOperatorEnum)),
+                _ => throw new ArgumentOutOfRangeException(nameof(searchOperatorEnum))
+            };
+        }
+
+        /// <summary>
+        /// If this yaml node is a value in a mapping gets the node for the key which refers to it
+        /// </summary>
+        /// <param name="rootNode">The root node of the document</param>
+        /// <param name="yamlNode">The node to get the name of</param>
+        /// <returns>Either the name node of an empty enumeration</returns>
+        private static IEnumerable<YamlNode> GetName(YamlNode rootNode, YamlNode yamlNode)
+        {
+            foreach (var node in rootNode.AllNodes)
+            {
+                if (node is YamlMappingNode { } yamlMappingNode)
+                {
+                    foreach (var child in yamlMappingNode.Children)
+                    {
+                        if (child.Value.Start.Equals(yamlNode.Start) && child.Value.End.Equals(yamlNode.End) && child.Value.Equals(yamlNode))
+                        {
+                            return new[] { child.Key };
+                        }
+                    }
+                }
+            }
+
+            return Enumerable.Empty<YamlNode>();
+        }
+
+        /// <summary>
+        /// Gets the parent node of this yaml node
+        /// </summary>
+        /// <param name="rootNode">The root node of the document</param>
+        /// <param name="yamlNode">The node to get the parent of</param>
+        /// <param name="numberOfLevels">The number of parent levels to traverse</param>
+        /// <returns>Either the parent node or an empty enumeration if there isn't one</returns>
+        private static IEnumerable<YamlNode> GetParent(YamlNode rootNode, YamlNode yamlNode, int numberOfLevels)
+        { 
+            var current = new []{yamlNode};
+            for (var i = 0; i < numberOfLevels; i++)
+            {
+                if (current.Length == 1)
+                {
+                    current = GetParent(rootNode, current[0]).ToArray();
+                }
+                else
+                {
+                    return Enumerable.Empty<YamlNode>();
+                }
+            }
+            return current;
+        }
+        
+        /// <summary>
+        /// Gets the parent node of this yaml node
+        /// </summary>
+        /// <param name="rootNode">The root node of the document</param>
+        /// <param name="yamlNode">The node to get the parent of</param>
+        /// <returns>Either the parent node or an empty enumeration if there isn't one</returns>
+        private static IEnumerable<YamlNode> GetParent(YamlNode rootNode, YamlNode yamlNode)
+        {
+            foreach (var node in rootNode.AllNodes)
+            {
+                if (node is YamlMappingNode { } yamlMappingNode)
+                {
+                    foreach (var child in yamlMappingNode.Children)
+                    {
+                        if (child.Value.Start.Equals(yamlNode.Start) && child.Value.End.Equals(yamlNode.End) && child.Value.Equals(yamlNode))
+                        {
+                            return new[] { yamlMappingNode };
+                        }
+                    }
+                }
+                else if (node is YamlSequenceNode { } yamlSequenceNode)
+                {
+                    foreach (var child in yamlSequenceNode.Children)
+                    {
+                        if (child.Start.Equals(yamlNode.Start) && child.End.Equals(yamlNode.End) && child.Equals(yamlNode))
+                        {
+                            return new[] { yamlSequenceNode };
+                        }
+                    }
+                }
+            }
+
+            return Enumerable.Empty<YamlNode>();
+        }
+
+        /// <summary>
+        /// Parse the <paramref name="yamlPathComponent"/> and execute the appropriate operation.
+        /// </summary>
+        /// <param name="yamlMappingNode"></param>
+        /// <param name="yamlPathComponent"></param>
+        /// <param name="rootNode"></param>
+        /// <returns>The matching nodes</returns>
+        private static IEnumerable<YamlNode> PerformOperation(YamlMappingNode yamlMappingNode, string yamlPathComponent, YamlNode rootNode)
+        {
+            // Break break down the components:
+            // The Operation to perform
+            // The element name to perform it on
+            // The argument for the operation
+            // If it should be inverted
+            var parsedOperation =
+                ParseOperator(yamlPathComponent);
+            // The operand could itself be a path
+            IEnumerable<YamlNode> nodesToUse = new List<YamlNode>(){yamlMappingNode};
+            var pieces = GenerateNavigationElements(parsedOperation.Operand);
+            if (pieces.Count > 1)
+            {
+                for(var i = 0; i < pieces.Count - 1; i++)
+                {
+                    nodesToUse = nodesToUse.SelectMany(x => AdvanceNode(x, pieces[i], rootNode)).ToList();
+                }
+
+                var operand = pieces.Last();
+
+                foreach (var nodeToUse in nodesToUse)
+                {
+                    switch (nodeToUse)
+                    {
+                        case YamlMappingNode mappingNode:
+                            foreach (var foundVal in PerformOperation(mappingNode, parsedOperation.OperatorEnum, operand, parsedOperation.Invert, parsedOperation.Term, rootNode))
+                            {
+                                yield return foundVal;
+                            }
+                            break;
+                        case YamlSequenceNode sequenceNode:
+                            foreach (var foundVal in PerformOperation(sequenceNode, parsedOperation.OperatorEnum, operand, parsedOperation.Invert, parsedOperation.Term, rootNode))
+                            {
+                                yield return foundVal;
+                            }
+                            break;
+                    }
+                }
+            }
+            else
+            {
+                foreach (var node in PerformOperation(yamlMappingNode, parsedOperation.OperatorEnum, parsedOperation.Operand, parsedOperation.Invert, parsedOperation.Term, rootNode))
+                {
+                    yield return node;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Execute the the appropriate operation on the provided <paramref name="yamlMappingNode"/> based on the
+        /// <paramref name="searchOperatorEnum"/>.
+        /// </summary>
+        /// <param name="yamlMappingNode">The <see cref="YamlMappingNode"/> to operate on</param>
+        /// <param name="searchOperatorEnum">The <see cref="SearchOperatorEnum"/> specifying the operation type</param>
+        /// <param name="operand">The operand to select keys</param>
+        /// <param name="invert">If the operation results should be inverted</param>
+        /// <param name="term">The term for the operation</param>
+        /// <param name="rootNode"></param>
+        /// <returns>The matching nodes</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If the operation requested by the Enum is not supported</exception>
+        private static IEnumerable<YamlNode> PerformOperation(YamlMappingNode yamlMappingNode, SearchOperatorEnum searchOperatorEnum,
+            string operand, bool invert, string term, YamlNode rootNode)
+        {
+            return searchOperatorEnum switch
+            {
+                SearchOperatorEnum.Equals => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    yamlScalarNode => yamlScalarNode.Value == term),
+                SearchOperatorEnum.LessThan => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    yamlScalarNode =>
+                        int.TryParse(yamlScalarNode.Value, out var value) && value < int.Parse(term)),
+                SearchOperatorEnum.GreaterThan => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    yamlScalarNode =>
+                        int.TryParse(yamlScalarNode.Value, out var value) && value > int.Parse(term)),
+                SearchOperatorEnum.LessThanOrEqual => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    yamlScalarNode =>
+                        int.TryParse(yamlScalarNode.Value, out var value) && value <= int.Parse(term)),
+                SearchOperatorEnum.GreaterThanOrEqual => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    yamlScalarNode =>
+                        int.TryParse(yamlScalarNode.Value, out var value) && value >= int.Parse(term)),
+                SearchOperatorEnum.StartsWith => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    // See GetNodesWithPredicate
+                    // Null checking is enforced before calling the predicate
+                    yamlScalarNode => yamlScalarNode.Value!.StartsWith(term)),
+                SearchOperatorEnum.EndsWith => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    yamlScalarNode => yamlScalarNode.Value!.EndsWith(term)),
+                SearchOperatorEnum.Contains => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    yamlScalarNode => yamlScalarNode.Value!.Contains(term)),
+                SearchOperatorEnum.Regex => GetNodesWithPredicate(yamlMappingNode, operand, invert,
+                    yamlScalarNode => Regex.IsMatch(yamlScalarNode.Value!, term)),
+                SearchOperatorEnum.Range => GetHashNodesByRange(yamlMappingNode, operand, term),
+                SearchOperatorEnum.MaxChild => GetMinOrMaxOfChild(yamlMappingNode, operand, invert, false),
+                SearchOperatorEnum.MinChild => GetMinOrMaxOfChild(yamlMappingNode, operand, invert, true),
+                SearchOperatorEnum.HasChild => yamlMappingNode.Children.Any(x =>
+                    x.Key is YamlScalarNode ysn && ysn.Value == operand)
+                    ? new[] { yamlMappingNode }
+                    : Enumerable.Empty<YamlNode>(),
+                SearchOperatorEnum.Name => GetName(rootNode, yamlMappingNode),
+                SearchOperatorEnum.Parent => int.TryParse(operand, out var numberOfLevels) ?
+                    GetParent(rootNode, yamlMappingNode, numberOfLevels) : GetParent(rootNode, yamlMappingNode),
+                SearchOperatorEnum.Invalid => throw new ArgumentOutOfRangeException(nameof(searchOperatorEnum)),
+                _ => throw new ArgumentOutOfRangeException(nameof(searchOperatorEnum))
+            };
+        }
+        
+        /// <summary>
+        /// Gets the min or max of the values of the keys of the provided <see cref="YamlSequenceNode"/>
+        /// </summary>
+        /// <param name="yamlSequenceNode">The <see cref="YamlSequenceNode"/> to check</param>
+        /// <param name="operand">The operand, '.' to check values</param>
+        /// <param name="invert">If result should be inverted</param>
+        /// <param name="doMinimum">If true, return minimum, if false return maximum</param>
+        /// <returns>The matching nodes</returns>
+        private static IEnumerable<YamlNode> GetMinOrMaxOfChild(YamlSequenceNode yamlSequenceNode, string operand, bool invert, bool doMinimum)
+        {
+            if (!string.IsNullOrEmpty(operand))
+            {
+                var potentialNodes = new List<(YamlNode, ParsedNode)>();
+                foreach (var child in yamlSequenceNode.Children)
+                {
+                    if (child is YamlMappingNode childMappingNode)
+                    {
+                        foreach (var targetChild in childMappingNode.Children)
+                        {
+                            // The value for this key is a valid target to take the max of
+                            if (targetChild.Key is YamlScalarNode { Value: { } } scalarKeyNode &&
+                                scalarKeyNode.Value == operand)
+                            {
+                                if (!(targetChild.Value is YamlScalarNode { Value: { } } yamlScalarNode))
+                                {
+                                    continue;
+                                }
+
+                                potentialNodes.Add((childMappingNode, new ParsedNode(yamlScalarNode)));
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (potentialNodes.Count > 0)
+                {
+                    var maxIndex = MaxIndex(doMinimum, potentialNodes.Select(x => x.Item2).ToList());
+
+                    if (invert)
+                    {
+                        potentialNodes.RemoveAt(maxIndex);
+                        foreach (var node in potentialNodes.Select(x => x.Item1))
+                        {
+                            yield return node;
+                        }
+                        yield break;
+                    }
+                    yield return potentialNodes[maxIndex].Item1;
+                }
+            }
+            else
+            {
+                var potentialNodes = new List<ParsedNode>();
+                foreach (var child in yamlSequenceNode.Children)
+                {
+                    if (child is YamlScalarNode { Value: { } } scalarValueNode)
+                    {
+                        potentialNodes.Add(new ParsedNode(scalarValueNode));
+                    }
+                }
+
+                if (potentialNodes.Count > 0)
+                {
+                    var maxIndex = MaxIndex(doMinimum, potentialNodes);
+
+                    if (invert)
+                    {
+                        potentialNodes.RemoveAt(maxIndex);
+                        foreach (var node in potentialNodes.Select(x => x.ParsedScalarNode))
+                        {
+                            yield return node;
+                        }
+                        yield break;
+                    }
+                    yield return potentialNodes[maxIndex].ParsedScalarNode;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the index of the maximal valued parsed node. If the first node's decimal value is non-null will use decimal comparison
+        /// otherwise will use string comparison.
+        /// </summary>
+        /// <param name="doMinimum">If the index of the minimum is desired, otherwise returns index of maximum</param>
+        /// <param name="potentialNodes">The list of parsed nodes</param>
+        /// <returns>The index of the maximal value</returns>
+        private static int MaxIndex(bool doMinimum, List<ParsedNode> potentialNodes)
+        {
+            var maxIndex = 0;
+            if (potentialNodes[0].DecimalValue is { })
+            {
+                for (var index = 1; index < potentialNodes.Count; index++)
+                {
+                    if (potentialNodes[index].DecimalValue is { })
+                    {
+                        if (doMinimum)
+                        {
+                            if (potentialNodes[index].DecimalValue < potentialNodes[maxIndex].DecimalValue)
+                            {
+                                maxIndex = index;
+                            }
+                        }
+                        else
+                        {
+                            if (potentialNodes[index].DecimalValue > potentialNodes[maxIndex].DecimalValue)
+                            {
+                                maxIndex = index;
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (var index = 1; index < potentialNodes.Count; index++)
+                {
+                    if (doMinimum)
+                    {
+                        if (string.Compare(potentialNodes[index].StringValue, potentialNodes[maxIndex].StringValue,
+                                StringComparison.Ordinal) < 0)
+                        {
+                            maxIndex = index;
+                        }
+                    }
+                    else
+                    {
+                        if (string.Compare(potentialNodes[index].StringValue, potentialNodes[maxIndex].StringValue,
+                                StringComparison.Ordinal) > 0)
+                        {
+                            maxIndex = index;
+                        }
+                    }
+                }
+            }
+
+            return maxIndex;
+        }
+
+        /// <summary>
+        /// Gets the min or max of the values of the keys of the provided <see cref="YamlMappingNode"/> with key name <see cref="operand"/>
+        /// </summary>
+        /// <param name="yamlMappingNode">The <see cref="YamlMappingNode"/> to check</param>
+        /// <param name="operand">The operand to specify key names</param>
+        /// <param name="invert">If result should be inverted</param>
+        /// <param name="doMinimum">If true, return minimum, if false return maximum</param>
+        /// <returns>The matching nodes</returns>
+        private static IEnumerable<YamlNode> GetMinOrMaxOfChild(YamlMappingNode yamlMappingNode, string operand, bool invert, bool doMinimum)
+        {
+            var potentialNodes = new List<(YamlMappingNode, ParsedNode)>();
+            foreach (var child in yamlMappingNode.Children)
+            {
+                if (child.Value is YamlMappingNode childMappingNode)
+                {
+                    foreach (var targetChild in childMappingNode.Children)
+                    {
+                        // The value for this key is a valid target to take the max of
+                        if (targetChild.Key is YamlScalarNode { Value: { } } scalarKeyNode && scalarKeyNode.Value == operand)
+                        {
+                            if (targetChild.Value is YamlScalarNode { Value: { } } scalarValueNode)
+                            {
+                                potentialNodes.Add((childMappingNode, new ParsedNode(scalarValueNode)));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (potentialNodes.Count > 0)
+            {
+                var maxIndex = MaxIndex(doMinimum, potentialNodes.Select(x => x.Item2).ToList());
+                if (invert)
+                {
+                    potentialNodes.RemoveAt(maxIndex);
+                    foreach (var node in potentialNodes.Select(x => x.Item1))
+                    {
+                        yield return node;
+                    }
+                    yield break;
+                }
+                yield return potentialNodes[maxIndex].Item1;
+            }
+        }
+
+        /// <summary>
+        /// Returned from <see cref="ParseNode"/> to check numbers when possible and strings when not
+        /// </summary>
+        private class ParsedNode
+        {
+            internal YamlScalarNode ParsedScalarNode { get; }
+            /// <summary>
+            /// Always contains the string value of the parsed node
+            /// </summary>
+            internal string? StringValue { get; }
+            /// <summary>
+            /// IF the parsedNode value could be parsed as <see cref="Decimal"/> this will be populated with the result
+            /// </summary>
+            internal decimal? DecimalValue { get; }
+
+            internal ParsedNode(YamlScalarNode scalarNode)
+            {
+                ParsedScalarNode = scalarNode;
+                if (decimal.TryParse(ParsedScalarNode.Value, out var parsedDecimalValue))
+                {
+                    DecimalValue = parsedDecimalValue;
+                }
+                StringValue = ParsedScalarNode.Value;
+            }
+        }
+
+        /// <summary>
+        ///     Get the selected nodes from the <see cref="YamlMappingNode" /> matching the element name and matching the predicate
+        /// </summary>
+        /// <param name="yamlMappingNode"></param>
+        /// <param name="operand">The operand to use, see <see cref="ParseOperator"/></param>
+        /// <param name="invert">If the result of the predicate should be inverted</param>
+        /// <param name="predicate">The predicate to test</param>
+        /// <returns>Enumeration of YamlNodes that pass the predicate</returns>
+        private static IEnumerable<YamlNode> GetNodesWithPredicate(YamlMappingNode yamlMappingNode, string operand,
+            bool invert, Func<YamlScalarNode, bool> predicate)
+        {
+            foreach (var child in yamlMappingNode.Children)
+            {
+                if (operand == ".")
+                {
+                    if (child.Key is YamlScalarNode { Value: { } } keyNode)
+                    {
+                        if (invert ? !predicate(keyNode) : predicate(keyNode))
+                        {
+                            yield return child.Value;
+                        }
+                    }
+                }
+                else
+                {
+                    // The key must match the element name
+                    if (child.Key is YamlScalarNode { Value: { } } keyNode && keyNode.Value == operand)
+                    {
+                        // Scalar nodes we can just return if they match the predicate
+                        if (child.Value is YamlScalarNode { Value: { } } valueNode)
+                        {
+                            if (invert ? !predicate(valueNode) : predicate(valueNode))
+                            {
+                                yield return valueNode;
+                            }
+                        }
+                        // Sequences we return the values of the sequence that match the predicate
+                        else if (child.Value is YamlSequenceNode yamlSequenceNode)
+                        {
+                            foreach (var subChild in yamlSequenceNode.Children)
+                            {
+                                if (subChild is YamlScalarNode { Value: { } } subChildValueNode)
+                                {
+                                    if (invert ? !predicate(subChildValueNode) : predicate(subChildValueNode))
+                                    {
+                                        yield return subChild;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Get the nodes from the <see cref="YamlSequenceNode" /> matching the predicate
+        /// </summary>
+        /// <param name="yamlSequenceNode"></param>
+        /// <param name="operand">The operand to use, see <see cref="ParseOperator"/></param>
+        /// <param name="invert">If the result of the predicate should be inverted</param>
+        /// <param name="predicate">The predicate to test</param>
+        /// <returns>Enumeration of YamlNodes that pass the predicate</returns>
+        private static IEnumerable<YamlNode> GetNodesWithPredicate(YamlSequenceNode yamlSequenceNode,
+            bool invert, string operand, Func<YamlScalarNode, bool> predicate)
+        {
+            foreach (var child in yamlSequenceNode.Children)
+            {
+                // Scalar nodes we can just return if they match the predicate
+                if (child is YamlScalarNode { Value: { } } valueNode)
+                {
+                    if (invert ? !predicate(valueNode) : predicate(valueNode))
+                    {
+                        yield return valueNode;
+                    }
+                }
+                else if (child is YamlMappingNode yamlMappingNode)
+                {
+                    foreach(var targetChild in yamlMappingNode.Children.Where(x => x.Key is YamlScalarNode ysn && ysn.Value == operand))
+                    {
+                        if (targetChild.Value is YamlScalarNode { Value: { } } yamlScalarNode)
+                        {
+                            if (invert ? !predicate(yamlScalarNode) : predicate(yamlScalarNode))
+                            {
+                                yield return yamlScalarNode;
+                            }
+                        }   
+                    }
+                }
+            }
+        }
+        
+        /// <summary>
+        ///     Gets all of the Scalar nodes which are children or grandchildren etc of the given node
+        /// </summary>
+        /// <param name="yamlNode"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private static IEnumerable<YamlNode> GetLeaves(YamlNode yamlNode)
+        {
+            return yamlNode switch
+            {
+                YamlScalarNode scalarNode => new[] { scalarNode },
+                YamlSequenceNode sequenceNode => sequenceNode.Children.SelectMany(GetLeaves),
+                YamlMappingNode mappingNode => mappingNode.Children.SelectMany(x => GetLeaves(x.Value)),
+                _ => throw new ArgumentOutOfRangeException(nameof(yamlNode))
+            };
+        }
+
+        private class ParsedOperation
+        {
+            internal SearchOperatorEnum OperatorEnum { get; }
+            internal string Operand { get; }
+            internal string Term { get; }
+            internal bool Invert { get; }
+
+            internal ParsedOperation(SearchOperatorEnum operatorEnum, string operand, string term, bool invert)
+            {
+                OperatorEnum = operatorEnum;
+                Operand = operand;
+                Term = term;
+                Invert = invert;
+            }
+        }
+        
+        /// <summary>
+        ///     Parse the operator component into its pieces
+        /// </summary>
+        /// <param name="yamlPathComponent"></param>
+        /// <returns></returns>
+        private static ParsedOperation
+            ParseOperator(string yamlPathComponent)
+        {
+            yamlPathComponent = yamlPathComponent.TrimStart('[').TrimEnd(']');
+            var invert = false;
+            if (yamlPathComponent[0] == '!')
+            {
+                yamlPathComponent = yamlPathComponent.Substring(1);
+                invert = !invert;
+            }
+
+            // First Check 2 length strings to greedily match
+            foreach (var pair in StringToOperatorMapping.Where(x => x.Key.Length == 2))
+            {
+                var idx = yamlPathComponent.IndexOf(pair.Key, StringComparison.Ordinal);
+                if (idx > -1)
+                {
+                    if (yamlPathComponent[idx - 1] == '!')
+                    {
+                        invert = !invert;
+                        return new ParsedOperation(pair.Value, yamlPathComponent.Substring(0,(idx - 1)).Trim().Trim('\'', '"'),
+                            yamlPathComponent.Substring((idx + pair.Key.Length)).Trim().Trim('\'', '"'), invert);
+                    }
+
+                    return new ParsedOperation(pair.Value, yamlPathComponent.Substring(0,idx).Trim().Trim('\'', '"'),
+                        yamlPathComponent.Substring((idx + pair.Key.Length)).Trim().Trim('\'', '"'), invert);
+                }
+            }
+
+            // No 2 length matches so we can check for 1 length matches
+            foreach (var pair in StringToOperatorMapping.Where(x => x.Key.Length == 1))
+            {
+                var idx = yamlPathComponent.IndexOf(pair.Key, StringComparison.Ordinal);
+                if (idx > -1)
+                {
+                    if (yamlPathComponent[idx - 1] == '!')
+                    {
+                        invert = !invert;
+                        return new ParsedOperation(pair.Value, yamlPathComponent.Substring(0,(idx - 1)).Trim().Trim('\'', '"'),
+                            yamlPathComponent.Substring((idx + pair.Key.Length)).Trim().Trim('\'', '"'), invert);
+                    }
+
+                    return new ParsedOperation(pair.Value, yamlPathComponent.Substring(0,idx).Trim().Trim('\'', '"'),
+                        yamlPathComponent.Substring((idx + pair.Key.Length)).Trim().Trim('\'', '"'), invert);
+                }
+            }
+
+            // No 2 length or 1 length matches so we check for ranges
+            var rangeIndex = yamlPathComponent.IndexOf(':');
+            if (rangeIndex > -1)
+            {
+                return new ParsedOperation(SearchOperatorEnum.Range, yamlPathComponent.Substring(0, rangeIndex),
+                    yamlPathComponent.Substring(rangeIndex+1), invert);
+            }
+            
+            // No range so we check for keywords
+            rangeIndex = yamlPathComponent.IndexOf("has_child", StringComparison.Ordinal);
+            if (rangeIndex > -1)
+            {
+                // 10 length of has_child(
+                return new ParsedOperation(SearchOperatorEnum.HasChild, yamlPathComponent.Substring(rangeIndex + 10).Trim(')'), string.Empty, invert);
+            }
+
+            rangeIndex = yamlPathComponent.IndexOf("max", StringComparison.Ordinal);
+            if (rangeIndex > -1)
+            {
+                // 4 length of max(
+                return new ParsedOperation(SearchOperatorEnum.MaxChild, yamlPathComponent.Substring(rangeIndex + 4).Trim(')'), string.Empty, invert);
+            }
+            
+            rangeIndex = yamlPathComponent.IndexOf("min", StringComparison.Ordinal);
+            if (rangeIndex > -1)
+            {
+                // 4 length of min(
+                return new ParsedOperation(SearchOperatorEnum.MinChild, yamlPathComponent.Substring(rangeIndex + 4).Trim(')'), string.Empty, invert);
+            }
+            
+            rangeIndex = yamlPathComponent.IndexOf("name", StringComparison.Ordinal);
+            if (rangeIndex > -1)
+            {
+                // 5 length of name(
+                return new ParsedOperation(SearchOperatorEnum.Name, yamlPathComponent.Substring(rangeIndex + 5).Trim(')'), string.Empty, invert);
+            }
+            
+            rangeIndex = yamlPathComponent.IndexOf("parent", StringComparison.Ordinal);
+            if (rangeIndex > -1)
+            {
+                // 7 length of parent(
+                return new ParsedOperation(SearchOperatorEnum.Parent, yamlPathComponent.Substring(rangeIndex + 7).Trim(')'), string.Empty, invert);
+            }
+            return new ParsedOperation(SearchOperatorEnum.Invalid, string.Empty, string.Empty, false);
+        }
+
+        /// <summary>
+        ///     Select elements out of the mapping node based on a single path component
+        /// </summary>
+        /// <param name="yamlNode"></param>
+        /// <param name="yamlPathComponent"></param>
+        /// <param name="rootNode"></param>
+        /// <returns></returns>
+        private static IEnumerable<YamlNode> SequenceNodeQuery(this YamlSequenceNode yamlNode, string yamlPathComponent, YamlNode rootNode)
+        {
+            var expr = yamlPathComponent.Trim(new[] { '[', ']' });
+            if (expr.StartsWith("&"))
+            {
+                return FollowAnchor(yamlNode, expr);
+            }
+
+            // https://github.com/wwkimball/yamlpath/wiki/Search-Expressions
+            if (yamlPathComponent.StartsWith("[") && yamlPathComponent.EndsWith("]"))
+            {
+                return PerformOperation(yamlNode, yamlPathComponent, rootNode);
+            }
+
+            // Wild Cards https://github.com/wwkimball/yamlpath/wiki/Wildcard-Segments
+            if (yamlPathComponent == "*")
+            {
+                return yamlNode.Children;
+            }
+
+            if (int.TryParse(yamlPathComponent, out var intVal))
+            {
+                if (intVal >= 0 && intVal < yamlNode.Children.Count)
+                {
+                    return new[] { yamlNode.Children[intVal] };
+                }
+            }
+
+            return Enumerable.Empty<YamlNode>();
+        }
+
+        /// <summary>
+        ///     Gets all child nodes (and their children) recursively of the given node.
+        /// </summary>
+        /// <param name="currentNode">The node to explore</param>
+        /// <returns>An enumeration of the child nodes</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If an unsupported type of <see cref="YamlNode" /> is provided</exception>
+        private static IEnumerable<YamlNode> RecursiveGetAllNodes(YamlNode currentNode)
+        {
+            return currentNode switch
+            {
+                YamlMappingNode yamlMappingNode => yamlMappingNode.Children.Values.Union(
+                    yamlMappingNode.Children.SelectMany(x => RecursiveGetAllNodes(x.Value))).Distinct(),
+                YamlSequenceNode yamlSequenceNode => yamlSequenceNode.Children.Union(
+                    yamlSequenceNode.Children.SelectMany(RecursiveGetAllNodes)).Distinct(),
+                YamlScalarNode _ => Enumerable
+                    .Empty<YamlNode>(), // Scalar children were already added by the recursion in the sequence or mapping
+                _ => throw new ArgumentOutOfRangeException(nameof(currentNode))
+            };
+        }
+
+        /// <summary>
+        ///     Break the provided <see cref="yamlPath" /> into components to iterate with
+        /// </summary>
+        /// <param name="yamlPath">The full YamlPath to break down</param>
+        /// <returns>A list of the broken down path pieces</returns>
+        private static List<string> GenerateNavigationElements(string yamlPath)
+        {
+            if (string.IsNullOrEmpty(yamlPath))
+            {
+                return new List<string>();
+            }
+            var pathComponents = new List<string>();
+            // The separator can either be . or /, but if it is / the string must start with /
+            var separator = yamlPath[0] == '/' ? '/' : '.';
+            // Ignore separators in brackets
+            var bracketsMode = false;
+            var demarcationMode = false;
+            var demarcationCharacter = '\'';
+            // The start of the currently tracked token
+            var startIndex = 0;
+            for (var i = 0; i < yamlPath.Length; i++)
+            {
+                if (!bracketsMode && !demarcationMode)
+                {
+                    // End of the token, add to components
+                    // Enter bracket mode, ignore separators until the next ]
+                    if (yamlPath[i] == '[')
+                    {
+                        bracketsMode = true;
+                        pathComponents.Add(yamlPath.Substring(startIndex,(i-startIndex)));
+                        startIndex = i;
+                    }
+
+                    if (yamlPath[i] == '\'')
+                    {
+                        demarcationMode = true;
+                        demarcationCharacter = '\'';
+                        startIndex = i + 1;
+                    }
+                    
+                    if (yamlPath[i] == '\"')
+                    {
+                        demarcationMode = true;
+                        demarcationCharacter = '"';
+                        startIndex = i + 1;
+                    }
+
+                    if (yamlPath[i] == separator)
+                    {
+                        var isEscaped = false;
+                        var innerItr = i;
+                        // Walk backwards to count the number of escape characters to determine if this separator is escaped.
+                        while (--innerItr >= 0 && yamlPath[innerItr] == EscapeCharacter)
+                        {
+                            isEscaped = !isEscaped;
+                        }
+
+                        if (!isEscaped)
+                        {
+                            pathComponents.Add(yamlPath.Substring(startIndex,(i-startIndex)));
+                            startIndex = i + 1;
+                        }
+                    }
+                }
+                else if (bracketsMode)
+                {
+                    // TODO: Strip out non-demarcated whitespace from brackets per https://github.com/wwkimball/yamlpath/wiki/Search-Expressions#supported-search-operators
+                    if (yamlPath[i] == ']')
+                    {
+                        bracketsMode = false;
+                        pathComponents.Add(yamlPath.Substring(startIndex,(i+1-startIndex)));
+                        startIndex = i + 1;
+                    }
+                }
+                else if (demarcationMode)
+                {
+                    if (yamlPath[i] == demarcationCharacter)
+                    {
+                        demarcationMode = false;
+                        pathComponents.Add(yamlPath.Substring(startIndex,(i-startIndex)));
+                        startIndex = i + 1;
+                    }
+                }
+            }
+
+            pathComponents.Add(yamlPath.Substring(startIndex));
+            pathComponents.RemoveAll(string.IsNullOrEmpty);
+            pathComponents = pathComponents.Select(x => x.Replace($"\\{separator}", $"{separator}")).ToList();
+            
+            // WildCards Search Shorthand https://github.com/wwkimball/yamlpath/wiki/Wildcard-Segments#search-shorthand 
+            for (var i =0; i < pathComponents.Count; i++)
+            {
+                // Search shorthand doesn't apply to expressions
+                if (!pathComponents[i].Contains('[') && pathComponents[i].Contains("*") && pathComponents[i] != "**" && pathComponents[i] != "*")
+                {
+                    var newExpression = new StringBuilder();
+                    newExpression.Append("[.=~");
+                    if (pathComponents[i].StartsWith("*"))
+                    {
+                        newExpression.Append("^");
+                    }
+                    newExpression.Append(pathComponents[i].Replace("*", ".*"));
+                    if (pathComponents[i].EndsWith("*"))
+                    {
+                        newExpression.Append("$");
+                    }
+                    newExpression.Append("]");
+                    pathComponents[i] = newExpression.ToString();
+                }
+            }
+            
+            return pathComponents;
+        }
+
+        /// <summary>
+        /// Get the set of nodes which can be transitioned from given the path component
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="pathComponent"></param>
+        /// <param name="rootNode"></param>
+        /// <returns></returns>
+        private static IEnumerable<YamlNode> AdvanceNode(YamlNode node, string pathComponent, YamlNode rootNode)
+        {
+            if (pathComponent.StartsWith("&"))
+            {
+                return FollowAnchor(rootNode, pathComponent);
+            }
+            return node switch
+            {
+                YamlMappingNode yamlMappingNode => yamlMappingNode.MappingNodeQuery(pathComponent, rootNode),
+                YamlSequenceNode yamlSequenceNode => yamlSequenceNode.SequenceNodeQuery(pathComponent, rootNode),
+                YamlScalarNode _ => Enumerable.Empty<YamlNode>(), // No path inside a scalar
+                _ => Enumerable.Empty<YamlNode>() // Nothing else is valid to continue
+            };
+        }
+
+        private static IEnumerable<YamlNode> FollowAnchor(YamlNode yamlNode, string pathComponent)
+        {
+            return yamlNode.AllNodes.Where(x => !x.Anchor.IsEmpty && 
+                                                    x.Anchor.Value == pathComponent.TrimStart('&')).Distinct();
+        }
+
+        /// <summary>
+        ///     Enum for the types of search operation operators
+        /// </summary>
+        private enum SearchOperatorEnum
+        {
+            Invalid,
+            Equals,
+            LessThan,
+            GreaterThan,
+            LessThanOrEqual,
+            GreaterThanOrEqual,
+            StartsWith,
+            EndsWith,
+            Contains,
+            Regex,
+            Range,
+            HasChild,
+            MinChild,
+            MaxChild,
+            Name,
+            Parent
+        }
+    }
+}


### PR DESCRIPTION
Adds support for YamlPath queries as a `Query` extension method to `YamlNode`.

Basic Usage to search a whole document:

```csharp
using YamlDotNet.YamlPath;

YamlStream yaml = new YamlStream();
yaml.Load(new StringReader(targetYamlString));
YamlMappingNode mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
IEnumerable<YamlNode> matching = mapping.Query(yourYamlPathQuery);
```

Fix #333

Implemented based on the YamlPath Spec located here: https://github.com/wwkimball/yamlpath/wiki/Segments-of-a-YAML-Path

Supported:
[Anchors](https://github.com/wwkimball/yamlpath/wiki/Segment:-Anchors)
[Array Elements](https://github.com/wwkimball/yamlpath/wiki/Segment:-Array-Elements)
[Array Element Searches](https://github.com/wwkimball/yamlpath/wiki/Segment:-Array-Element-Searches)
[Array Slices](https://github.com/wwkimball/yamlpath/wiki/Segment:-Array-Slices)
[Hash Attribute Searches](https://github.com/wwkimball/yamlpath/wiki/Segment:-Hash-Attribute-Searches)
[Hash Keys](https://github.com/wwkimball/yamlpath/wiki/Segment:-Hash-Keys)
[Hash Slices](https://github.com/wwkimball/yamlpath/wiki/Segment:-Hash-Slices)
[Pass-Through Selections for Arrays of Hashes](https://github.com/wwkimball/yamlpath/wiki/Segment:--Array-of-Hashes-Pass-Through-Selection)
[Search Keywords](https://github.com/wwkimball/yamlpath/wiki/Search-Keywords)
[Set Values](https://github.com/wwkimball/yamlpath/wiki/Segment:-Set-Values)
[Wildcard Segments](https://github.com/wwkimball/yamlpath/wiki/Wildcard-Segments)

Not supported:
[Collectors](https://github.com/wwkimball/yamlpath/wiki/Segment:-Collectors)
