### PR TITLE
updated Bullseye from 4.0.0 to 4.2.0

### DIFF
--- a/tools/build/Program.cs
+++ b/tools/build/Program.cs
@@ -9,9 +9,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Bullseye;
-using Bullseye.Internal;
 using static Bullseye.Targets;
-using OperatingSystem = Bullseye.Internal.OperatingSystem;
 
 namespace build
 {
@@ -136,18 +134,18 @@ namespace build
 
             var (specifiedTargets, options, unknownOptions, showHelp) = CommandLine.Parse(filteredArguments);
             verbose = options.Verbose;
-            Host = options.Host.DetectIfAutomatic();
+            Host = options.Host.DetectIfNull();
 
-            var operatingSystem =
+            var osPlatform =
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? OperatingSystem.Windows
+                    ? OSPlatform.Windows
                     : RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                        ? OperatingSystem.Linux
+                        ? OSPlatform.Linux
                         : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                            ? OperatingSystem.MacOS
-                            : OperatingSystem.Unknown;
+                            ? OSPlatform.OSX
+                            : OSPlatform.Create("Unknown");
 
-            palette = new Palette(options.NoColor, options.NoExtendedChars, options.Host, operatingSystem);
+            palette = new Palette(options.NoColor, options.NoExtendedChars, Host, osPlatform);
 
             var targets = specifiedTargets.ToList();
 
@@ -209,9 +207,9 @@ namespace build
             if (showHelp)
             {
                 Console.WriteLine();
-                Console.WriteLine($"{palette.Default}Additional options:");
-                Console.WriteLine($"  {palette.Option}--no-prerelease            {palette.Default}Force the current version to be considered final{palette.Reset}");
-                Console.WriteLine($"  {palette.Option}--version=<version>        {palette.Default}Force the current version to equal to the specified value{palette.Reset}");
+                Console.WriteLine($"{palette.Text}Additional options:");
+                Console.WriteLine($"  {palette.Option}--no-prerelease            {palette.Text}Force the current version to be considered final{palette.Default}");
+                Console.WriteLine($"  {palette.Option}--version=<version>        {palette.Text}Force the current version to equal to the specified value{palette.Default}");
             }
 
             return exitCode;
@@ -227,12 +225,12 @@ namespace build
 
         public static void WriteInformation(string text)
         {
-            Console.WriteLine($"  {palette.Default}(i)  {text}{palette.Reset}");
+            Console.WriteLine($"  {palette.Text}(i)  {text}{palette.Default}");
         }
 
         public static void WriteWarning(string text)
         {
-            Console.WriteLine($"  {palette.Option}/!\\  {text}{palette.Reset}");
+            Console.WriteLine($"  {palette.Option}/!\\  {text}{palette.Default}");
         }
 
         public static void WriteImportant(string text)
@@ -300,7 +298,7 @@ namespace build
 
         private static void Write(string text, string color)
         {
-            Console.WriteLine($"{color}{text}{palette.Reset}");
+            Console.WriteLine($"{color}{text}{palette.Default}");
         }
 
         public static IEnumerable<string> ReadLines(string name, string? args = null, string? workingDirectory = null) => SimpleExec.Command

--- a/tools/build/build.csproj
+++ b/tools/build/build.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bullseye" Version="4.0.0" />
+        <PackageReference Include="Bullseye" Version="4.2.0" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="SimpleExec" Version="6.4.0" />
     </ItemGroup>


### PR DESCRIPTION
## Welcome!

Thanks for your interest in contributing to this project. Any contribution will
be gladly accepted, provided that they are generally useful and follow the
conventions of the project.

1. Please create **one pull request for each feature**. This results in smaller pull requests that are easier to review and validate.

1. **Avoid reformatting existing code** unless you are making other changes to it.  
   - Cleaning-up of `using`s is acceptable, if you made other changes to that file.
   - If you believe that some code is badly formatted and needs fixing, isolate that change in a separate pull request.

1. Always add one or more **unit tests** that prove that the feature / fix you are submitting is working correctly.

1. Please **describe the motivation** behind the pull request. Explain what was the problem / requirement. Unless the implementation is self-explanatory, also describe the solution.
   * Of course, there's no need to be too verbose. Usually one or two lines will be enough.

1. Follow the project's [coding conventions](CONTRIBUTING.md#coding-style)

---

In Bullseye 4.2.0, `Palette` and `HostExtensions` are logically public (they exist in the `Bullseye` namespace), so there's no longer a need to use anything from the `Bullseye.Internal` namespace to provide output which matches the coloring of, and symbols used by, Bullseye output. Also, `Bullseye.Internal.OperatingSystem` has been removed in favour of `System.Runtime.InteropServices.OSPlatform`.