### PR TITLE
Throw an exception on duplicate keys

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -284,7 +284,25 @@ b: &number 1
         }
 
         [Fact]
-        public void Deserialize_YamlWithDuplicateKeys_ThrowsYamlException()
+        public void DeserializeWithDuplicateKeyChecking_YamlWithDuplicateKeys_ThrowsYamlException()
+        {
+            var yaml = @"
+name: Jack
+momentOfBirth: 1983-04-21T20:21:03.0041599Z
+name: Jake
+";
+
+            var sut = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithDuplicateKeyChecking()
+                .Build();
+
+            Action act = () => sut.Deserialize<Person>(yaml);
+            act.ShouldThrow<YamlException>("Because there are duplicate name keys");
+        }
+
+        [Fact]
+        public void DeserializeWithoutDuplicateKeyChecking_YamlWithDuplicateKeys_DoesNotThrowYamlException()
         {
             var yaml = @"
 name: Jack
@@ -297,7 +315,7 @@ name: Jake
                 .Build();
 
             Action act = () => sut.Deserialize<Person>(yaml);
-            act.ShouldThrow<YamlException>("Because there are duplicate name keys");
+            act.ShouldNotThrow<YamlException>("Because duplicate key checking is not enabled");
         }
 
         public class Test

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -216,7 +217,6 @@ b: &number 1
             Assert.Equal($"value\na\nb", dictionary.First().Value);
         }
 
-        
         [Theory]
         [InlineData(".nan", System.Single.NaN)]
         [InlineData(".NaN", System.Single.NaN)]
@@ -281,6 +281,23 @@ b: &number 1
             var result = deserializer.Deserialize(value.ToString(), type);
 
             result.Should().Be(value);
+        }
+
+        [Fact]
+        public void Deserialize_YamlWithDuplicateKeys_ThrowsYamlException()
+        {
+            var yaml = @"
+name: Jack
+momentOfBirth: 1983-04-21T20:21:03.0041599Z
+name: Jake
+";
+
+            var sut = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+
+            Action act = () => sut.Deserialize<Person>(yaml);
+            act.ShouldThrow<YamlException>("Because there are duplicate name keys");
         }
 
         public class Test

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1312,7 +1312,6 @@ y:
                     "scratch: 'scratcher'",
                     "deleteScratch: false",
                     "notScratch: 9443",
-                    "notScratch: 192.168.1.30",
                     "mappedScratch:",
                     "- '/work/'"
                 );

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1312,6 +1312,7 @@ y:
                     "scratch: 'scratcher'",
                     "deleteScratch: false",
                     "notScratch: 9443",
+                    "notScratch: 192.168.1.30",
                     "mappedScratch:",
                     "- '/work/'"
                 );

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -47,6 +47,7 @@ namespace YamlDotNet.Serialization
         private readonly Dictionary<TagName, Type> tagMappings;
         private readonly Dictionary<Type, Type> typeMappings;
         private bool ignoreUnmatched;
+        private bool duplicateKeyChecking;
         private bool attemptUnknownTypeDeserialization;
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace YamlDotNet.Serialization
                 { typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value) },
                 { typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value) },
                 { typeof(EnumerableNodeDeserializer), _ => new EnumerableNodeDeserializer() },
-                { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(objectFactory.Value, BuildTypeInspector(), ignoreUnmatched) }
+                { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(objectFactory.Value, BuildTypeInspector(), ignoreUnmatched, duplicateKeyChecking) }
             };
 
             nodeTypeResolverFactories = new LazyComponentRegistrationList<Nothing, INodeTypeResolver>
@@ -385,6 +386,16 @@ namespace YamlDotNet.Serialization
         public DeserializerBuilder IgnoreUnmatchedProperties()
         {
             ignoreUnmatched = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Instructs the deserializer to check for duplicate keys and throw an exception if duplicate keys are found.
+        /// </summary>
+        /// <returns></returns>
+        public DeserializerBuilder WithDuplicateKeyChecking()
+        {
+            duplicateKeyChecking = true;
             return this;
         }
 

--- a/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
@@ -33,12 +33,14 @@ namespace YamlDotNet.Serialization.NodeDeserializers
         private readonly IObjectFactory objectFactory;
         private readonly ITypeInspector typeDescriptor;
         private readonly bool ignoreUnmatched;
+        private readonly bool duplicateKeyChecking;
 
-        public ObjectNodeDeserializer(IObjectFactory objectFactory, ITypeInspector typeDescriptor, bool ignoreUnmatched)
+        public ObjectNodeDeserializer(IObjectFactory objectFactory, ITypeInspector typeDescriptor, bool ignoreUnmatched, bool duplicateKeyChecking)
         {
             this.objectFactory = objectFactory ?? throw new ArgumentNullException(nameof(objectFactory));
             this.typeDescriptor = typeDescriptor ?? throw new ArgumentNullException(nameof(typeDescriptor));
             this.ignoreUnmatched = ignoreUnmatched;
+            this.duplicateKeyChecking = duplicateKeyChecking;
         }
 
         bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
@@ -57,9 +59,9 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             while (!parser.TryConsume<MappingEnd>(out var _))
             {
                 var propertyName = parser.Consume<Scalar>();
-                if (consumedProperties.Contains(propertyName.Value))
+                if (duplicateKeyChecking && consumedProperties.Contains(propertyName.Value))
                 {
-                    throw new YamlException(propertyName.Start, propertyName.End, $"Encountered duplicate property {propertyName.Value}");
+                    throw new YamlException(propertyName.Start, propertyName.End, $"Encountered duplicate key {propertyName.Value}");
                 }
                 try
                 {


### PR DESCRIPTION
Deserializing YAML with non-unique keys throws a YamlException.  Resolves #536 
