### PR TITLE
Quoted scalars are flow scalars only if flowLevel > 0

### DIFF
--- a/YamlDotNet.Test/Core/ScannerTests.cs
+++ b/YamlDotNet.Test/Core/ScannerTests.cs
@@ -443,6 +443,26 @@ namespace YamlDotNet.Test.Core
                 Error("Invalid key indicator format."));
         }
 
+        [Fact]
+        public void Quoted_string_on_block_level_and_subsequent_key_starting_with_colon() 
+        {
+            AssertSequenceOfTokensFrom(Yaml.ScannerForText(@"
+:a: '1'
+:b: 2"),
+                StreamStart,
+                BlockMappingStart,
+                Key,
+                PlainScalar(":a"),
+                Value,
+                SingleQuotedScalar("1"),
+                Key,
+                PlainScalar(":b"),
+                Value,
+                PlainScalar("2"),
+                BlockEnd,
+                StreamEnd);
+        }
+
         private void AssertPartialSequenceOfTokensFrom(Scanner scanner, params Token[] tokens)
         {
             var tokenNumber = 1;

--- a/YamlDotNet.Test/Core/ScannerTests.cs
+++ b/YamlDotNet.Test/Core/ScannerTests.cs
@@ -444,19 +444,35 @@ namespace YamlDotNet.Test.Core
         }
 
         [Fact]
-        public void Quoted_string_on_block_level_and_subsequent_key_starting_with_colon() 
+        public void Keys_can_start_with_colons()
         {
-            AssertSequenceOfTokensFrom(Yaml.ScannerForText(@"
-:a: '1'
-:b: 2"),
+           AssertSequenceOfTokensFrom(Yaml.ScannerForText(":first: 1\n:second: 2"),
                 StreamStart,
                 BlockMappingStart,
                 Key,
-                PlainScalar(":a"),
+                PlainScalar(":first"),
+                Value,
+                PlainScalar("1"),
+                Key,
+                PlainScalar(":second"),
+                Value,
+                PlainScalar("2"),
+                BlockEnd,
+                StreamEnd);
+        }
+
+        [Fact]
+        public void Keys_can_start_with_colons_if_values_are_quoted() 
+        {
+           AssertSequenceOfTokensFrom(Yaml.ScannerForText(":first: '1'\n:second: 2"),
+                StreamStart,
+                BlockMappingStart,
+                Key,
+                PlainScalar(":first"),
                 Value,
                 SingleQuotedScalar("1"),
                 Key,
-                PlainScalar(":b"),
+                PlainScalar(":second"),
                 Value,
                 PlainScalar("2"),
                 BlockEnd,

--- a/YamlDotNet.Test/Core/ScannerTests.cs
+++ b/YamlDotNet.Test/Core/ScannerTests.cs
@@ -444,10 +444,14 @@ namespace YamlDotNet.Test.Core
         }
 
         [Fact]
-        public void Keys_can_start_with_colons()
+        public void Keys_can_start_with_colons_in_nested_block()
         {
-           AssertSequenceOfTokensFrom(Yaml.ScannerForText(":first: 1\n:second: 2"),
+           AssertSequenceOfTokensFrom(Yaml.ScannerForText("root:\n  :first: 1\n  :second: 2"),
                 StreamStart,
+                BlockMappingStart,
+                Key,
+                PlainScalar("root"),
+                Value,
                 BlockMappingStart,
                 Key,
                 PlainScalar(":first"),
@@ -458,11 +462,12 @@ namespace YamlDotNet.Test.Core
                 Value,
                 PlainScalar("2"),
                 BlockEnd,
+                BlockEnd,
                 StreamEnd);
         }
 
         [Fact]
-        public void Keys_can_start_with_colons_if_values_are_quoted() 
+        public void Keys_can_start_with_colons_after_quoted_values() 
         {
            AssertSequenceOfTokensFrom(Yaml.ScannerForText(":first: '1'\n:second: 2"),
                 StreamStart,

--- a/YamlDotNet.Test/Core/ScannerTests.cs
+++ b/YamlDotNet.Test/Core/ScannerTests.cs
@@ -484,6 +484,52 @@ namespace YamlDotNet.Test.Core
                 StreamEnd);
         }
 
+        [Fact]
+        public void Keys_can_start_with_colons_after_single_quoted_values_in_nested_block() 
+        {
+           AssertSequenceOfTokensFrom(Yaml.ScannerForText("xyz:\n  :hello: 'world'\n  :goodbye: world"),
+                StreamStart,
+                BlockMappingStart,
+                Key,
+                PlainScalar("xyz"),
+                Value,
+                BlockMappingStart,
+                Key,
+                PlainScalar(":hello"),
+                Value,
+                SingleQuotedScalar("world"),
+                Key,
+                PlainScalar(":goodbye"),
+                Value,
+                PlainScalar("world"),
+                BlockEnd,
+                BlockEnd,
+                StreamEnd);
+        }
+
+        [Fact]
+        public void Keys_can_start_with_colons_after_double_quoted_values_in_nested_block() 
+        {
+           AssertSequenceOfTokensFrom(Yaml.ScannerForText("xyz:\n  :hello: \"world\"\n  :goodbye: world"),
+                StreamStart,
+                BlockMappingStart,
+                Key,
+                PlainScalar("xyz"),
+                Value,
+                BlockMappingStart,
+                Key,
+                PlainScalar(":hello"),
+                Value,
+                DoubleQuotedScalar("world"),
+                Key,
+                PlainScalar(":goodbye"),
+                Value,
+                PlainScalar("world"),
+                BlockEnd,
+                BlockEnd,
+                StreamEnd);
+        }
+
         private void AssertPartialSequenceOfTokensFrom(Scanner scanner, params Token[] tokens)
         {
             var tokenNumber = 1;

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -479,7 +479,7 @@ namespace YamlDotNet.Core
 
             if (analyzer.Check('\''))
             {
-                FetchFlowScalar(true);
+                FetchQuotedScalar(true);
                 return;
             }
 
@@ -487,7 +487,7 @@ namespace YamlDotNet.Core
 
             if (analyzer.Check('"'))
             {
-                FetchFlowScalar(false);
+                FetchQuotedScalar(false);
                 return;
             }
 
@@ -1770,7 +1770,7 @@ namespace YamlDotNet.Core
         /// Produce the SCALAR(...,single-quoted) or SCALAR(...,double-quoted) tokens.
         /// </summary>
 
-        private void FetchFlowScalar(bool isSingleQuoted)
+        private void FetchQuotedScalar(bool isSingleQuoted)
         {
             // A plain scalar could be a simple key.
 
@@ -1782,7 +1782,7 @@ namespace YamlDotNet.Core
 
             // Indicates the adjacent flow scalar that a prior flow scalar has been fetched.
 
-            flowScalarFetched = true;
+            flowScalarFetched = flowLevel > 0;
 
             // Create the SCALAR token and append it to the queue.
 


### PR DESCRIPTION
The parser currently crashes on (some) YAML generated by Ruby.

Serializing objects to YAML in Ruby generally results in keys starting with a colon (symbols) and in single quoted values if strings values could otherwise be mistaken for numbers. Something like:
```
:string_value: '1'
:numeric_value: 2
```
The scanner will, after fetching the quoted scalar `'1'`, gobble up the initial colon from `:numeric_value` and insert another block level. The parser then raises the exception `YamlDotNet.Core.SemanticErrorException : While parsing a block mapping, did not find expected key.`

This fix remedies that behavior by not setting `flowScalarFetched` to `true` after fetching a quoted scalar on the block level