### PR TITLE
Correction of LowerCaseNamingConvention documentation

### DIFF
--- a/YamlDotNet/Serialization/NamingConventions/LowerCaseNamingConvention.cs
+++ b/YamlDotNet/Serialization/NamingConventions/LowerCaseNamingConvention.cs
@@ -25,8 +25,7 @@ namespace YamlDotNet.Serialization.NamingConventions
 {
     /// <summary>
     /// Convert the string with underscores (this_is_a_test) or hyphens (this-is-a-test) to 
-    /// pascal case (ThisIsATest). Pascal case is the same as camel case, except the first letter
-    /// is uppercase.
+    /// lower case (thisisatest).
     /// </summary>
     public sealed class LowerCaseNamingConvention : INamingConvention
     {


### PR DESCRIPTION
Hello,

This is a simple correction of documentation of the API.
The original documentation was describing pascal case naming convention instead of lower case one.

Regards