### PR TITLE
Fix nullable annotations for IPropertyDescriptor.GetCustomAttribute

### DIFF
--- a/YamlDotNet/Serialization/IPropertyDescriptor.cs
+++ b/YamlDotNet/Serialization/IPropertyDescriptor.cs
@@ -33,7 +33,7 @@ namespace YamlDotNet.Serialization
         int Order { get; set; }
         ScalarStyle ScalarStyle { get; set; }
 
-        T GetCustomAttribute<T>() where T : Attribute;
+        T? GetCustomAttribute<T>() where T : Attribute;
 
         IObjectDescriptor Read(object target);
         void Write(object target, object? value);

--- a/YamlDotNet/Serialization/PropertyDescriptor.cs
+++ b/YamlDotNet/Serialization/PropertyDescriptor.cs
@@ -62,7 +62,7 @@ namespace YamlDotNet.Serialization
             baseDescriptor.Write(target, value);
         }
 
-        public T GetCustomAttribute<T>() where T : Attribute
+        public T? GetCustomAttribute<T>() where T : Attribute
         {
             return baseDescriptor.GetCustomAttribute<T>();
         }

--- a/YamlDotNet/Serialization/TypeInspectors/ReadableFieldsTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadableFieldsTypeInspector.cs
@@ -70,10 +70,10 @@ namespace YamlDotNet.Serialization.TypeInspectors
                 fieldInfo.SetValue(target, value);
             }
 
-            public T GetCustomAttribute<T>() where T : Attribute
+            public T? GetCustomAttribute<T>() where T : Attribute
             {
                 var attributes = fieldInfo.GetCustomAttributes(typeof(T), true);
-                return (T)attributes.FirstOrDefault();
+                return (T?)attributes.FirstOrDefault();
             }
 
             public IObjectDescriptor Read(object target)

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -84,10 +84,10 @@ namespace YamlDotNet.Serialization.TypeInspectors
                 propertyInfo.SetValue(target, value, null);
             }
 
-            public T GetCustomAttribute<T>() where T : Attribute
+            public T? GetCustomAttribute<T>() where T : Attribute
             {
                 var attributes = propertyInfo.GetAllCustomAttributes<T>();
-                return (T)attributes.FirstOrDefault();
+                return (T?)attributes.FirstOrDefault();
             }
 
             public IObjectDescriptor Read(object target)

--- a/YamlDotNet/Serialization/TypeInspectors/WritablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/WritablePropertiesTypeInspector.cs
@@ -85,10 +85,10 @@ namespace YamlDotNet.Serialization.TypeInspectors
                 propertyInfo.SetValue(target, value, null);
             }
 
-            public T GetCustomAttribute<T>() where T : Attribute
+            public T? GetCustomAttribute<T>() where T : Attribute
             {
                 var attributes = propertyInfo.GetAllCustomAttributes<T>();
-                return (T)attributes.FirstOrDefault();
+                return (T?)attributes.FirstOrDefault();
             }
 
             public IObjectDescriptor Read(object target)

--- a/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
+++ b/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
@@ -95,7 +95,7 @@ namespace YamlDotNet.Serialization
                 baseDescriptor.Write(target, value);
             }
 
-            public T GetCustomAttribute<T>() where T : Attribute
+            public T? GetCustomAttribute<T>() where T : Attribute
             {
                 var attr = overrides.GetAttribute<T>(classType, Name);
                 return attr ?? baseDescriptor.GetCustomAttribute<T>();


### PR DESCRIPTION
The current implementations of `IPropertyDescriptor.GetCustomAttribute` can return null values. This PR change the interface to allow null values. This fixes some build warnings.