### PR TITLE
MergingParser deserializer can now handle nested NodeSequence with aliases (try2)

### DIFF
--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -69,13 +69,7 @@ namespace YamlDotNet.Test.Core
             return EnumerationOf(parser).ToList();
         }
 
-        private IEnumerable<ParsingEvent> EnumerationOf(IParser parser)
-        {
-            while (parser.MoveNext())
-            {
-                yield return parser.Current;
-            }
-        }
+
 
         [Fact]
         public void PlainScalarCanBeFollowedByImplicitDocument()

--- a/YamlDotNet.Test/Core/EmitterTestsHelper.cs
+++ b/YamlDotNet.Test/Core/EmitterTestsHelper.cs
@@ -52,7 +52,7 @@ namespace YamlDotNet.Test.Core
             events.Run(emitter.Emit);
             return writer.ToString();
         }
-        
+
         protected static IEnumerable<ParsingEvent> EnumerationOf(IParser parser)
         {
             while (parser.MoveNext())

--- a/YamlDotNet.Test/Core/EmitterTestsHelper.cs
+++ b/YamlDotNet.Test/Core/EmitterTestsHelper.cs
@@ -52,6 +52,14 @@ namespace YamlDotNet.Test.Core
             events.Run(emitter.Emit);
             return writer.ToString();
         }
+        
+        protected static IEnumerable<ParsingEvent> EnumerationOf(IParser parser)
+        {
+            while (parser.MoveNext())
+            {
+                yield return parser.Current;
+            }
+        }
 
         protected IEnumerable<ParsingEvent> StreamedDocumentWith(IEnumerable<ParsingEvent> events)
         {

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -21,7 +21,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
@@ -333,42 +332,6 @@ name: Jake
             act.ShouldNotThrow<YamlException>("Because duplicate key checking is not enabled");
         }
         
-        [Fact]
-        public void MergingParserWithMergeObjectWithSequence_ShouldNotThrowException()
-        {
-            var yaml = @"
-base_level: &base 
-  tenant: 
-  - a1
-Level1: &Level1
-    <<: [*base]
-Level2: &Level2
-    <<: *Level1
-";
-            var mergingParserFailed = new MergingParser(new Parser(new StringReader(yaml)));
-            var deserializer = new DeserializerBuilder().Build();
-            Action act = () => deserializer.Deserialize(mergingParserFailed);
-            act.ShouldNotThrow<Exception>();
-        }
-        
-        [Fact]
-        public void MergingParserWithNestedSequence_ShouldNotThrowException()
-        {
-            var yaml = @"
-base_level: &base {}
-Level1: &Level1
-    <<: [*base]
-Level2: &Level2
-    <<: [*Level1]
-Level3:
-    <<: *Level2
-";
-            var mergingParserFailed = new MergingParser(new Parser(new StringReader(yaml)));
-            var deserializer = new DeserializerBuilder().Build();
-            Action act = () => deserializer.Deserialize(mergingParserFailed);
-            act.ShouldNotThrow<Exception>();
-        }
-
         public class Test
         {
             public string Value { get; set; }

--- a/YamlDotNet.Test/Serialization/MergingParserTests.cs
+++ b/YamlDotNet.Test/Serialization/MergingParserTests.cs
@@ -29,7 +29,7 @@ using YamlDotNet.Test.Core;
 
 namespace YamlDotNet.Test.Serialization
 {
-    public class MergingParserTests: EmitterTestsHelper
+    public class MergingParserTests : EmitterTestsHelper
     {
         [Fact]
         public void MergingParserWithMergeObjectWithSequence_EachLevelsShouldEquals()
@@ -43,12 +43,12 @@ Level1: &Level1
 Level2: &Level2
     <<: *Level1
 ";
-            
+
             var etalonLevel = @"tenant:
 - a1
 - a2
 ".NormalizeNewLines();
-            
+
             var mergingParser = new MergingParser(new Parser(new StringReader(yaml)));
             var yamlObject = new DeserializerBuilder().Build().Deserialize<Dictionary<string, object>>(mergingParser);
             yamlObject.Should().NotBeNull();
@@ -57,8 +57,8 @@ Level2: &Level2
             serializer.Serialize(yamlObject["base_level"]).NormalizeNewLines().Should().Be(etalonLevel);
             serializer.Serialize(yamlObject["Level1"]).NormalizeNewLines().Should().Be(etalonLevel);
             serializer.Serialize(yamlObject["Level2"]).NormalizeNewLines().Should().Be(etalonLevel);
-        } 
-        
+        }
+
         [Fact]
         public void MergingParserWithMergeObjectWithSequence_EmittedTextShouldNotContainsDeletedEvents()
         {
@@ -85,12 +85,12 @@ Level2:
   - a1
   - a2
 ".NormalizeNewLines();
-            
+
             var mergingParser = new MergingParser(new Parser(new StringReader(yaml)));
             var events = EnumerationOf(mergingParser);
             EmittedTextFrom(events).NormalizeNewLines().Should().Be(etalonEmittedText);
-        }  
-        
+        }
+
         [Fact]
         public void MergingParserWithMergeObjectWithSequenceAndScalarItems_EmittedTextShouldNotContainsDeletedEvents()
         {
@@ -122,7 +122,7 @@ Level2:
   item1: ''
   item2: ''
 ".NormalizeNewLines();
-            
+
             var mergingParser = new MergingParser(new Parser(new StringReader(yaml)));
             var events = EnumerationOf(mergingParser);
             EmittedTextFrom(events).NormalizeNewLines().Should().Be(etalonEmittedText);

--- a/YamlDotNet.Test/Serialization/MergingParserTests.cs
+++ b/YamlDotNet.Test/Serialization/MergingParserTests.cs
@@ -1,0 +1,155 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Test.Core;
+
+namespace YamlDotNet.Test.Serialization
+{
+    public class MergingParserTests: EmitterTestsHelper
+    {
+        [Fact]
+        public void MergingParserWithMergeObjectWithSequence_EachLevelsShouldEquals()
+        {
+            var yaml = @"base_level: &base 
+  tenant: 
+  - a1
+  - a2
+Level1: &Level1
+    <<: [*base]
+Level2: &Level2
+    <<: *Level1
+";
+            
+            var etalonLevel = @"tenant:
+- a1
+- a2
+".NormalizeNewLines();
+            
+            var mergingParser = new MergingParser(new Parser(new StringReader(yaml)));
+            var yamlObject = new DeserializerBuilder().Build().Deserialize<Dictionary<string, object>>(mergingParser);
+            yamlObject.Should().NotBeNull();
+
+            var serializer = new SerializerBuilder().Build();
+            serializer.Serialize(yamlObject["base_level"]).NormalizeNewLines().Should().Be(etalonLevel);
+            serializer.Serialize(yamlObject["Level1"]).NormalizeNewLines().Should().Be(etalonLevel);
+            serializer.Serialize(yamlObject["Level2"]).NormalizeNewLines().Should().Be(etalonLevel);
+        } 
+        
+        [Fact]
+        public void MergingParserWithMergeObjectWithSequence_EmittedTextShouldNotContainsDeletedEvents()
+        {
+            var yaml = @"base_level: &base 
+  tenant:
+  - a1
+  - a2
+Level1: &Level1
+    <<: [*base]
+Level2:
+    <<: *Level1
+";
+
+            var etalonEmittedText = @"base_level: &base
+  tenant:
+  - a1
+  - a2
+Level1: &Level1
+  tenant:
+  - a1
+  - a2
+Level2:
+  tenant:
+  - a1
+  - a2
+".NormalizeNewLines();
+            
+            var mergingParser = new MergingParser(new Parser(new StringReader(yaml)));
+            var events = EnumerationOf(mergingParser);
+            EmittedTextFrom(events).NormalizeNewLines().Should().Be(etalonEmittedText);
+        }  
+        
+        [Fact]
+        public void MergingParserWithMergeObjectWithSequenceAndScalarItems_EmittedTextShouldNotContainsDeletedEvents()
+        {
+            var yaml = @"base_level: &base 
+  tenant:
+  - a1
+  - a2
+Level1: &Level1
+    <<: [*base]
+    item1:
+Level2:
+    <<: *Level1
+    item2:
+";
+
+            var etalonEmittedText = @"base_level: &base
+  tenant:
+  - a1
+  - a2
+Level1: &Level1
+  tenant:
+  - a1
+  - a2
+  item1: ''
+Level2:
+  tenant:
+  - a1
+  - a2
+  item1: ''
+  item2: ''
+".NormalizeNewLines();
+            
+            var mergingParser = new MergingParser(new Parser(new StringReader(yaml)));
+            var events = EnumerationOf(mergingParser);
+            EmittedTextFrom(events).NormalizeNewLines().Should().Be(etalonEmittedText);
+        }
+
+        [Fact]
+        public void MergingParserWithNestedSequence_ShouldNotThrowException()
+        {
+            var yaml = @"
+base_level: &base {}
+Level1: &Level1
+    <<: [*base]
+Level2: &Level2
+    <<: [*Level1]
+Level3:
+    <<: *Level2
+";
+            var etalonMergedYaml = @"base_level: {}
+Level1: {}
+Level2: {}
+Level3: {}
+".NormalizeNewLines();
+
+            var mergingParserFailed = new MergingParser(new Parser(new StringReader(yaml)));
+            var yamlObject = new DeserializerBuilder().Build().Deserialize(mergingParserFailed);
+
+            new SerializerBuilder().Build().Serialize(yamlObject!).NormalizeNewLines().Should().Be(etalonMergedYaml);
+        }
+    }
+}

--- a/YamlDotNet/Core/MergingParser.cs
+++ b/YamlDotNet/Core/MergingParser.cs
@@ -140,8 +140,7 @@ namespace YamlDotNet.Core
             var current = node;
             while (current != null)
             {
-                if (current.Value is SequenceEnd &&
-                    current.Value.Start.Line >= sequenceStart.Value.Start.Line)
+                if (current.Value is SequenceEnd)
                 {
                     events.MarkDeleted(current);
                     return true;
@@ -160,7 +159,7 @@ namespace YamlDotNet.Core
             var cloner = new ParsingEventCloner();
             var nesting = 0;
 
-            return events.FromAnchor(anchor)
+            return events.FromAnchor(anchor).Where(e => !this.events.IsDeleted(e))
                 .Select(e => e.Value)
                 .TakeWhile(e => (nesting += e.NestingIncrease) >= 0)
                 .Select(e => cloner.Clone(e));
@@ -196,6 +195,11 @@ namespace YamlDotNet.Core
             public void MarkDeleted(LinkedListNode<ParsingEvent> node)
             {
                 deleted.Add(node);
+            }
+
+            public bool IsDeleted(LinkedListNode<ParsingEvent> node)
+            {
+                return deleted.Contains(node);
             }
 
             public void CleanMarked()


### PR DESCRIPTION
re-fixed bug: https://github.com/aaubry/YamlDotNet/issues/777 

revert fix in pr: https://github.com/aaubry/YamlDotNet/pull/780
instead added a deleted events filter in `GetMappingEvents`

moved new tests to `MergingParserTests.cs`