### PR TITLE
Fixes parsing bug for floats with non english culture

### DIFF
--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -364,13 +364,13 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                     }
                     else if (Regex.IsMatch(v, @"[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?")) //regular number
                     {
-                        if (TryAndSwallow(() => byte.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => short.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => int.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => long.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => ulong.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => float.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => double.Parse(v), out result)) { }
+                        if (TryAndSwallow(() => byte.Parse(v, YamlFormatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => short.Parse(v, YamlFormatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => int.Parse(v, YamlFormatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => long.Parse(v, YamlFormatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => ulong.Parse(v, YamlFormatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => float.Parse(v, YamlFormatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => double.Parse(v, YamlFormatter.NumberFormat), out result)) { }
                         else
                         {
                             //we couldn't parse it, default to string, It's probably too big


### PR DESCRIPTION
## Summary

This PR fixes a serious bug that caused an incorrect parsing of floats and doubles in machines with non english cultures.

The bug was reproduced with Windows 11 setting the culture to `Spanish (Argentina)`. If the culture is `English (United States)` the parsing works fine.

This PR fix a bug related to #792. For a full explanation refer to that issue.

## Fix

The fix adds `YamlFormatter.NumberFormat` format provider in `Parse` methods in `ScalarNodeDeserializer.AttemptUnknownTypeDeserialization`. 

- Without this fix, the tests work with `English (United states)` but failed in `Spanish (Argentina)`.
- With this fix, all the tests work fine with both `English (United states)` culture and `Spanish (Argentina)` culture. 

-----------------------------

**Extra comments**

Question: Why does this part of the code does not use `TryParse`? Using `Parse` and the `TryAndSwallow` method causes unnecessary allocations for the exceptions. I think it would be an easy change.