### PR TITLE
Add missing methods to (de)serializer interfaces and implementations

### DIFF
--- a/YamlDotNet/Serialization/Deserializer.cs
+++ b/YamlDotNet/Serialization/Deserializer.cs
@@ -77,11 +77,26 @@ namespace YamlDotNet.Serialization
             return Deserialize<T>(new Parser(input));
         }
 
+        public T Deserialize<T>(IParser parser)
+        {
+            return (T)Deserialize(parser, typeof(T))!; // We really want an exception if we are trying to deserialize null into a non-nullable type
+        }
+        
+        public object? Deserialize(string input)
+        {
+            return Deserialize(input, typeof(object));
+        }
+        
         public object? Deserialize(TextReader input)
         {
             return Deserialize(input, typeof(object));
         }
 
+        public object? Deserialize(IParser parser)
+        {
+            return Deserialize(parser, typeof(object));
+        }
+        
         public object? Deserialize(string input, Type type)
         {
             using var reader = new StringReader(input);
@@ -91,16 +106,6 @@ namespace YamlDotNet.Serialization
         public object? Deserialize(TextReader input, Type type)
         {
             return Deserialize(new Parser(input), type);
-        }
-
-        public T Deserialize<T>(IParser parser)
-        {
-            return (T)Deserialize(parser, typeof(T))!; // We really want an exception if we are trying to deserialize null into a non-nullable type
-        }
-
-        public object? Deserialize(IParser parser)
-        {
-            return Deserialize(parser, typeof(object));
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/IDeserializer.cs
+++ b/YamlDotNet/Serialization/IDeserializer.cs
@@ -29,12 +29,15 @@ namespace YamlDotNet.Serialization
     {
         T Deserialize<T>(string input);
         T Deserialize<T>(TextReader input);
-        object? Deserialize(TextReader input);
-        object? Deserialize(string input, Type type);
-        object? Deserialize(TextReader input, Type type);
         T Deserialize<T>(IParser parser);
+
+        object? Deserialize(string input);
+        object? Deserialize(TextReader input);
         object? Deserialize(IParser parser);
 
+        object? Deserialize(string input, Type type);
+        object? Deserialize(TextReader input, Type type);
+        
         /// <summary>
         /// Deserializes an object of the specified type.
         /// </summary>

--- a/YamlDotNet/Serialization/ISerializer.cs
+++ b/YamlDotNet/Serialization/ISerializer.cs
@@ -28,17 +28,24 @@ namespace YamlDotNet.Serialization
     public interface ISerializer
     {
         /// <summary>
-        /// Serializes the specified object.
+        /// Serializes the specified object into a string.
         /// </summary>
-        /// <param name="writer">The <see cref="TextWriter" /> where to serialize the object.</param>
         /// <param name="graph">The object to serialize.</param>
-        void Serialize(TextWriter writer, object? graph);
+        string Serialize(object? graph);
 
         /// <summary>
         /// Serializes the specified object into a string.
         /// </summary>
         /// <param name="graph">The object to serialize.</param>
-        string Serialize(object? graph);
+        /// <param name="type">The static type of the object to serialize.</param> 
+        string Serialize(object? graph, Type type);
+        
+        /// <summary>
+        /// Serializes the specified object.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter" /> where to serialize the object.</param>
+        /// <param name="graph">The object to serialize.</param>
+        void Serialize(TextWriter writer, object? graph);
 
         /// <summary>
         /// Serializes the specified object.

--- a/YamlDotNet/Serialization/Serializer.cs
+++ b/YamlDotNet/Serialization/Serializer.cs
@@ -63,16 +63,6 @@ namespace YamlDotNet.Serialization
         }
 
         /// <summary>
-        /// Serializes the specified object.
-        /// </summary>
-        /// <param name="writer">The <see cref="TextWriter" /> where to serialize the object.</param>
-        /// <param name="graph">The object to serialize.</param>
-        public void Serialize(TextWriter writer, object? graph)
-        {
-            Serialize(new Emitter(writer, emitterSettings), graph);
-        }
-
-        /// <summary>
         /// Serializes the specified object into a string.
         /// </summary>
         /// <param name="graph">The object to serialize.</param>
@@ -81,6 +71,28 @@ namespace YamlDotNet.Serialization
             using var buffer = new StringWriter();
             Serialize(buffer, graph);
             return buffer.ToString();
+        }
+
+        /// <summary>
+        /// Serializes the specified object into a string.
+        /// </summary>
+        /// <param name="graph">The object to serialize.</param>
+        /// <param name="type">The static type of the object to serialize.</param> 
+        public string Serialize(object? graph, Type type)
+        {
+            using var buffer = new StringWriter();
+            Serialize(buffer, graph, type);
+            return buffer.ToString();
+        }
+        
+        /// <summary>
+        /// Serializes the specified object.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter" /> where to serialize the object.</param>
+        /// <param name="graph">The object to serialize.</param>
+        public void Serialize(TextWriter writer, object? graph)
+        {
+            Serialize(new Emitter(writer, emitterSettings), graph);
         }
 
         /// <summary>


### PR DESCRIPTION
Add missing methods to (de)serializer interfaces and implementations - also reorder the methods to make a sorted sequence.

Closes #828 