### PR TITLE
Implement DateOnly and TimeOnly converters.

### DIFF
--- a/YamlDotNet.Test/Serialization/DateOnlyConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/DateOnlyConverterTests.cs
@@ -1,0 +1,347 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Globalization;
+using FakeItEasy;
+using FluentAssertions;
+using Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.Converters;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace YamlDotNet.Test.Serialization
+{
+    /// <summary>
+    /// This represents the test entity for the <see cref="DateOnlyConverter"/> class.
+    /// </summary>
+    public class DateOnlyConverterTests
+    {
+        /// <summary>
+        /// Tests whether the Accepts() method should return expected result or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <param name="expected">Expected result.</param>
+        [Theory]
+        [InlineData(typeof(DateOnly), true)]
+        [InlineData(typeof(string), false)]
+        public void Given_Type_Accepts_ShouldReturn_Result(Type type, bool expected)
+        {
+            var converter = new DateOnlyConverter();
+
+            var result = converter.Accepts(type);
+
+            result.Should().Be(expected);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should throw <see cref="FormatException"/> or not.
+        /// </summary>
+        /// <param name="year">Year value.</param>
+        /// <param name="month">Month value.</param>
+        /// <param name="day">Day value.</param>
+        /// <remarks>The converter instance uses its default parameter of "d".</remarks>
+        [Theory]
+        [InlineData(2016, 12, 31)]
+        public void Given_Yaml_WithInvalidDateTimeFormat_WithDefaultParameter_ReadYaml_ShouldThrow_Exception(int year, int month, int day)
+        {
+            var yaml = $"{year}-{month:00}-{day:00}";
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(yaml));
+
+            var converter = new DateOnlyConverter();
+
+            Action action = () => { converter.ReadYaml(parser, typeof(DateOnly)); };
+
+            action.ShouldThrow<FormatException>();
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="year">Year value.</param>
+        /// <param name="month">Month value.</param>
+        /// <param name="day">Day value.</param>
+        /// <remarks>The converter instance uses its default parameter of "d".</remarks>
+        [Theory]
+        [InlineData(2016, 12, 31)]
+        public void Given_Yaml_WithValidDateTimeFormat_WithDefaultParameter_ReadYaml_ShouldReturn_Result(int year, int month, int day)
+        {
+            var yaml = $"{month:00}/{day:00}/{year}"; // This is the DateOnly format of "d"
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(yaml));
+
+            var converter = new DateOnlyConverter();
+
+            var result = converter.ReadYaml(parser, typeof(DateOnly));
+
+            result.Should().BeOfType<DateOnly>();
+            ((DateOnly)result).Year.Should().Be(year);
+            ((DateOnly)result).Month.Should().Be(month);
+            ((DateOnly)result).Day.Should().Be(day);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="year">Year value.</param>
+        /// <param name="month">Month value.</param>
+        /// <param name="day">Day value.</param>
+        /// <param name="format1">Designated date/time format 1.</param>
+        /// <param name="format2">Designated date/time format 2.</param>
+        [Theory]
+        [InlineData(2016, 12, 31, "yyyy-MM-dd", "yyyy/MM/dd")]
+        public void Given_Yaml_WithValidDateTimeFormat_ReadYaml_ShouldReturn_Result(int year, int month, int day, string format1, string format2)
+        {
+            var yaml = $"{year}-{month:00}-{day:00}";
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(yaml));
+
+            var converter = new DateOnlyConverter(formats: new[] { format1, format2 });
+
+            var result = converter.ReadYaml(parser, typeof(DateOnly));
+
+            result.Should().BeOfType<DateOnly>();
+            ((DateOnly)result).Year.Should().Be(year);
+            ((DateOnly)result).Month.Should().Be(month);
+            ((DateOnly)result).Day.Should().Be(day);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="year">Year value.</param>
+        /// <param name="month">Month value.</param>
+        /// <param name="day">Day value.</param>
+        /// <param name="format1">Designated date/time format 1.</param>
+        /// <param name="format2">Designated date/time format 2.</param>
+        [Theory]
+        [InlineData(2016, 12, 31, "yyyy-MM-dd", "yyyy/MM/dd")]
+        public void Given_Yaml_WithSpecificCultureAndValidDateTimeFormat_ReadYaml_ShouldReturn_Result(int year, int month, int day, string format1, string format2)
+        {
+            var yaml = $"{year}-{month:00}-{day:00}";
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(yaml));
+
+            var culture = new CultureInfo("ko-KR"); // Sample specific culture
+            var converter = new DateOnlyConverter(provider: culture, formats: new[] { format1, format2 });
+
+            var result = converter.ReadYaml(parser, typeof(DateOnly));
+
+            result.Should().BeOfType<DateOnly>();
+            ((DateOnly)result).Year.Should().Be(year);
+            ((DateOnly)result).Month.Should().Be(month);
+            ((DateOnly)result).Day.Should().Be(day);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="format">Date/Time format.</param>
+        /// <param name="value">Date/Time value.</param>
+        [Theory]
+        [InlineData("d", "01/11/2017")]
+        [InlineData("D", "Wednesday, 11 January 2017")]
+        [InlineData("f", "Wednesday, 11 January 2017 02:36")]
+        [InlineData("F", "Wednesday, 11 January 2017 02:36:16")]
+        [InlineData("g", "01/11/2017 02:36")]
+        [InlineData("G", "01/11/2017 02:36:16")]
+        [InlineData("M", "January 11")]
+        [InlineData("s", "2017-01-11T02:36:16")]
+        [InlineData("u", "2017-01-11 02:36:16Z")]
+        [InlineData("Y", "2017 January")]
+        public void Given_Yaml_WithDateTimeFormat_ReadYaml_ShouldReturn_Result(string format, string value)
+        {
+            var expected = DateOnly.ParseExact(value, format, CultureInfo.InvariantCulture);
+            var converter = new DateOnlyConverter(formats: new[] { "d", "D", "f", "F", "g", "G", "M", "s", "u", "Y" });
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(value));
+
+            var result = converter.ReadYaml(parser, typeof(DateOnly));
+
+            result.Should().Be(expected);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="format">Date/Time format.</param>
+        /// <param name="locale">Locale value.</param>
+        /// <param name="value">Date/Time value.</param>
+        [Theory]
+        [InlineData("d", "fr-FR", "13/01/2017")]
+        [InlineData("D", "fr-FR", "vendredi 13 janvier 2017")]
+        [InlineData("f", "fr-FR", "vendredi 13 janvier 2017 05:25")]
+        [InlineData("F", "fr-FR", "vendredi 13 janvier 2017 05:25:08")]
+        [InlineData("g", "fr-FR", "13/01/2017 05:25")]
+        [InlineData("G", "fr-FR", "13/01/2017 05:25:08")]
+        [InlineData("M", "fr-FR", "13 janvier")]
+        [InlineData("s", "fr-FR", "2017-01-13T05:25:08")]
+        [InlineData("u", "fr-FR", "2017-01-13 05:25:08Z")]
+        [InlineData("Y", "fr-FR", "janvier 2017")]
+        // [InlineData("d", "ko-KR", "2017-01-13")]
+        [InlineData("D", "ko-KR", "2017년 1월 13일 금요일")]
+        // [InlineData("f", "ko-KR", "2017년 1월 13일 금요일 오전 5:32")]
+        // [InlineData("F", "ko-KR", "2017년 1월 13일 금요일 오전 5:32:06")]
+        // [InlineData("g", "ko-KR", "2017-01-13 오전 5:32")]
+        // [InlineData("G", "ko-KR", "2017-01-13 오전 5:32:06")]
+        [InlineData("M", "ko-KR", "1월 13일")]
+        [InlineData("s", "ko-KR", "2017-01-13T05:32:06")]
+        [InlineData("u", "ko-KR", "2017-01-13 05:32:06Z")]
+        [InlineData("Y", "ko-KR", "2017년 1월")]
+        public void Given_Yaml_WithLocaleAndDateTimeFormat_ReadYaml_ShouldReturn_Result(string format, string locale, string value)
+        {
+            var culture = new CultureInfo(locale);
+
+            var expected = default(DateOnly);
+            try
+            {
+                expected = DateOnly.ParseExact(value, format, culture);
+            }
+            catch (Exception ex)
+            {
+                var message = string.Format("Failed to parse the test argument to DateOnly. The expected date/time format should look like this: '{0}'", DateTime.Now.ToString(format, culture));
+                throw new Exception(message, ex);
+            }
+
+            var converter = new DateOnlyConverter(provider: culture, formats: new[] { "d", "D", "f", "F", "g", "G", "M", "s", "u", "Y" });
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(value));
+
+            var result = converter.ReadYaml(parser, typeof(DateOnly));
+
+            result.Should().Be(expected);
+        }
+
+        /// <summary>
+        /// Tests whether the WriteYaml method should return expected result or not.
+        /// </summary>
+        /// <param name="year">Year value.</param>
+        /// <param name="month">Month value.</param>
+        /// <param name="day">Day value.</param>
+        /// <remarks>The converter instance uses its default parameter of "d".</remarks>
+        [Theory]
+        [InlineData(2016, 12, 31)]
+        public void Given_Values_WriteYaml_ShouldReturn_Result(int year, int month, int day)
+        {
+            var dateOnly = new DateOnly(year, month, day);
+            var formatted = dateOnly.ToString("d", CultureInfo.InvariantCulture);
+            var obj = new TestObject() { DateOnly = dateOnly };
+
+            var builder = new SerializerBuilder();
+            builder.WithNamingConvention(CamelCaseNamingConvention.Instance);
+            builder.WithTypeConverter(new DateOnlyConverter());
+
+            var serialiser = builder.Build();
+
+            var serialised = serialiser.Serialize(obj);
+
+            serialised.Should().ContainEquivalentOf($"dateonly: {formatted}");
+        }
+
+        /// <summary>
+        /// Tests whether the WriteYaml method should return expected result or not.
+        /// </summary>
+        /// <param name="year">Year value.</param>
+        /// <param name="month">Month value.</param>
+        /// <param name="day">Day value.</param>
+        /// <param name="locale">Locale value.</param>
+        /// <remarks>The converter instance uses its default parameter of "d".</remarks>
+        [Theory]
+        [InlineData(2016, 12, 31, "es-ES")]
+        [InlineData(2016, 12, 31, "ko-KR")]
+        public void Given_Values_WithLocale_WriteYaml_ShouldReturn_Result(int year, int month, int day, string locale)
+        {
+            var dateOnly = new DateOnly(year, month, day);
+            var culture = new CultureInfo(locale);
+            var formatted = dateOnly.ToString("d", culture);
+            var obj = new TestObject() { DateOnly = dateOnly };
+
+            var builder = new SerializerBuilder();
+            builder.WithNamingConvention(CamelCaseNamingConvention.Instance);
+            builder.WithTypeConverter(new DateOnlyConverter(provider: culture));
+
+            var serialiser = builder.Build();
+
+            var serialised = serialiser.Serialize(obj);
+
+            serialised.Should().ContainEquivalentOf($"dateonly: {formatted}");
+        }
+
+        /// <summary>
+        /// Tests whether the WriteYaml method should return expected result or not.
+        /// </summary>
+        /// <param name="year">Year value.</param>
+        /// <param name="month">Month value.</param>
+        /// <param name="day">Day value.</param>
+        /// <remarks>The converter instance uses its default parameter of "d".</remarks>
+        [Theory]
+        [InlineData(2016, 12, 31)]
+        public void Given_Values_WithFormats_WriteYaml_ShouldReturn_Result_WithFirstFormat(int year, int month, int day)
+        {
+            var dateOnly = new DateOnly(year, month, day);
+            var format = "yyyy-MM-dd";
+            var formatted = dateOnly.ToString(format, CultureInfo.InvariantCulture);
+            var obj = new TestObject() { DateOnly = dateOnly };
+
+            var builder = new SerializerBuilder();
+            builder.WithNamingConvention(CamelCaseNamingConvention.Instance);
+            builder.WithTypeConverter(new DateOnlyConverter(formats: new[] { format, "d" }));
+
+            var serialiser = builder.Build();
+
+            var serialised = serialiser.Serialize(obj);
+
+            serialised.Should().ContainEquivalentOf($"dateonly: {formatted}");
+        }
+
+        [Fact]
+        public void JsonCompatible_EncaseDateOnlyInDoubleQuotes()
+        {
+            var serializer = new SerializerBuilder().JsonCompatible().Build();
+            var testObject = new TestObject { DateOnly = new DateOnly(2023, 01, 14) };
+            var actual = serializer.Serialize(testObject);
+
+            actual.TrimNewLines().Should().ContainEquivalentOf("{\"DateOnly\": \"01/14/2023\"}");
+        }
+
+        /// <summary>
+        /// This represents the test object entity.
+        /// </summary>
+        private class TestObject
+        {
+            /// <summary>
+            /// Gets or sets the <see cref="System.DateOnly"/> value.
+            /// </summary>
+            public DateOnly DateOnly { get; set; }
+        }
+    }
+}
+#endif

--- a/YamlDotNet.Test/Serialization/TimeOnlyConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/TimeOnlyConverterTests.cs
@@ -1,0 +1,335 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Globalization;
+using FakeItEasy;
+using FluentAssertions;
+using Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.Converters;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace YamlDotNet.Test.Serialization
+{
+    /// <summary>
+    /// This represents the test entity for the <see cref="TimeOnlyConverter"/> class.
+    /// </summary>
+    public class TimeOnlyConverterTests
+    {
+        /// <summary>
+        /// Tests whether the Accepts() method should return expected result or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <param name="expected">Expected result.</param>
+        [Theory]
+        [InlineData(typeof(TimeOnly), true)]
+        [InlineData(typeof(string), false)]
+        public void Given_Type_Accepts_ShouldReturn_Result(Type type, bool expected)
+        {
+            var converter = new TimeOnlyConverter();
+
+            var result = converter.Accepts(type);
+
+            result.Should().Be(expected);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should throw <see cref="FormatException"/> or not.
+        /// </summary>
+        /// <param name="hour">Hour value.</param>
+        /// <param name="minute">Minute value.</param>
+        /// <param name="second">Second value.</param>
+        /// <remarks>The converter instance uses its default parameter of "T".</remarks>
+        [Theory]
+        [InlineData(6, 12, 31)]
+        public void Given_Yaml_WithInvalidDateTimeFormat_WithDefaultParameters_ReadYaml_ShouldThrow_Exception(int hour, int minute, int second)
+        {
+            var yaml = $"{hour:00}-{minute:00}-{second:00}";
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(yaml));
+
+            var converter = new TimeOnlyConverter();
+
+            Action action = () => { converter.ReadYaml(parser, typeof(TimeOnly)); };
+
+            action.ShouldThrow<FormatException>();
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="hour">Hour value.</param>
+        /// <param name="minute">Minute value.</param>
+        /// <param name="second">Second value.</param>
+        /// <remarks>The converter instance uses its default parameter of "T".</remarks>
+        [Theory]
+        [InlineData(6, 12, 31)]
+        public void Given_Yaml_WithValidDateTimeFormat_WithDefaultParameters_ReadYaml_ShouldReturn_Result(int hour, int minute, int second)
+        {
+            var yaml = $"{hour:00}:{minute:00}:{second:00}"; // This is the DateTime format of "T"
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(yaml));
+
+            var converter = new TimeOnlyConverter();
+
+            var result = converter.ReadYaml(parser, typeof(TimeOnly));
+
+            result.Should().BeOfType<TimeOnly>();
+            ((TimeOnly)result).Hour.Should().Be(hour);
+            ((TimeOnly)result).Minute.Should().Be(minute);
+            ((TimeOnly)result).Second.Should().Be(second);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="hour">Hour value.</param>
+        /// <param name="minute">Minute value.</param>
+        /// <param name="second">Second value.</param>
+        /// <param name="format1">Designated date/time format 1.</param>
+        /// <param name="format2">Designated date/time format 2.</param>
+        [Theory]
+        [InlineData(6, 12, 31, "HH-mm-ss", "HH:mm:ss")]
+        public void Given_Yaml_WithValidDateTimeFormat_ReadYaml_ShouldReturn_Result(int hour, int minute, int second, string format1, string format2)
+        {
+            var yaml = $"{hour:00}-{minute:00}-{second:00}";
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(yaml));
+
+            var converter = new TimeOnlyConverter(formats: new[] { format1, format2 });
+
+            var result = converter.ReadYaml(parser, typeof(TimeOnly));
+
+            result.Should().BeOfType<TimeOnly>();
+            ((TimeOnly)result).Hour.Should().Be(6);
+            ((TimeOnly)result).Minute.Should().Be(12);
+            ((TimeOnly)result).Second.Should().Be(31);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="hour">Hour value.</param>
+        /// <param name="minute">Minute value.</param>
+        /// <param name="second">Second value.</param>
+        /// <param name="format1">Designated date/time format 1.</param>
+        /// <param name="format2">Designated date/time format 2.</param>
+        [Theory]
+        [InlineData(6, 12, 31, "HH-mm-ss", "HH:mm:ss")]
+        public void Given_Yaml_WithSpecificCultureAndValidDateTimeFormat_ReadYaml_ShouldReturn_Result(int hour, int minute, int second, string format1, string format2)
+        {
+            var yaml = $"{hour:00}-{minute:00}-{second:00}";
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(yaml));
+
+            var culture = new CultureInfo("ko-KR"); // Sample specific culture
+            var converter = new TimeOnlyConverter(provider: culture, formats: new[] { format1, format2 });
+
+            var result = converter.ReadYaml(parser, typeof(TimeOnly));
+
+            result.Should().BeOfType<TimeOnly>();
+            ((TimeOnly)result).Hour.Should().Be(6);
+            ((TimeOnly)result).Minute.Should().Be(12);
+            ((TimeOnly)result).Second.Should().Be(31);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="format">Date/Time format.</param>
+        /// <param name="value">Date/Time value.</param>
+        [Theory]
+        [InlineData("g", "01/11/2017 02:36")]
+        [InlineData("G", "01/11/2017 02:36:16")]
+        [InlineData("s", "2017-01-11T02:36:16")]
+        [InlineData("t", "02:36")]
+        [InlineData("T", "02:36:16")]
+        [InlineData("u", "2017-01-11 02:36:16Z")]
+        public void Given_Yaml_WithTimeFormat_ReadYaml_ShouldReturn_Result(string format, string value)
+        {
+            var expected = TimeOnly.ParseExact(value, format, CultureInfo.InvariantCulture);
+            var converter = new TimeOnlyConverter(formats: new[] { "g", "G", "s", "t", "T", "u" });
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(value));
+
+            var result = converter.ReadYaml(parser, typeof(TimeOnly));
+
+            result.Should().Be(expected);
+        }
+
+        /// <summary>
+        /// Tests whether the ReadYaml() method should return expected result or not.
+        /// </summary>
+        /// <param name="format">Date/Time format.</param>
+        /// <param name="locale">Locale value.</param>
+        /// <param name="value">Date/Time value.</param>
+        [Theory]
+        [InlineData("g", "fr-FR", "13/01/2017 05:25")]
+        [InlineData("G", "fr-FR", "13/01/2017 05:25:08")]
+        [InlineData("s", "fr-FR", "2017-01-13T05:25:08")]
+        [InlineData("t", "fr-FR", "05:25")]
+        [InlineData("T", "fr-FR", "05:25:08")]
+        [InlineData("u", "fr-FR", "2017-01-13 05:25:08Z")]
+        // [InlineData("g", "ko-KR", "2017-01-13 오전 5:32")]
+        // [InlineData("G", "ko-KR", "2017-01-13 오전 5:32:06")]
+        [InlineData("s", "ko-KR", "2017-01-13T05:32:06")]
+        // [InlineData("t", "ko-KR", "오전 5:32")]
+        // [InlineData("T", "ko-KR", "오전 5:32:06")]
+        [InlineData("u", "ko-KR", "2017-01-13 05:32:06Z")]
+        public void Given_Yaml_WithLocaleAndTimeFormat_ReadYaml_ShouldReturn_Result(string format, string locale, string value)
+        {
+            var culture = new CultureInfo(locale);
+
+            var expected = default(TimeOnly);
+            try
+            {
+                expected = TimeOnly.ParseExact(value, format, culture);
+            }
+            catch (Exception ex)
+            {
+                var message = string.Format("Failed to parse the test argument to TimeOnly. The expected date/time format should look like this: '{0}'", DateTime.Now.ToString(format, culture));
+                throw new Exception(message, ex);
+            }
+
+            var converter = new TimeOnlyConverter(provider: culture, formats: new[] { "g", "G", "s", "t", "T", "u" });
+
+            var parser = A.Fake<IParser>();
+            A.CallTo(() => parser.Current).ReturnsLazily(() => new Scalar(value));
+
+            var result = converter.ReadYaml(parser, typeof(TimeOnly));
+
+            result.Should().Be(expected);
+        }
+
+        /// <summary>
+        /// Tests whether the WriteYaml method should return expected result or not.
+        /// </summary>
+        /// <param name="hour">Hour value.</param>
+        /// <param name="minute">Minute value.</param>
+        /// <param name="second">Second value.</param>
+        /// <remarks>The converter instance uses its default parameter of "T".</remarks>
+        [Theory]
+        [InlineData(6, 12, 31)]
+        public void Given_Values_WriteYaml_ShouldReturn_Result(int hour, int minute, int second)
+        {
+            var timeOnly = new TimeOnly(hour, minute, second);
+            var formatted = timeOnly.ToString("T", CultureInfo.InvariantCulture);
+            var obj = new TestObject() { TimeOnly = timeOnly };
+
+            var builder = new SerializerBuilder();
+            builder.WithNamingConvention(CamelCaseNamingConvention.Instance);
+            builder.WithTypeConverter(new TimeOnlyConverter());
+
+            var serialiser = builder.Build();
+
+            var serialised = serialiser.Serialize(obj);
+
+            serialised.Should().ContainEquivalentOf($"timeonly: {formatted}");
+        }
+
+        /// <summary>
+        /// Tests whether the WriteYaml method should return expected result or not.
+        /// </summary>
+        /// <param name="hour">Hour value.</param>
+        /// <param name="minute">Minute value.</param>
+        /// <param name="second">Second value.</param>
+        /// <param name="locale">Locale value.</param>
+        /// <remarks>The converter instance uses its default parameter of "T".</remarks>
+        [Theory]
+        [InlineData(6, 12, 31, "es-ES")]
+        [InlineData(6, 12, 31, "ko-KR")]
+        public void Given_Values_WithLocale_WriteYaml_ShouldReturn_Result(int hour, int minute, int second, string locale)
+        {
+            var timeOnly = new TimeOnly(hour, minute, second);
+            var culture = new CultureInfo(locale);
+            var formatted = timeOnly.ToString("T", culture);
+            var obj = new TestObject() { TimeOnly = timeOnly };
+
+            var builder = new SerializerBuilder();
+            builder.WithNamingConvention(CamelCaseNamingConvention.Instance);
+            builder.WithTypeConverter(new TimeOnlyConverter(provider: culture));
+
+            var serialiser = builder.Build();
+
+            var serialised = serialiser.Serialize(obj);
+
+            serialised.Should().ContainEquivalentOf($"timeonly: {formatted}");
+        }
+
+        /// <summary>
+        /// Tests whether the WriteYaml method should return expected result or not.
+        /// </summary>
+        /// <param name="hour">Hour value.</param>
+        /// <param name="minute">Minute value.</param>
+        /// <param name="second">Second value.</param>
+        /// <remarks>The converter instance uses its default parameter of "T".</remarks>
+        [Theory]
+        [InlineData(6, 12, 31)]
+        public void Given_Values_WithFormats_WriteYaml_ShouldReturn_Result_WithFirstFormat(int hour, int minute, int second)
+        {
+            var timeOnly = new TimeOnly(hour, minute, second);
+            var format = "HH:mm:ss";
+            var formatted = timeOnly.ToString(format, CultureInfo.InvariantCulture);
+            var obj = new TestObject() { TimeOnly = timeOnly };
+
+            var builder = new SerializerBuilder();
+            builder.WithNamingConvention(CamelCaseNamingConvention.Instance);
+            builder.WithTypeConverter(new TimeOnlyConverter(formats: new[] { format, "T" }));
+
+            var serialiser = builder.Build();
+
+            var serialised = serialiser.Serialize(obj);
+
+            serialised.Should().ContainEquivalentOf($"timeonly: {formatted}");
+        }
+
+        [Fact]
+        public void JsonCompatible_EncaseTimeOnlyInDoubleQuotes()
+        {
+            var serializer = new SerializerBuilder().JsonCompatible().Build();
+            var testObject = new TestObject { TimeOnly = new TimeOnly(6, 12, 31) };
+            var actual = serializer.Serialize(testObject);
+
+            actual.TrimNewLines().Should().ContainEquivalentOf("{\"TimeOnly\": \"06:12:31\"}");
+        }
+
+        /// <summary>
+        /// This represents the test object entity.
+        /// </summary>
+        private class TestObject
+        {
+            /// <summary>
+            /// Gets or sets the <see cref="System.TimeOnly"/> value.
+            /// </summary>
+            public TimeOnly TimeOnly { get; set; }
+        }
+    }
+}
+#endif

--- a/YamlDotNet/Serialization/Converters/DateOnlyConverter.cs
+++ b/YamlDotNet/Serialization/Converters/DateOnlyConverter.cs
@@ -1,0 +1,96 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Globalization;
+using System.Linq;
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace YamlDotNet.Serialization.Converters
+{
+    /// <summary>
+    /// This represents the YAML converter entity for <see cref="DateOnly"/>.
+    /// </summary>
+    public class DateOnlyConverter : IYamlTypeConverter
+    {
+        private readonly IFormatProvider provider;
+        private readonly bool doubleQuotes;
+        private readonly string[] formats;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateOnlyConverter"/> class.
+        /// </summary>
+        /// <param name="provider"><see cref="IFormatProvider"/> instance. Default value is <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <param name="doubleQuotes">If true, will use double quotes when writing the value to the stream.</param>
+        /// <param name="formats">List of date/time formats for parsing. Default value is "<c>d</c>".</param>
+        /// <remarks>On deserializing, all formats in the list are used for conversion, while on serializing, the first format in the list is used.</remarks>
+        public DateOnlyConverter(IFormatProvider? provider = null, bool doubleQuotes = false, params string[] formats)
+        {
+            this.provider = provider ?? CultureInfo.InvariantCulture;
+            this.doubleQuotes = doubleQuotes;
+            this.formats = formats.DefaultIfEmpty("d").ToArray();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current converter supports converting the specified type.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>Returns <c>True</c>, if the current converter supports; otherwise returns <c>False</c>.</returns>
+        public bool Accepts(Type type)
+        {
+            return type == typeof(DateOnly);
+        }
+
+        /// <summary>
+        /// Reads an object's state from a YAML parser.
+        /// </summary>
+        /// <param name="parser"><see cref="IParser"/> instance.</param>
+        /// <param name="type"><see cref="Type"/> to convert.</param>
+        /// <returns>Returns the <see cref="DateOnly"/> instance converted.</returns>
+        /// <remarks>On deserializing, all formats in the list are used for conversion.</remarks>
+        public object ReadYaml(IParser parser, Type type)
+        {
+            var value = parser.Consume<Scalar>().Value;
+
+            var dateOnly = DateOnly.ParseExact(value, this.formats, this.provider);
+            return dateOnly;
+        }
+
+        /// <summary>
+        /// Writes the specified object's state to a YAML emitter.
+        /// </summary>
+        /// <param name="emitter"><see cref="IEmitter"/> instance.</param>
+        /// <param name="value">Value to write.</param>
+        /// <param name="type"><see cref="Type"/> to convert.</param>
+        /// <remarks>On serializing, the first format in the list is used.</remarks>
+        public void WriteYaml(IEmitter emitter, object? value, Type type)
+        {
+            var dateOnly = (DateOnly)value!;
+            var formatted = dateOnly.ToString(this.formats.First(), this.provider); // Always take the first format of the list.
+
+            emitter.Emit(new Scalar(AnchorName.Empty, TagName.Empty, formatted, doubleQuotes ? ScalarStyle.DoubleQuoted : ScalarStyle.Any, true, false));
+        }
+    }
+}
+#endif

--- a/YamlDotNet/Serialization/Converters/TimeOnlyConverter.cs
+++ b/YamlDotNet/Serialization/Converters/TimeOnlyConverter.cs
@@ -1,0 +1,96 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Globalization;
+using System.Linq;
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace YamlDotNet.Serialization.Converters
+{
+    /// <summary>
+    /// This represents the YAML converter entity for <see cref="TimeOnly"/>.
+    /// </summary>
+    public class TimeOnlyConverter : IYamlTypeConverter
+    {
+        private readonly IFormatProvider provider;
+        private readonly bool doubleQuotes;
+        private readonly string[] formats;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeOnlyConverter"/> class.
+        /// </summary>
+        /// <param name="provider"><see cref="IFormatProvider"/> instance. Default value is <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <param name="doubleQuotes">If true, will use double quotes when writing the value to the stream.</param>
+        /// <param name="formats">List of date/time formats for parsing. Default value is "<c>T</c>".</param>
+        /// <remarks>On deserializing, all formats in the list are used for conversion, while on serializing, the first format in the list is used.</remarks>
+        public TimeOnlyConverter(IFormatProvider? provider = null, bool doubleQuotes = false, params string[] formats)
+        {
+            this.provider = provider ?? CultureInfo.InvariantCulture;
+            this.doubleQuotes = doubleQuotes;
+            this.formats = formats.DefaultIfEmpty("T").ToArray();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current converter supports converting the specified type.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>Returns <c>True</c>, if the current converter supports; otherwise returns <c>False</c>.</returns>
+        public bool Accepts(Type type)
+        {
+            return type == typeof(TimeOnly);
+        }
+
+        /// <summary>
+        /// Reads an object's state from a YAML parser.
+        /// </summary>
+        /// <param name="parser"><see cref="IParser"/> instance.</param>
+        /// <param name="type"><see cref="Type"/> to convert.</param>
+        /// <returns>Returns the <see cref="TimeOnly"/> instance converted.</returns>
+        /// <remarks>On deserializing, all formats in the list are used for conversion.</remarks>
+        public object ReadYaml(IParser parser, Type type)
+        {
+            var value = parser.Consume<Scalar>().Value;
+
+            var timeOnly = TimeOnly.ParseExact(value, this.formats, this.provider);
+            return timeOnly;
+        }
+
+        /// <summary>
+        /// Writes the specified object's state to a YAML emitter.
+        /// </summary>
+        /// <param name="emitter"><see cref="IEmitter"/> instance.</param>
+        /// <param name="value">Value to write.</param>
+        /// <param name="type"><see cref="Type"/> to convert.</param>
+        /// <remarks>On serializing, the first format in the list is used.</remarks>
+        public void WriteYaml(IEmitter emitter, object? value, Type type)
+        {
+            var timeOnly = (TimeOnly)value!;
+            var formatted = timeOnly.ToString(this.formats.First(), this.provider); // Always take the first format of the list.
+
+            emitter.Emit(new Scalar(AnchorName.Empty, TagName.Empty, formatted, doubleQuotes ? ScalarStyle.DoubleQuoted : ScalarStyle.Any, true, false));
+        }
+    }
+}
+#endif

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -335,6 +335,10 @@ namespace YamlDotNet.Serialization
             return this
                 .WithTypeConverter(new GuidConverter(true), w => w.InsteadOf<GuidConverter>())
                 .WithTypeConverter(new DateTimeConverter(doubleQuotes: true))
+#if NET6_0_OR_GREATER
+                .WithTypeConverter(new DateOnlyConverter(doubleQuotes: true))
+                .WithTypeConverter(new TimeOnlyConverter(doubleQuotes: true))
+#endif
                 .WithEventEmitter(inner => new JsonEventEmitter(inner, yamlFormatter), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
         }
 


### PR DESCRIPTION
Since .NET 6 there are two new types available for dates and times: [`DateOnly`](https://learn.microsoft.com/en-us/dotnet/api/system.dateonly) and [`TimeOnly`](https://learn.microsoft.com/en-us/dotnet/api/system.timeonly). These new converters supplement the existing `DateTimeConverter`.

The unit tests are based on `DateTimeConverterTests`. Some tests were removed because they used `DateTimeKind` and were identical to other tests after removing all irrelevant code. Some test cases using date/time formats were removed because they made no sense in that context, or because the formats are explicitly unsupported (i.e. throwing an exception) for `DateOnly` or `TimeOnly`.
The commented-out test cases fail, just like they do in `DateTimeConverterTests`. I'm not entirely sure why the various date/time format test cases exist, since they do not test additional code paths. But I've left them in for consistency.