### PR TITLE
Support null values in YamlScalarNode for YamlStream

### DIFF
--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -27,7 +27,9 @@ using System.Text;
 using FluentAssertions;
 using Xunit;
 using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 using YamlDotNet.RepresentationModel;
+using YamlDotNet.Serialization.Schemas;
 
 namespace YamlDotNet.Test.RepresentationModel
 {
@@ -101,6 +103,63 @@ namespace YamlDotNet.Test.RepresentationModel
             Assert.Equal("another scalar", ((YamlScalarNode)sequence.Children[1]).Value);
             Assert.Equal("a scalar", ((YamlScalarNode)sequence.Children[2]).Value);
             Assert.Same(sequence.Children[0], sequence.Children[2]);
+        }
+
+        [Theory]
+        [InlineData("B: !!null ", "", ScalarStyle.Plain, false)]
+        [InlineData("B: ", "", ScalarStyle.Plain, true)]
+        [InlineData("B: abc", "abc", ScalarStyle.Plain, true)]
+        [InlineData("B: ~", "~", ScalarStyle.Plain, true)]
+        [InlineData("B: Null", "Null", ScalarStyle.Plain, true)]
+        [InlineData("B: ''", "", ScalarStyle.SingleQuoted, true)]
+        [InlineData("B: 'Null'", "Null", ScalarStyle.SingleQuoted, true)]
+        public void ImplicitNullRoundtrips(string yaml, string value, ScalarStyle style, bool implicitPlain)
+        {
+            //load
+            var stream = new YamlStream();
+            stream.Load(new StringReader(yaml));
+            var mapping = (YamlMappingNode)stream.Documents[0].RootNode;
+            var map = mapping.Children[0];
+
+            var yamlValue = (YamlScalarNode)map.Value;
+            Assert.Equal(value, yamlValue.Value);
+
+            var emitter = new RoundTripNullTestEmitter(implicitPlain, style);
+            yamlValue.Emit(emitter, null);
+
+            var stringWriter = new StringWriter();
+            new YamlStream(stream.Documents).Save(stringWriter);
+            Assert.Equal($@"{yaml}
+...".NormalizeNewLines(),
+stringWriter.ToString().NormalizeNewLines().TrimNewLines());
+        }
+
+        [Fact]
+        public void EmptyScalarsAreEmptySingleQuoted()
+        {
+            var stringWriter = new StringWriter();
+            var rootNode = new YamlMappingNode();
+            rootNode.Children.Add(new YamlScalarNode("test"), new YamlScalarNode(""));
+            var document = new YamlDocument(rootNode);
+            var yamlStream = new YamlStream(document);
+            yamlStream.Save(stringWriter);
+            var actual = stringWriter.ToString().NormalizeNewLines();
+            var expected = "test: ''\r\n...\r\n".NormalizeNewLines();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void NullScalarsAreEmptyPlain()
+        {
+            var stringWriter = new StringWriter();
+            var rootNode = new YamlMappingNode();
+            rootNode.Children.Add(new YamlScalarNode("test"), new YamlScalarNode(null));
+            var document = new YamlDocument(rootNode);
+            var yamlStream = new YamlStream(document);
+            yamlStream.Save(stringWriter);
+            var actual = stringWriter.ToString().NormalizeNewLines();
+            var expected = "test: \r\n...\r\n".NormalizeNewLines();
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -312,6 +371,37 @@ namespace YamlDotNet.Test.RepresentationModel
             MappingStart,
             MappingEnd,
             Scalar,
+        }
+
+        private class RoundTripNullTestEmitter : IEmitter
+        {
+            private readonly bool enforceImplicit;
+            private readonly ScalarStyle style;
+
+            public RoundTripNullTestEmitter(bool enforceImplicit, ScalarStyle style)
+            {
+                this.enforceImplicit = enforceImplicit;
+                this.style = style;
+            }
+
+            public void Emit(ParsingEvent @event)
+            {
+                Assert.Equal(EventType.Scalar, @event.Type);
+                Assert.IsType<Scalar>(@event);
+                var scalar = (Scalar)@event;
+
+                Assert.Equal(style, scalar.Style);
+                if (enforceImplicit)
+                {
+                    Assert.True(scalar.IsPlainImplicit);
+                }
+                else
+                {
+                    Assert.False(scalar.IsPlainImplicit);
+                }
+
+                Assert.False(scalar.IsQuotedImplicit);
+            }
         }
     }
 }

--- a/YamlDotNet/Portability/net35+unitysubset3.5/include/Lazy.cs
+++ b/YamlDotNet/Portability/net35+unitysubset3.5/include/Lazy.cs
@@ -46,6 +46,7 @@ namespace System
             this.valueFactory = valueFactory;
             this.isThreadSafe = false;
             valueState = ValueState.NotCreated;
+            value = default!;
         }
 
         public Lazy(Func<T> valueFactory, bool isThreadSafe)

--- a/YamlDotNet/Serialization/BufferedDeserialization/TypeDiscriminators/UniqueKeyTypeDiscriminator.cs
+++ b/YamlDotNet/Serialization/BufferedDeserialization/TypeDiscriminators/UniqueKeyTypeDiscriminator.cs
@@ -1,4 +1,4 @@
-// This file is part of YamlDotNet - A .NET library for YAML.
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
 // Copyright (c) Antoine Aubry and contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -74,8 +74,8 @@ namespace YamlDotNet.Serialization.BufferedDeserialization.TypeDiscriminators
         {
             if (parser.TryFindMappingEntry(
                 scalar => this.typeMapping.ContainsKey(scalar.Value),
-                out Scalar key,
-                out ParsingEvent _))
+                out var key,
+                out var _))
             {
                 suggestedType = this.typeMapping[key.Value];
                 return true;

--- a/YamlDotNet/Serialization/Deserializer.cs
+++ b/YamlDotNet/Serialization/Deserializer.cs
@@ -81,12 +81,12 @@ namespace YamlDotNet.Serialization
         {
             return (T)Deserialize(parser, typeof(T))!; // We really want an exception if we are trying to deserialize null into a non-nullable type
         }
-        
+
         public object? Deserialize(string input)
         {
             return Deserialize(input, typeof(object));
         }
-        
+
         public object? Deserialize(TextReader input)
         {
             return Deserialize(input, typeof(object));
@@ -96,7 +96,7 @@ namespace YamlDotNet.Serialization
         {
             return Deserialize(parser, typeof(object));
         }
-        
+
         public object? Deserialize(string input, Type type)
         {
             using var reader = new StringReader(input);

--- a/YamlDotNet/Serialization/IDeserializer.cs
+++ b/YamlDotNet/Serialization/IDeserializer.cs
@@ -34,10 +34,9 @@ namespace YamlDotNet.Serialization
         object? Deserialize(string input);
         object? Deserialize(TextReader input);
         object? Deserialize(IParser parser);
-
         object? Deserialize(string input, Type type);
         object? Deserialize(TextReader input, Type type);
-        
+
         /// <summary>
         /// Deserializes an object of the specified type.
         /// </summary>

--- a/YamlDotNet/Serialization/ISerializer.cs
+++ b/YamlDotNet/Serialization/ISerializer.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Serialization
         /// <param name="graph">The object to serialize.</param>
         /// <param name="type">The static type of the object to serialize.</param> 
         string Serialize(object? graph, Type type);
-        
+
         /// <summary>
         /// Serializes the specified object.
         /// </summary>

--- a/YamlDotNet/Serialization/Serializer.cs
+++ b/YamlDotNet/Serialization/Serializer.cs
@@ -84,7 +84,7 @@ namespace YamlDotNet.Serialization
             Serialize(buffer, graph, type);
             return buffer.ToString();
         }
-        
+
         /// <summary>
         /// Serializes the specified object.
         /// </summary>


### PR DESCRIPTION
Fixes #810

For backwards compatibility we wont set the `Value` property to `null`.