### PR TITLE
Use a span to reduce string allocations

### DIFF
--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -2405,7 +2405,11 @@ namespace YamlDotNet.Core
 
             if (head != null && head.Length > 1)
             {
+#if NETFRAMEWORK || NETSTANDARD2_0
                 tag.Append(head.Substring(1));
+#else
+                tag.Append(head.AsSpan()[1..]);
+#endif
             }
 
             // Scan the tag.


### PR DESCRIPTION
On versions that support it we can use Span<char> to ease GC pressure by not having to allocate a temporary string from substring, instead we can just get a readonly span of what we want and send that to the string builder
