### PR TITLE
Fixed DateTime serialization with JSON using single quotes

### DIFF
--- a/YamlDotNet.Test/Serialization/DateTimeConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/DateTimeConverterTests.cs
@@ -564,6 +564,16 @@ namespace YamlDotNet.Test.Serialization
 
             serialised.Should().ContainEquivalentOf($"datetime: {formatted}");
         }
+
+        [Fact]
+        public void JsonCompatible_EncaseDateTimesInDoubleQuotes()
+        {
+            var serializer = new SerializerBuilder().JsonCompatible().Build();
+            var testObject = new TestObject { DateTime = new DateTime(2023, 01, 14, 0, 1, 2) };
+            var actual = serializer.Serialize(testObject);
+
+            actual.TrimNewLines().Should().ContainEquivalentOf("{\"DateTime\": \"01/14/2023 00:01:02\"}");
+        }
     }
 
     /// <summary>

--- a/YamlDotNet/Serialization/Converters/DateTimeConverter.cs
+++ b/YamlDotNet/Serialization/Converters/DateTimeConverter.cs
@@ -35,6 +35,7 @@ namespace YamlDotNet.Serialization.Converters
     {
         private readonly DateTimeKind kind;
         private readonly IFormatProvider provider;
+        private readonly bool doubleQuotes;
         private readonly string[] formats;
 
         /// <summary>
@@ -42,12 +43,14 @@ namespace YamlDotNet.Serialization.Converters
         /// </summary>
         /// <param name="kind"><see cref="DateTimeKind"/> value. Default value is <see cref="DateTimeKind.Utc"/>. <see cref="DateTimeKind.Unspecified"/> is considered as <see cref="DateTimeKind.Utc"/>.</param>
         /// <param name="provider"><see cref="IFormatProvider"/> instance. Default value is <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <param name="doubleQuotes">If true, will use double quotes when writing the value to the stream.</param>
         /// <param name="formats">List of date/time formats for parsing. Default value is "<c>G</c>".</param>
         /// <remarks>On deserializing, all formats in the list are used for conversion, while on serializing, the first format in the list is used.</remarks>
-        public DateTimeConverter(DateTimeKind kind = DateTimeKind.Utc, IFormatProvider? provider = null, params string[] formats)
+        public DateTimeConverter(DateTimeKind kind = DateTimeKind.Utc, IFormatProvider? provider = null, bool doubleQuotes = false, params string[] formats)
         {
             this.kind = kind == DateTimeKind.Unspecified ? DateTimeKind.Utc : kind;
             this.provider = provider ?? CultureInfo.InvariantCulture;
+            this.doubleQuotes = doubleQuotes;
             this.formats = formats.DefaultIfEmpty("G").ToArray();
         }
 
@@ -91,7 +94,7 @@ namespace YamlDotNet.Serialization.Converters
             var adjusted = this.kind == DateTimeKind.Local ? dt.ToLocalTime() : dt.ToUniversalTime();
             var formatted = adjusted.ToString(this.formats.First(), this.provider); // Always take the first format of the list.
 
-            emitter.Emit(new Scalar(AnchorName.Empty, TagName.Empty, formatted, ScalarStyle.Any, true, false));
+            emitter.Emit(new Scalar(AnchorName.Empty, TagName.Empty, formatted, doubleQuotes ? ScalarStyle.DoubleQuoted : ScalarStyle.Any, true, false));
         }
 
         private static DateTime EnsureDateTimeKind(DateTime dt, DateTimeKind kind)

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -334,6 +334,7 @@ namespace YamlDotNet.Serialization
 
             return this
                 .WithTypeConverter(new GuidConverter(true), w => w.InsteadOf<GuidConverter>())
+                .WithTypeConverter(new DateTimeConverter(doubleQuotes: true))
                 .WithEventEmitter(inner => new JsonEventEmitter(inner), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
         }
 


### PR DESCRIPTION
Fixes #587 

When using `JsonCompatible` we will now register a `DateTimeConverter`.

If the user is adding a `DateTimeConverter` object before calling `JsonCompatible` on the serializer, this call will fail. If the user is adding some other, custom, `DateTime` converter, the one added by `JsonCompatible` will take priority, and the users converter will be skipped.

If the user wants to specify their own `DateTimeConverter` or some other `DateTime` converter object, they will need to do it after calling `JsonCompatible`.

If they are passing their own `DateTimeConverter`, they can now specify the optional constructor argument, `doubleQuotes`, so it will dish out valid JSON.
