### PR TITLE
Add default scalar style

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -456,6 +456,19 @@ namespace YamlDotNet.Test.Serialization
         public string DoubleQuotedString { get; set; }
     }
 
+    /// <summary>
+    /// This class demonstrates an object with serializable data that will be
+    /// written to YAML with strings that are formatted as valid numbers.
+    /// </summary>
+    public class MixedFormatScalarStyleExample
+    {
+        public string[] Data { get; }
+        public MixedFormatScalarStyleExample(string[] data)
+        {
+            Data = data;
+        }
+    }
+
     public class DefaultsExample
     {
         public const string DefaultValue = "myDefault";

--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -463,6 +463,7 @@ namespace YamlDotNet.Test.Serialization
     public class MixedFormatScalarStyleExample
     {
         public string[] Data { get; }
+
         public MixedFormatScalarStyleExample(string[] data)
         {
             Data = data;

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1019,7 +1019,7 @@ y:
         }
 
         [Fact]
-        public void SerializationRespectsGlobalScalarStyleOverride()
+        public void SerializationRespectsDefaultScalarStyle()
         {
             var writer = new StringWriter();
             var obj = new MixedFormatScalarStyleExample(new string[] { "01", "0.1", "myString" });
@@ -1028,11 +1028,16 @@ y:
 
             serializer.Serialize(writer, obj);
 
-            var serialized = writer.ToString();
+            var yaml = writer.ToString();
 
-            var expected = "Data:\r\n- '01'\r\n- '0.1'\r\n- 'myString'\r\n".NormalizeNewLines();
+            var expected = Yaml.Text(@"
+                Data:
+                - '01'
+                - '0.1'
+                - 'myString'
+            ");
 
-            serialized.Should().Be(expected);
+            Assert.Equal(expected.NormalizeNewLines(), yaml.NormalizeNewLines().TrimNewLines());
         }
 
         [Fact]

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1019,6 +1019,23 @@ y:
         }
 
         [Fact]
+        public void SerializationRespectsGlobalScalarStyleOverride()
+        {
+            var writer = new StringWriter();
+            var obj = new MixedFormatScalarStyleExample(new string[] { "01", "0.1", "myString" });
+
+            var serializer = new SerializerBuilder().Build();
+
+            serializer.Serialize(writer, obj);
+
+            var serialized = writer.ToString();
+
+            var expected = "Data:\r\n- '01'\r\n- '0.1'\r\n- 'myString'\r\n".NormalizeNewLines();
+
+            serialized.Should().Be(expected);
+        }
+
+        [Fact]
         public void SerializationDerivedAttributeOverride()
         {
             var writer = new StringWriter();

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1024,7 +1024,7 @@ y:
             var writer = new StringWriter();
             var obj = new MixedFormatScalarStyleExample(new string[] { "01", "0.1", "myString" });
 
-            var serializer = new SerializerBuilder().Build();
+            var serializer = new SerializerBuilder().WithDefaultScalarStyle(ScalarStyle.SingleQuoted).Build();
 
             serializer.Serialize(writer, obj);
 

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -65,14 +65,14 @@ namespace YamlDotNet.Serialization.EventEmitters
                 + @"|\.(nan|NaN|NAN)"
             + @")$";
 
-        private readonly ScalarStyle? globalScalarStyle;
+        private readonly ScalarStyle defaultScalarStyle;
 
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings, ScalarStyle? globalScalarStyle = null)
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings, ScalarStyle defaultScalarStyle = ScalarStyle.Any)
             : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings)
         {
             this.quoteNecessaryStrings = quoteNecessaryStrings;
 
-            this.globalScalarStyle = globalScalarStyle;
+            this.defaultScalarStyle = defaultScalarStyle;
 
             var specialStringValuePattern = quoteYaml1_1Strings
                 ? CombinedYaml1_1SpecialStrings_Pattern
@@ -141,13 +141,9 @@ namespace YamlDotNet.Serialization.EventEmitters
                             {
                                 suggestedStyle = ScalarStyle.DoubleQuoted;
                             }
-                            else if (globalScalarStyle != null)
-                            {
-                                suggestedStyle = (ScalarStyle)globalScalarStyle;
-                            }
                             else
                             {
-                                suggestedStyle = ScalarStyle.Any;
+                                suggestedStyle = defaultScalarStyle;
                             }
                         }
                         else
@@ -181,13 +177,9 @@ namespace YamlDotNet.Serialization.EventEmitters
                         {
                             suggestedStyle = ScalarStyle.DoubleQuoted;
                         }
-                        else if (globalScalarStyle != null)
-                        {
-                            suggestedStyle = (ScalarStyle)globalScalarStyle;
-                        }
                         else
                         {
-                            suggestedStyle = ScalarStyle.Any;
+                            suggestedStyle = defaultScalarStyle;
                         }
 
                         break;

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -65,10 +65,14 @@ namespace YamlDotNet.Serialization.EventEmitters
                 + @"|\.(nan|NaN|NAN)"
             + @")$";
 
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings)
+        private readonly ScalarStyle? globalScalarStyle;
+
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings, ScalarStyle? globalScalarStyle = null)
             : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings)
         {
             this.quoteNecessaryStrings = quoteNecessaryStrings;
+
+            this.globalScalarStyle = globalScalarStyle;
 
             var specialStringValuePattern = quoteYaml1_1Strings
                 ? CombinedYaml1_1SpecialStrings_Pattern
@@ -137,6 +141,10 @@ namespace YamlDotNet.Serialization.EventEmitters
                             {
                                 suggestedStyle = ScalarStyle.DoubleQuoted;
                             }
+                            else if (globalScalarStyle != null)
+                            {
+                                suggestedStyle = (ScalarStyle)globalScalarStyle;
+                            }
                             else
                             {
                                 suggestedStyle = ScalarStyle.Any;
@@ -172,6 +180,10 @@ namespace YamlDotNet.Serialization.EventEmitters
                         if (quoteNecessaryStrings && IsSpecialStringValue(eventInfo.RenderedValue))
                         {
                             suggestedStyle = ScalarStyle.DoubleQuoted;
+                        }
+                        else if (globalScalarStyle != null)
+                        {
+                            suggestedStyle = (ScalarStyle)globalScalarStyle;
                         }
                         else
                         {

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -73,6 +73,12 @@ namespace YamlDotNet.Serialization.EventEmitters
             this.defaultScalarStyle = defaultScalarStyle;
         }
 
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, ScalarStyle defaultScalarStyle)
+            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, quoteNecessaryStrings)
+        {
+            this.defaultScalarStyle = defaultScalarStyle;
+        }
+
         public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings)
             : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings)
         {
@@ -86,12 +92,6 @@ namespace YamlDotNet.Serialization.EventEmitters
 #else
             isSpecialStringValue_Regex = new Regex(specialStringValuePattern, RegexOptions.Compiled);
 #endif
-        }
-
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, ScalarStyle defaultScalarStyle)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, quoteNecessaryStrings)
-        {
-            this.defaultScalarStyle = defaultScalarStyle;
         }
 
         public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings)

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -65,10 +65,16 @@ namespace YamlDotNet.Serialization.EventEmitters
                 + @"|\.(nan|NaN|NAN)"
             + @")$";
 
-        private readonly ScalarStyle defaultScalarStyle;
+        private readonly ScalarStyle defaultScalarStyle = ScalarStyle.Any;
 
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings, ScalarStyle defaultScalarStyle = ScalarStyle.Any)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, defaultScalarStyle: defaultScalarStyle)
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings, ScalarStyle defaultScalarStyle)
+            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings)
+        {
+            this.defaultScalarStyle = defaultScalarStyle;
+        }
+
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings)
+            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings)
         {
             this.quoteNecessaryStrings = quoteNecessaryStrings;
 
@@ -82,8 +88,14 @@ namespace YamlDotNet.Serialization.EventEmitters
 #endif
         }
 
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, ScalarStyle defaultScalarStyle = ScalarStyle.Any)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, defaultScalarStyle: defaultScalarStyle)
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, ScalarStyle defaultScalarStyle)
+            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, quoteNecessaryStrings)
+        {
+            this.defaultScalarStyle = defaultScalarStyle;
+        }
+
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings)
+            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings)
         {
             this.quoteNecessaryStrings = quoteNecessaryStrings;
 
@@ -94,12 +106,11 @@ namespace YamlDotNet.Serialization.EventEmitters
 #endif
         }
 
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, ScalarStyle defaultScalarStyle = ScalarStyle.Any)
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings)
             : base(nextEmitter)
         {
             this.requireTagWhenStaticAndActualTypesAreDifferent = requireTagWhenStaticAndActualTypesAreDifferent;
             this.tagMappings = tagMappings ?? throw new ArgumentNullException(nameof(tagMappings));
-            this.defaultScalarStyle = defaultScalarStyle;
         }
 
         public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -68,11 +68,9 @@ namespace YamlDotNet.Serialization.EventEmitters
         private readonly ScalarStyle defaultScalarStyle;
 
         public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings, ScalarStyle defaultScalarStyle = ScalarStyle.Any)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings)
+            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, defaultScalarStyle: defaultScalarStyle)
         {
             this.quoteNecessaryStrings = quoteNecessaryStrings;
-
-            this.defaultScalarStyle = defaultScalarStyle;
 
             var specialStringValuePattern = quoteYaml1_1Strings
                 ? CombinedYaml1_1SpecialStrings_Pattern
@@ -84,8 +82,8 @@ namespace YamlDotNet.Serialization.EventEmitters
 #endif
         }
 
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings)
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, ScalarStyle defaultScalarStyle = ScalarStyle.Any)
+            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, defaultScalarStyle: defaultScalarStyle)
         {
             this.quoteNecessaryStrings = quoteNecessaryStrings;
 
@@ -96,11 +94,12 @@ namespace YamlDotNet.Serialization.EventEmitters
 #endif
         }
 
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings)
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, ScalarStyle defaultScalarStyle = ScalarStyle.Any)
             : base(nextEmitter)
         {
             this.requireTagWhenStaticAndActualTypesAreDifferent = requireTagWhenStaticAndActualTypesAreDifferent;
             this.tagMappings = tagMappings ?? throw new ArgumentNullException(nameof(tagMappings));
+            this.defaultScalarStyle = defaultScalarStyle;
         }
 
         public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -119,6 +119,11 @@ namespace YamlDotNet.Serialization
             return this;
         }
 
+        public SerializerBuilder WithDefaultScalarStyle(ScalarStyle style)
+        {
+            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, globalScalarStyle: style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+        }
+
         /// <summary>
         /// Sets the maximum recursion that is allowed while traversing the object graph. The default value is 50.
         /// </summary>
@@ -304,7 +309,7 @@ namespace YamlDotNet.Serialization
         /// </summary>
         /// <remarks>
         /// If more control is needed, create a class that extends from ChainedObjectGraphVisitor and override its EnterMapping methods.
-        /// Then register it as follows: 
+        /// Then register it as follows:
         /// WithEmissionPhaseObjectGraphVisitor(args => new MyDefaultHandlingStrategy(args.InnerVisitor));
         /// </remarks>
         public SerializerBuilder ConfigureDefaultValuesHandling(DefaultValuesHandling configuration)

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -121,7 +121,7 @@ namespace YamlDotNet.Serialization
 
         public SerializerBuilder WithDefaultScalarStyle(ScalarStyle style)
         {
-            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, globalScalarStyle: style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle: style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -124,7 +124,7 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public SerializerBuilder WithDefaultScalarStyle(ScalarStyle style)
         {
-            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle: style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -119,6 +119,9 @@ namespace YamlDotNet.Serialization
             return this;
         }
 
+        /// <summary>
+        /// Sets the default quoting style for scalar values. The default value is <see cref="ScalarStyle.Any"/>
+        /// </summary>
         public SerializerBuilder WithDefaultScalarStyle(ScalarStyle style)
         {
             return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle: style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());

--- a/YamlDotNet/Serialization/StaticSerializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticSerializerBuilder.cs
@@ -113,6 +113,11 @@ namespace YamlDotNet.Serialization
             return this;
         }
 
+        public StaticSerializerBuilder WithDefaultScalarStyle(ScalarStyle style)
+        {
+            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, defaultScalarStyle: style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+        }
+
         /// <summary>
         /// Sets the maximum recursion that is allowed while traversing the object graph. The default value is 50.
         /// </summary>

--- a/YamlDotNet/Serialization/StaticSerializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticSerializerBuilder.cs
@@ -118,7 +118,7 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public StaticSerializerBuilder WithDefaultScalarStyle(ScalarStyle style)
         {
-            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, defaultScalarStyle: style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/StaticSerializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticSerializerBuilder.cs
@@ -113,6 +113,9 @@ namespace YamlDotNet.Serialization
             return this;
         }
 
+        /// <summary>
+        /// Sets the default quoting style for scalar values. The default value is <see cref="ScalarStyle.Any"/>
+        /// </summary>
         public StaticSerializerBuilder WithDefaultScalarStyle(ScalarStyle style)
         {
             return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, defaultScalarStyle: style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());


### PR DESCRIPTION
## Summary
Re: #714 , it is sometimes desirable to force a quotation style on all strings in a YAML document. For example, when some strings contain valid numeric literals.

This implements the suggested change from that issue by exposing the "default scalar style" as a constructor argument. Previously, this value was hard-coded to `ScalarStyle.Any` as the local value `suggestedStyle`.

## Changes
- `YamlDotNet/Serialization`
  - Add `defaultScalarStyle = ScalarStyle.Any` to `TypeAssigningEventEmitter`
  - Add `SerializerBuilder.WithDefaultScalarStyle`
    - I wasn't sure of the best way to create the `TypeAssigningEventEmitter`, so I copied the instantiation from the constructor and used `loc.InsteadOf<_>` to replace it.
    - I'm not sure how necessary it is, but here it would have been a bit more ergonomic to have an instance member on the `SerializerBuilder` to construct its `TypeAssigningEventEmitter`
- `YamlDotNet.Test`
  - Add `SerializationRespectsDefaultScalarStyle`
    - This is only testing `SingleQuote`. I can add others if necessary.
  - Add  `MixedFormatScalarStyleExample` to helpers

## To Do
- [x] Add `StaticSerializerBuilder.WithDefaultScalarStyle`
- [x] Use literal strings in test case
- [x] Increase newline consistency quotient
- [x] Add new constructors instead of changing signatures


Fix #714 