### PR TITLE
Fix Emitter to handle comments between a mapping key and a mapping/sequence value

### DIFF
--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -297,6 +297,28 @@ namespace YamlDotNet.Test.Core
         }
 
         [Fact]
+        public void CommentsBetweenMappingKeyAndValueAreEmittedCorrectly()
+        {
+            var events = MappingWith(
+                Scalar("key").ImplicitPlain,
+                InlineComment("inline comment"),
+                StandaloneComment("standalone comment"),
+                BlockSequenceStart,
+                Scalar("value").ImplicitPlain,
+                SequenceEnd
+            );
+
+            var yaml = EmittedTextFrom(StreamedDocumentWith(events));
+
+            yaml.Should()
+                .Contain(Lines(
+                    "key: # inline comment",
+                    "# standalone comment",
+                    "  - value"
+                ));
+        }
+
+        [Fact]
         public void ACommentAsTheFirstEventAddsANewLine()
         {
             var events = new ParsingEvent[]

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -1638,6 +1638,7 @@ namespace YamlDotNet.Core
             {
                 states.Push(EmitterState.BlockMappingSimpleValue);
                 EmitNode(evt, true, true);
+                WriteIndicator(":", false, false, false);
             }
             else
             {
@@ -1652,11 +1653,7 @@ namespace YamlDotNet.Core
         /// </summary>
         private void EmitBlockMappingValue(ParsingEvent evt, bool isSimple)
         {
-            if (isSimple)
-            {
-                WriteIndicator(":", false, false, false);
-            }
-            else
+            if (!isSimple)
             {
                 WriteIndent();
                 WriteIndicator(":", true, false, true);


### PR DESCRIPTION
This PR fixes https://github.com/aaubry/YamlDotNet/issues/812

TL;DR the Emitter doesn't handle comment events that are emitted between a mapping key and a mapping value of the mapping or sequence type. So parsing and regenerate the following yaml will fail for example:

```yaml
hello:
  # comment
  - world
```

becomes
```yaml
hello
# this is a comment
:
- world
```

This PR moves the writing of the `:` symbol to be inside the block mapping key emission. Previously it was at the beginning of the block mapping value emission. If the mapping key is prefixed with a `?` (explicit form), however, the `:` is still kept at the mapping value to preserve the existing behaviour, since in the explicit form, the comment does not break YAML syntax. That is,
```yaml
? hello
# this is a comment
:
- world
```
is valid.

