### PR TITLE
Fixes test `DeserializeScalarEdgeCases` for non english cultures.

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -28,6 +28,7 @@ using Xunit;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using System.Globalization;
 
 namespace YamlDotNet.Test.Serialization
 {
@@ -279,7 +280,8 @@ b: &number 1
         public void DeserializeScalarEdgeCases(IConvertible value, Type type)
         {
             var deserializer = new DeserializerBuilder().Build();
-            var result = deserializer.Deserialize(value.ToString(), type);
+            var stringValue = string.Format(CultureInfo.InvariantCulture, "{0}", value);
+            var result = deserializer.Deserialize(stringValue, type);
 
             result.Should().Be(value);
         }


### PR DESCRIPTION
The test `DeserializeScalarEdgeCases` fails if the machine culture does not use the dot decimal separator. This is caused due to `object.ToString()` being used that is culture sensitive. This commit fixes the test using `string.Format` with `CultureInfo.InvariantCulture`.

This PR addresses partially #792. For a full explanation refer to that issue.
