### PR TITLE
Allow to Serialize with line breaks between sections

### DIFF
--- a/YamlDotNet.Test/Serialization/YamlNewLineTests.cs
+++ b/YamlDotNet.Test/Serialization/YamlNewLineTests.cs
@@ -1,0 +1,124 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.Test.Serialization
+{
+    public class YamlNewLineTests
+    {
+        protected readonly ITestOutputHelper Output;
+
+        public YamlNewLineTests(ITestOutputHelper helper)
+        {
+            Output = helper;
+        }
+
+        [Fact]
+        public void SerializationWithoutNewLine()
+        {
+            var person = new PersonWithoutNewLine { Name = "PandaTea", Age = 100 };
+
+            const string expected =
+@"# The person's name
+Name: PandaTea
+# The person's age
+Age: 100
+";
+
+            var result = new Serializer().Serialize(person);
+            Output.WriteLine(result);
+
+            result.Should().Be(expected);
+
+            new Deserializer()
+              .Deserialize<Person>(result)
+              .ShouldBeEquivalentTo(person);
+        }
+
+        [Fact]
+        public void SerializationWithNewLine()
+        {
+            var person = new Person { Name = "PandaTea", Age = 100 };
+
+            const string expected =
+@"# The person's name
+Name: PandaTea
+
+# The person's age
+Age: 100
+";
+
+            var result = new Serializer().Serialize(person);
+            Output.WriteLine(result);
+
+            result.Should().Be(expected);
+
+            new Deserializer()
+                .Deserialize<Person>(result)
+                .ShouldBeEquivalentTo(person);
+        }
+
+        [Fact]
+        public void SerializationWithNewLine_IndentedInSequence()
+        {
+            var persons = new Person[] { new Person { Name = "PandaTea", Age = 100 } };
+
+            const string expected =
+@"- # The person's name
+  Name: PandaTea
+
+  # The person's age
+  Age: 100
+";
+
+            var result = new Serializer().Serialize(persons);
+            Output.WriteLine(result);
+
+            result.Should().Be(expected);
+
+            new Deserializer()
+              .Deserialize<Person[]>(result)
+              .ShouldBeEquivalentTo(persons);
+        }
+
+        private class Person
+        {
+            [YamlMember(Description = "The person's name")]
+            public string Name { get; set; }
+
+            [YamlMember(Description = "The person's age", NewLine = true)]
+            public int Age { get; set; }
+        }
+
+        private class PersonWithoutNewLine
+        {
+            [YamlMember(Description = "The person's name")]
+            public string Name { get; set; }
+
+            [YamlMember(Description = "The person's age")]
+            public int Age { get; set; }
+        }
+    }
+}

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -166,7 +166,6 @@ namespace YamlDotNet.Core
                 var current = events.Peek();
                 try
                 {
-
                     AnalyzeEvent(current);
                     StateMachine(current);
                 }
@@ -566,6 +565,12 @@ namespace YamlDotNet.Core
                 return;
             }
 
+            if (evt is NewLine)
+            {
+                EmitNewLine();
+                return;
+            }
+
             switch (state)
             {
                 case EmitterState.StreamStart:
@@ -686,6 +691,17 @@ namespace YamlDotNet.Core
             isIndentation = true;
         }
 
+        private void EmitNewLine()
+        {
+            // If we're in flow mode or about to enter it: Skip 
+            if (flowLevel > 0 || state == EmitterState.FlowMappingFirstKey || state == EmitterState.FlowSequenceFirstItem)
+            {
+                return;
+            }
+
+            WriteBreak();
+        }
+
         /// <summary>
         /// Expect STREAM-START.
         /// </summary>
@@ -781,7 +797,6 @@ namespace YamlDotNet.Core
 
                 state = EmitterState.DocumentContent;
             }
-
             else if (evt is StreamEnd)
             {
                 state = EmitterState.StreamEnd;

--- a/YamlDotNet/Core/Events/EventType.cs
+++ b/YamlDotNet/Core/Events/EventType.cs
@@ -35,5 +35,6 @@ namespace YamlDotNet.Core.Events
         MappingStart,
         MappingEnd,
         Comment,
+        NewLine
     }
 }

--- a/YamlDotNet/Core/Events/NewLine.cs
+++ b/YamlDotNet/Core/Events/NewLine.cs
@@ -21,22 +21,17 @@
 
 namespace YamlDotNet.Core.Events
 {
-    /// <summary>
-    /// Callback interface for external event Visitor.
-    /// </summary>
-    public interface IParsingEventVisitor
+    public class NewLine : ParsingEvent
     {
-        void Visit(AnchorAlias e);
-        void Visit(StreamStart e);
-        void Visit(StreamEnd e);
-        void Visit(DocumentStart e);
-        void Visit(DocumentEnd e);
-        void Visit(Scalar e);
-        void Visit(SequenceStart e);
-        void Visit(SequenceEnd e);
-        void Visit(MappingStart e);
-        void Visit(MappingEnd e);
-        void Visit(Comment e);
-        void Visit(NewLine e);
+        public NewLine() : base(Mark.Empty, Mark.Empty)
+        {
+        }
+
+        internal override EventType Type => EventType.NewLine;
+
+        public override void Accept(IParsingEventVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
     }
 }

--- a/YamlDotNet/Core/MergingParser.cs
+++ b/YamlDotNet/Core/MergingParser.cs
@@ -307,6 +307,11 @@ namespace YamlDotNet.Core
             {
                 throw new NotSupportedException();
             }
+
+            public void Visit(NewLine e)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/NewLineObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/NewLineObjectGraphVisitor.cs
@@ -1,0 +1,44 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using YamlDotNet.Core;
+
+namespace YamlDotNet.Serialization.ObjectGraphVisitors
+{
+    internal class NewLineObjectGraphVisitor : ChainedObjectGraphVisitor
+    {
+        public NewLineObjectGraphVisitor(IObjectGraphVisitor<IEmitter> nextVisitor)
+            : base(nextVisitor)
+        {
+        }
+
+        public override bool EnterMapping(IPropertyDescriptor key, IObjectDescriptor value, IEmitter context)
+        {
+            var yamlMember = key.GetCustomAttribute<YamlMemberAttribute>();
+            if (yamlMember?.NewLine == true)
+            {
+                context.Emit(new Core.Events.NewLine());
+            }
+
+            return base.EnterMapping(key, value, context);
+        }
+    }
+}

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -90,6 +90,10 @@ namespace YamlDotNet.Serialization
                     args => new DefaultValuesObjectGraphVisitor(defaultValuesHandlingConfiguration, args.InnerVisitor, new DefaultObjectFactory())
                 },
                 {
+                    typeof(NewLineObjectGraphVisitor),
+                    args => new NewLineObjectGraphVisitor(args.InnerVisitor)
+                },
+                {
                     typeof(CommentsObjectGraphVisitor),
                     args => new CommentsObjectGraphVisitor(args.InnerVisitor)
                 }

--- a/YamlDotNet/Serialization/StaticSerializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticSerializerBuilder.cs
@@ -25,7 +25,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 #endif
 using YamlDotNet.Core;
-using YamlDotNet.Helpers;
 using YamlDotNet.Serialization.Converters;
 using YamlDotNet.Serialization.EventEmitters;
 using YamlDotNet.Serialization.NamingConventions;
@@ -37,7 +36,6 @@ using YamlDotNet.Serialization.TypeResolvers;
 
 namespace YamlDotNet.Serialization
 {
-
     /// <summary>
     /// Creates and configures instances of <see cref="Serializer" />.
     /// This class is used to customize the behavior of <see cref="Serializer" />. Use the relevant methods
@@ -86,6 +84,10 @@ namespace YamlDotNet.Serialization
                 {
                     typeof(DefaultValuesObjectGraphVisitor),
                     args => new DefaultValuesObjectGraphVisitor(defaultValuesHandlingConfiguration, args.InnerVisitor, factory)
+                },
+                  {
+                    typeof(NewLineObjectGraphVisitor),
+                    args => new NewLineObjectGraphVisitor(args.InnerVisitor)
                 },
                 {
                     typeof(CommentsObjectGraphVisitor),
@@ -298,7 +300,7 @@ namespace YamlDotNet.Serialization
         /// </summary>
         /// <remarks>
         /// If more control is needed, create a class that extends from ChainedObjectGraphVisitor and override its EnterMapping methods.
-        /// Then register it as follows: 
+        /// Then register it as follows:
         /// WithEmissionPhaseObjectGraphVisitor(args => new MyDefaultHandlingStrategy(args.InnerVisitor));
         /// </remarks>
         public StaticSerializerBuilder ConfigureDefaultValuesHandling(DefaultValuesHandling configuration)

--- a/YamlDotNet/Serialization/YamlMemberAttribute.cs
+++ b/YamlDotNet/Serialization/YamlMemberAttribute.cs
@@ -75,6 +75,11 @@ namespace YamlDotNet.Serialization
         public bool IsDefaultValuesHandlingSpecified => defaultValuesHandling.HasValue;
 
         /// <summary>
+        /// Adds a new line for this property
+        /// </summary>
+        public bool NewLine { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="YamlMemberAttribute" /> class.
         /// </summary>
         public YamlMemberAttribute()


### PR DESCRIPTION
This is related to the issue that I described here https://github.com/aaubry/YamlDotNet/issues/803.
For my usage it's important to be able to serialize a Yaml with line breaks.
Due to yaml's nature, which is declarative and human readable I think it makes sense to support it. We often see files like docker-compose  separating sections by break line.
With this PR, that would be possible, either by using YamlMemberAttribute, or by emiting the event manually.
Please let me know if there's an existing and more straightforward way of doing this, then I will abort my PR.
Thanks.