### PR TITLE
Follow up on duplicate key checking

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -299,6 +299,13 @@ name: Jake
 
             Action act = () => sut.Deserialize<Person>(yaml);
             act.ShouldThrow<YamlException>("Because there are duplicate name keys");
+            act = () => sut.Deserialize<IDictionary<object, object>>(yaml);
+            act.ShouldThrow<YamlException>("Because there are duplicate name keys");
+
+            var stream = Yaml.ReaderFrom("backreference.yaml");
+            var parser = new MergingParser(new Parser(stream));
+            act = () => sut.Deserialize<Dictionary<string, Dictionary<string, string>>>(parser);
+            act.ShouldThrow<YamlException>("Because there are duplicate name keys");
         }
 
         [Fact]
@@ -315,6 +322,13 @@ name: Jake
                 .Build();
 
             Action act = () => sut.Deserialize<Person>(yaml);
+            act.ShouldNotThrow<YamlException>("Because duplicate key checking is not enabled");
+            act = () => sut.Deserialize<IDictionary<object, object>>(yaml);
+            act.ShouldNotThrow<YamlException>("Because duplicate key checking is not enabled");
+
+            var stream = Yaml.ReaderFrom("backreference.yaml");
+            var parser = new MergingParser(new Parser(stream));
+            act = () => sut.Deserialize<Dictionary<string, Dictionary<string, string>>>(parser);
             act.ShouldNotThrow<YamlException>("Because duplicate key checking is not enabled");
         }
 

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -91,7 +91,7 @@ namespace YamlDotNet.Serialization
                 { typeof(NullNodeDeserializer), _ => new NullNodeDeserializer() },
                 { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization) },
                 { typeof(ArrayNodeDeserializer), _ => new ArrayNodeDeserializer() },
-                { typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value) },
+                { typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value, duplicateKeyChecking) },
                 { typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value) },
                 { typeof(EnumerableNodeDeserializer), _ => new EnumerableNodeDeserializer() },
                 { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(objectFactory.Value, BuildTypeInspector(), ignoreUnmatched, duplicateKeyChecking) }
@@ -151,7 +151,7 @@ namespace YamlDotNet.Serialization
             _baseTypeInspector = context.GetTypeInspector();
 
             WithoutNodeDeserializer<DictionaryNodeDeserializer>();
-            WithNodeDeserializer(new StaticDictionaryNodeDeserializer(context.GetFactory()));
+            WithNodeDeserializer(new StaticDictionaryNodeDeserializer(context.GetFactory(), duplicateKeyChecking));
 
             return Self;
         }

--- a/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
@@ -55,17 +55,16 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             var implementationType = Nullable.GetUnderlyingType(expectedType) ?? expectedType;
 
             value = objectFactory.Create(implementationType);
-            var consumedProperties = new List<string>();
+            var consumedProperties = new HashSet<string>(StringComparer.Ordinal);
             while (!parser.TryConsume<MappingEnd>(out var _))
             {
                 var propertyName = parser.Consume<Scalar>();
-                if (duplicateKeyChecking && consumedProperties.Contains(propertyName.Value))
+                if (duplicateKeyChecking && !consumedProperties.Add(propertyName.Value))
                 {
                     throw new YamlException(propertyName.Start, propertyName.End, $"Encountered duplicate key {propertyName.Value}");
                 }
                 try
                 {
-                    consumedProperties.Add(propertyName.Value);
                     var property = typeDescriptor.GetProperty(implementationType, null, propertyName.Value, ignoreUnmatched);
                     if (property == null)
                     {

--- a/YamlDotNet/Serialization/NodeDeserializers/StaticDictionaryNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/StaticDictionaryNodeDeserializer.cs
@@ -29,8 +29,8 @@ namespace YamlDotNet.Serialization.NodeDeserializers
     {
         private readonly ObjectFactories.StaticObjectFactory _objectFactory;
 
-        public StaticDictionaryNodeDeserializer(ObjectFactories.StaticObjectFactory objectFactory)
-            : base(objectFactory)
+        public StaticDictionaryNodeDeserializer(ObjectFactories.StaticObjectFactory objectFactory, bool duplicateKeyChecking)
+            : base(objectFactory, duplicateKeyChecking)
         {
             _objectFactory = objectFactory ?? throw new ArgumentNullException(nameof(objectFactory));
         }


### PR DESCRIPTION
Follow up on #536 and extend the functionality to `DictionaryNodeDeserializer`.