### PR TITLE
Fix tests running in cultures using different cultures

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .git
 Dockerfile.NonEnglish
 Dockerfile
+bin
+obj

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 .git
+Dockerfile.NonEnglish
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt install -y wget
 RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 RUN apt update
-RUN apt install -y dotnet-sdk-3.1
+RUN apt install -y dotnet-sdk-3.1 dotnet-sdk-6.0
 
 FROM builder AS build
 WORKDIR /src
@@ -46,10 +46,9 @@ RUN dotnet build -c Release --framework net70 YamlDotNet/YamlDotNet.csproj -o /o
 
 RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
 
-RUN dotnet test -c Release YamlDotNet.sln --framework net70 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.sln --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests.netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net47 --logger:"trx;LogFileName=/output/tests.net47.trx" --logger:"console;Verbosity=detailed"
 
 FROM alpine
 VOLUME /output

--- a/Dockerfile.NonEnglish
+++ b/Dockerfile.NonEnglish
@@ -38,17 +38,16 @@ RUN dotnet restore YamlDotNet.sln
 
 COPY . .
 
-# RUN dotnet build -c Release --framework net35 YamlDotNet/YamlDotNet.csproj -o /output/net35
-# RUN dotnet build -c Release --framework net40 YamlDotNet/YamlDotNet.csproj -o /output/net40
-# RUN dotnet build -c Release --framework net45 YamlDotNet/YamlDotNet.csproj -o /output/net45
-# RUN dotnet build -c Release --framework net47 YamlDotNet/YamlDotNet.csproj -o /output/net47
-# RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.0
-# RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
-# RUN dotnet build -c Release --framework net60 YamlDotNet/YamlDotNet.csproj -o /output/net60
-# RUN dotnet build -c Release --framework net70 YamlDotNet/YamlDotNet.csproj -o /output/net70
+RUN dotnet build -c Release --framework net35 YamlDotNet/YamlDotNet.csproj -o /output/net35
+RUN dotnet build -c Release --framework net40 YamlDotNet/YamlDotNet.csproj -o /output/net40
+RUN dotnet build -c Release --framework net45 YamlDotNet/YamlDotNet.csproj -o /output/net45
+RUN dotnet build -c Release --framework net47 YamlDotNet/YamlDotNet.csproj -o /output/net47
+RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.0
+RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
+RUN dotnet build -c Release --framework net60 YamlDotNet/YamlDotNet.csproj -o /output/net60
+RUN dotnet build -c Release --framework net70 YamlDotNet/YamlDotNet.csproj -o /output/net70
 
-# RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
-
+RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
 
 ARG LOCALE_LANGUAGE="en"
 ARG LOCALE_COUNTRY="DK"
@@ -65,12 +64,12 @@ RUN echo -n "${LC_ALL}" > /etc/locale.gen && \
     locale-gen
 
 RUN dotnet test -c Release YamlDotNet.sln --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
-#RUN dotnet test -c Release YamlDotNet.sln --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
-#RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests.netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
-#RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net47 --logger:"trx;LogFileName=/output/tests.net47.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.sln --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests.netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net47 --logger:"trx;LogFileName=/output/tests.net47.trx" --logger:"console;Verbosity=detailed"
 
-#FROM alpine
-#VOLUME /output
-#WORKDIR /libraries
-#COPY --from=build /output /libraries
-#CMD [ "cp", "-r", "/libraries", "/output" ]
+FROM alpine
+VOLUME /output
+WORKDIR /libraries
+COPY --from=build /output /libraries
+CMD [ "cp", "-r", "/libraries", "/output" ]

--- a/Dockerfile.NonEnglish
+++ b/Dockerfile.NonEnglish
@@ -1,0 +1,76 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
+RUN apt update && \
+    apt install -y \
+        apt-transport-https \
+        gnupg \
+        ca-certificates \
+        curl \
+        locales
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+# yes, we're using the bullseye (debian 11) image, however mono only has buster, but it still works for bullseye
+RUN echo "deb https://download.mono-project.com/repo/debian stable-buster main" > /etc/apt/sources.list.d/mono-official-stable.list
+RUN apt update
+RUN apt install -y mono-complete
+
+# install dot net 3.1 for running netstandard2.1 tests
+RUN apt install -y wget
+RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+RUN apt update
+RUN apt install -y dotnet-sdk-3.1
+
+
+FROM builder AS build
+WORKDIR /src
+ARG PACKAGE_VERSION=1.0.0
+
+COPY YamlDotNet.sln YamlDotNet.sln
+COPY YamlDotNet/YamlDotNet.csproj YamlDotNet/YamlDotNet.csproj
+COPY YamlDotNet.AotTest/YamlDotNet.AotTest.csproj YamlDotNet.AotTest/YamlDotNet.AotTest.csproj
+COPY YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
+COPY YamlDotNet.Samples/YamlDotNet.Samples.csproj YamlDotNet.Samples/YamlDotNet.Samples.csproj
+COPY YamlDotNet.Test/YamlDotNet.Test.csproj YamlDotNet.Test/YamlDotNet.Test.csproj
+COPY YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.csproj YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.csproj
+COPY YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
+
+RUN dotnet restore YamlDotNet.sln
+
+COPY . .
+
+# RUN dotnet build -c Release --framework net35 YamlDotNet/YamlDotNet.csproj -o /output/net35
+# RUN dotnet build -c Release --framework net40 YamlDotNet/YamlDotNet.csproj -o /output/net40
+# RUN dotnet build -c Release --framework net45 YamlDotNet/YamlDotNet.csproj -o /output/net45
+# RUN dotnet build -c Release --framework net47 YamlDotNet/YamlDotNet.csproj -o /output/net47
+# RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.0
+# RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
+# RUN dotnet build -c Release --framework net60 YamlDotNet/YamlDotNet.csproj -o /output/net60
+# RUN dotnet build -c Release --framework net70 YamlDotNet/YamlDotNet.csproj -o /output/net70
+
+# RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
+
+
+ARG LOCALE_LANGUAGE="en"
+ARG LOCALE_COUNTRY="DK"
+ARG LOCALE_LOCALE="${LOCALE_LANGUAGE}_${LOCALE_COUNTRY}"
+ARG LOCALE_ENCODING="UTF-8"
+
+ENV LANG="${LOCALE_LANGUAGE}_${LOCALE_COUNTRY}.${LOCALE_ENCODING}"
+ENV LANGUAGE="${LOCALE_LANGUAGE}_${LOCALE_COUNTRY}:${LOCALE_LANGUAGE}"
+ENV LC_ALL="${LOCALE_LANGUAGE}_${LOCALE_COUNTRY}.${LOCALE_ENCODING}"
+
+RUN echo -n "${LC_ALL}" > /etc/locale.gen && \
+    printenv && \
+    apt install -y locales && \
+    locale-gen
+
+RUN dotnet test -c Release YamlDotNet.sln --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
+#RUN dotnet test -c Release YamlDotNet.sln --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
+#RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests.netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
+#RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net47 --logger:"trx;LogFileName=/output/tests.net47.trx" --logger:"console;Verbosity=detailed"
+
+#FROM alpine
+#VOLUME /output
+#WORKDIR /libraries
+#COPY --from=build /output /libraries
+#CMD [ "cp", "-r", "/libraries", "/output" ]

--- a/Dockerfile.NonEnglish
+++ b/Dockerfile.NonEnglish
@@ -4,8 +4,7 @@ RUN apt update && \
         apt-transport-https \
         gnupg \
         ca-certificates \
-        curl \
-        locales
+        curl
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 # yes, we're using the bullseye (debian 11) image, however mono only has buster, but it still works for bullseye
@@ -18,7 +17,7 @@ RUN apt install -y wget
 RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 RUN apt update
-RUN apt install -y dotnet-sdk-3.1
+RUN apt install -y dotnet-sdk-3.1 dotnet-sdk-6.0
 
 
 FROM builder AS build
@@ -63,10 +62,9 @@ RUN echo -n "${LC_ALL}" > /etc/locale.gen && \
     apt install -y locales && \
     locale-gen
 
-RUN dotnet test -c Release YamlDotNet.sln --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.sln --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests.netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net47 --logger:"trx;LogFileName=/output/tests.net47.trx" --logger:"console;Verbosity=detailed"
 
 FROM alpine
 VOLUME /output

--- a/YamlDotNet.Core7AoTCompileTest/Program.cs
+++ b/YamlDotNet.Core7AoTCompileTest/Program.cs
@@ -18,6 +18,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+#pragma warning disable CS8604 // Possible null reference argument.
+#pragma warning disable CS8618 // Possible null reference argument.
+#pragma warning disable CS8602 // Possible null reference argument.
 
 using System;
 using System.Collections;
@@ -208,3 +211,6 @@ public enum MyTestEnum
     Z = 1,
 }
 
+#pragma warning restore CS8604 // Possible null reference argument.
+#pragma warning restore CS8618 // Possible null reference argument.
+#pragma warning restore CS8602 // Possible null reference argument.

--- a/YamlDotNet.Samples/UseTypeConverters.cs
+++ b/YamlDotNet.Samples/UseTypeConverters.cs
@@ -48,7 +48,7 @@ namespace YamlDotNet.Samples
             var serializer = new SerializerBuilder()
                 .WithTypeConverter(new DateTimeOffsetConverter())
                 .Build();
-            var o = new { Hello = new DateTimeOffset(DateTime.Now, new TimeSpan(-6, 0, 0)) };
+            var o = new { Hello = DateTime.UtcNow };
             var yaml = serializer.Serialize(o);
             output.WriteLine(yaml);
         }

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -278,7 +278,7 @@ b: &number 1
         public void DeserializeScalarEdgeCases(IConvertible value, Type type)
         {
             var deserializer = new DeserializerBuilder().Build();
-            var result = deserializer.Deserialize(value.ToString(), type);
+            var result = deserializer.Deserialize(value.ToString(YamlFormatter.Default.NumberFormat), type);
 
             result.Should().Be(value);
         }

--- a/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -42,6 +42,7 @@ namespace YamlDotNet.Serialization
         internal bool ignoreFields;
         internal bool includeNonPublicProperties = false;
         internal Settings settings;
+        internal YamlFormatter yamlFormatter = YamlFormatter.Default;
 
         internal BuilderSkeleton(ITypeResolver typeResolver)
         {
@@ -292,6 +293,18 @@ namespace YamlDotNet.Serialization
             }
 
             typeInspectorFactories.Remove(inspectorType);
+            return Self;
+        }
+
+        /// <summary>
+        /// Override the default yaml formatter with the one passed in
+        /// </summary>
+        /// <param name="formatter"><seealso cref="YamlFormatter"/>to use when serializing and deserializing objects.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public TBuilder WithYamlFormatter(YamlFormatter formatter)
+        {
+            yamlFormatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
             return Self;
         }
 

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -92,7 +92,7 @@ namespace YamlDotNet.Serialization
                 { typeof(YamlSerializableNodeDeserializer), _ => new YamlSerializableNodeDeserializer(objectFactory.Value) },
                 { typeof(TypeConverterNodeDeserializer), _ => new TypeConverterNodeDeserializer(BuildTypeConverters()) },
                 { typeof(NullNodeDeserializer), _ => new NullNodeDeserializer() },
-                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization, typeConverter) },
+                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization, typeConverter, yamlFormatter) },
                 { typeof(ArrayNodeDeserializer), _ => new ArrayNodeDeserializer() },
                 { typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value, duplicateKeyChecking) },
                 { typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value) },

--- a/YamlDotNet/Serialization/EventEmitters/JsonEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/JsonEventEmitter.cs
@@ -27,8 +27,16 @@ namespace YamlDotNet.Serialization.EventEmitters
 {
     public sealed class JsonEventEmitter : ChainedEventEmitter
     {
-        public JsonEventEmitter(IEventEmitter nextEmitter)
+        private readonly YamlFormatter formatter;
+
+        public JsonEventEmitter(IEventEmitter nextEmitter, YamlFormatter formatter)
             : base(nextEmitter)
+        {
+            this.formatter = formatter;
+        }
+
+        public JsonEventEmitter(IEventEmitter nextEmitter)
+            : this(nextEmitter, YamlFormatter.Default)
         {
         }
 
@@ -53,7 +61,7 @@ namespace YamlDotNet.Serialization.EventEmitters
                 switch (typeCode)
                 {
                     case TypeCode.Boolean:
-                        eventInfo.RenderedValue = YamlFormatter.FormatBoolean(value);
+                        eventInfo.RenderedValue = formatter.FormatBoolean(value);
                         break;
 
                     case TypeCode.Byte:
@@ -72,13 +80,13 @@ namespace YamlDotNet.Serialization.EventEmitters
                             break;
                         }
 
-                        eventInfo.RenderedValue = YamlFormatter.FormatNumber(value);
+                        eventInfo.RenderedValue = formatter.FormatNumber(value);
                         break;
 
                     case TypeCode.Single:
                     case TypeCode.Double:
                     case TypeCode.Decimal:
-                        eventInfo.RenderedValue = YamlFormatter.FormatNumber(value);
+                        eventInfo.RenderedValue = formatter.FormatNumber(value);
                         break;
 
                     case TypeCode.String:
@@ -88,7 +96,7 @@ namespace YamlDotNet.Serialization.EventEmitters
                         break;
 
                     case TypeCode.DateTime:
-                        eventInfo.RenderedValue = YamlFormatter.FormatDateTime(value);
+                        eventInfo.RenderedValue = formatter.FormatDateTime(value);
                         break;
 
                     case TypeCode.Empty:
@@ -98,7 +106,7 @@ namespace YamlDotNet.Serialization.EventEmitters
                     default:
                         if (eventInfo.Source.Type == typeof(TimeSpan))
                         {
-                            eventInfo.RenderedValue = YamlFormatter.FormatTimeSpan(value);
+                            eventInfo.RenderedValue = formatter.FormatTimeSpan(value);
                             break;
                         }
 

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -35,12 +35,19 @@ namespace YamlDotNet.Serialization.NodeDeserializers
         private const string BooleanFalsePattern = "^(false|n|no|off)$";
         private readonly bool attemptUnknownTypeDeserialization;
         private readonly ITypeConverter typeConverter;
+        private readonly YamlFormatter formatter;
 
-        public ScalarNodeDeserializer(bool attemptUnknownTypeDeserialization, ITypeConverter typeConverter)
+        public ScalarNodeDeserializer(bool attemptUnknownTypeDeserialization, ITypeConverter typeConverter, YamlFormatter formatter)
         {
             this.attemptUnknownTypeDeserialization = attemptUnknownTypeDeserialization;
             this.typeConverter = typeConverter ?? throw new ArgumentNullException(nameof(typeConverter));
+            this.formatter = formatter;
         }
+
+        //public ScalarNodeDeserializer(bool attemptUnknownTypeDeserialization, ITypeConverter typeConverter)
+        //    : this(attemptUnknownTypeDeserialization, typeConverter, YamlFormatter.Default)
+        //{
+        //}
 
         public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
         {
@@ -78,15 +85,15 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                     break;
 
                 case TypeCode.Single:
-                    value = float.Parse(scalar.Value, YamlFormatter.NumberFormat);
+                    value = float.Parse(scalar.Value, formatter.NumberFormat);
                     break;
 
                 case TypeCode.Double:
-                    value = double.Parse(scalar.Value, YamlFormatter.NumberFormat);
+                    value = double.Parse(scalar.Value, formatter.NumberFormat);
                     break;
 
                 case TypeCode.Decimal:
-                    value = decimal.Parse(scalar.Value, YamlFormatter.NumberFormat);
+                    value = decimal.Parse(scalar.Value, formatter.NumberFormat);
                     break;
 
                 case TypeCode.String:
@@ -144,7 +151,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             return result;
         }
 
-        private static object DeserializeIntegerHelper(TypeCode typeCode, string value)
+        private object DeserializeIntegerHelper(TypeCode typeCode, string value)
         {
             using var numberBuilderStringBuilder = StringBuilderPool.Rent();
             var numberBuilder = numberBuilderStringBuilder.Builder;
@@ -223,7 +230,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                         break;
 
                     case 16:
-                        result = ulong.Parse(numberBuilder.ToString(), NumberStyles.HexNumber, YamlFormatter.NumberFormat);
+                        result = ulong.Parse(numberBuilder.ToString(), NumberStyles.HexNumber, formatter.NumberFormat);
                         break;
 
                     case 10:
@@ -308,7 +315,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             }
         }
 
-        private static object? AttemptUnknownTypeDeserialization(Scalar value)
+        private object? AttemptUnknownTypeDeserialization(Scalar value)
         {
             if (value.Style == ScalarStyle.SingleQuoted ||
                 value.Style == ScalarStyle.DoubleQuoted ||
@@ -364,13 +371,13 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                     }
                     else if (Regex.IsMatch(v, @"[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?")) //regular number
                     {
-                        if (TryAndSwallow(() => byte.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => short.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => int.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => long.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => ulong.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => float.Parse(v), out result)) { }
-                        else if (TryAndSwallow(() => double.Parse(v), out result)) { }
+                        if (TryAndSwallow(() => byte.Parse(v, formatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => short.Parse(v, formatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => int.Parse(v, formatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => long.Parse(v, formatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => ulong.Parse(v, formatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => float.Parse(v, formatter.NumberFormat), out result)) { }
+                        else if (TryAndSwallow(() => double.Parse(v, formatter.NumberFormat), out result)) { }
                         else
                         {
                             //we couldn't parse it, default to string, It's probably too big

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -59,6 +59,7 @@ namespace YamlDotNet.Serialization
         private int maximumRecursion = 50;
         private EmitterSettings emitterSettings = EmitterSettings.Default;
         private DefaultValuesHandling defaultValuesHandlingConfiguration = DefaultValuesHandling.Preserve;
+        private ScalarStyle defaultScalarStyle = ScalarStyle.Any;
         private bool quoteNecessaryStrings;
         private bool quoteYaml1_1Strings;
 
@@ -97,7 +98,7 @@ namespace YamlDotNet.Serialization
 
             eventEmitterFactories = new LazyComponentRegistrationList<IEventEmitter, IEventEmitter>
             {
-                { typeof(TypeAssigningEventEmitter), inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings) }
+                { typeof(TypeAssigningEventEmitter), inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle, yamlFormatter) }
             };
 
             objectFactory = new DefaultObjectFactory();
@@ -124,7 +125,8 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public SerializerBuilder WithDefaultScalarStyle(ScalarStyle style)
         {
-            return WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, style), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+            this.defaultScalarStyle = style;
+            return this;
         }
 
         /// <summary>
@@ -280,7 +282,7 @@ namespace YamlDotNet.Serialization
                 settings,
                 objectFactory
             );
-            WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, true, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+            WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, true, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle, yamlFormatter), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
             return WithTypeInspector(inner => new ReadableAndWritablePropertiesTypeInspector(inner), loc => loc.OnBottom());
         }
 
@@ -333,7 +335,7 @@ namespace YamlDotNet.Serialization
             return this
                 .WithTypeConverter(new GuidConverter(true), w => w.InsteadOf<GuidConverter>())
                 .WithTypeConverter(new DateTimeConverter(doubleQuotes: true))
-                .WithEventEmitter(inner => new JsonEventEmitter(inner), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+                .WithEventEmitter(inner => new JsonEventEmitter(inner, yamlFormatter), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/StaticBuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/StaticBuilderSkeleton.cs
@@ -40,6 +40,7 @@ namespace YamlDotNet.Serialization
         internal readonly LazyComponentRegistrationList<ITypeInspector, ITypeInspector> typeInspectorFactories;
         internal bool includeNonPublicProperties = false;
         internal Settings settings;
+        internal YamlFormatter yamlFormatter = YamlFormatter.Default;
 
         internal StaticBuilderSkeleton(ITypeResolver typeResolver)
         {
@@ -235,6 +236,18 @@ namespace YamlDotNet.Serialization
             }
 
             typeInspectorFactories.Remove(inspectorType);
+            return Self;
+        }
+
+        /// <summary>
+        /// Override the default yaml formatter with the one passed in
+        /// </summary>
+        /// <param name="formatter"><seealso cref="YamlFormatter"/>to use when serializing and deserializing objects.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public TBuilder WithYamlFormatter(YamlFormatter formatter)
+        {
+            yamlFormatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
             return Self;
         }
 

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -87,7 +87,7 @@ namespace YamlDotNet.Serialization
                 { typeof(YamlSerializableNodeDeserializer), _ => new YamlSerializableNodeDeserializer(factory) },
                 { typeof(TypeConverterNodeDeserializer), _ => new TypeConverterNodeDeserializer(BuildTypeConverters()) },
                 { typeof(NullNodeDeserializer), _ => new NullNodeDeserializer() },
-                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization, typeConverter) },
+                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization, typeConverter, yamlFormatter) },
                 { typeof(StaticArrayNodeDeserializer), _ => new StaticArrayNodeDeserializer(factory) },
                 { typeof(StaticDictionaryNodeDeserializer), _ => new StaticDictionaryNodeDeserializer(factory, duplicateKeyChecking) },
                 { typeof(StaticCollectionNodeDeserializer), _ => new StaticCollectionNodeDeserializer(factory) },

--- a/YamlDotNet/Serialization/YamlFormatter.cs
+++ b/YamlDotNet/Serialization/YamlFormatter.cs
@@ -24,9 +24,11 @@ using System.Globalization;
 
 namespace YamlDotNet.Serialization
 {
-    internal static class YamlFormatter
+    public class YamlFormatter
     {
-        public static readonly NumberFormatInfo NumberFormat = new NumberFormatInfo
+        public static YamlFormatter Default { get; } = new YamlFormatter();
+
+        public NumberFormatInfo NumberFormat { get; set; } = new NumberFormatInfo
         {
             CurrencyDecimalSeparator = ".",
             CurrencyGroupSeparator = "_",
@@ -42,32 +44,32 @@ namespace YamlDotNet.Serialization
             NegativeInfinitySymbol = "-.inf"
         };
 
-        public static string FormatNumber(object number)
+        public string FormatNumber(object number)
         {
             return Convert.ToString(number, NumberFormat)!;
         }
 
-        public static string FormatNumber(double number)
+        public string FormatNumber(double number)
         {
             return number.ToString("G", NumberFormat);
         }
 
-        public static string FormatNumber(float number)
+        public string FormatNumber(float number)
         {
             return number.ToString("G", NumberFormat);
         }
 
-        public static string FormatBoolean(object boolean)
+        public string FormatBoolean(object boolean)
         {
             return boolean.Equals(true) ? "true" : "false";
         }
 
-        public static string FormatDateTime(object dateTime)
+        public string FormatDateTime(object dateTime)
         {
             return ((DateTime)dateTime).ToString("o", CultureInfo.InvariantCulture);
         }
 
-        public static string FormatTimeSpan(object timeSpan)
+        public string FormatTimeSpan(object timeSpan)
         {
             return ((TimeSpan)timeSpan).ToString();
         }


### PR DESCRIPTION
Fixes #792 

Also adds the ability to specify the number format for the project, defaults to yaml standard.

To specify the number format when serializing or deserializing, use a custom `YamlFormatter`, setting the `NumberFormat` property to what you want, for example, `CultureInfo.CurrentCulture.NumberFormat` and pass that in to the builders with the `WithYamlFormatter` method.

Full example, to use the current culture's number format,

```csharp
var serializer = new SerializerBuilder()
    .WithYamlFormatter(
        new YamlFormatter
        {
            NumberFormat = CultureInfo.CurrentCulture.NumberFormat
        }
    ).Build();
```