### PR TITLE
Added support for serialization and deserialization of 'object' to static code generation

### DIFF
--- a/YamlDotNet.Analyzers.StaticGenerator/StaticPropertyDescriptorFile.cs
+++ b/YamlDotNet.Analyzers.StaticGenerator/StaticPropertyDescriptorFile.cs
@@ -34,6 +34,7 @@ namespace YamlDotNet.Analyzers.StaticGenerator
         {
             Write("class StaticPropertyDescriptor : YamlDotNet.Serialization.IPropertyDescriptor");
             Write("{"); Indent();
+            Write("private readonly YamlDotNet.Serialization.ITypeResolver _typeResolver;");
             Write("private YamlDotNet.Serialization.IObjectAccessor _accessor;");
             Write("private readonly Attribute[] _attributes;");
             Write("public string Name { get; }");
@@ -52,14 +53,17 @@ namespace YamlDotNet.Analyzers.StaticGenerator
             UnIndent(); Write("}");
             Write("public YamlDotNet.Serialization.IObjectDescriptor Read(object target)");
             Write("{"); Indent();
-            Write("return new YamlDotNet.Serialization.ObjectDescriptor(_accessor.Read(Name, target), Type, Type, this.ScalarStyle);");
+            Write("var propertyValue = _accessor.Read(Name, target);");
+            Write("var actualType = _typeResolver.Resolve(Type, propertyValue);");
+            Write("return new YamlDotNet.Serialization.ObjectDescriptor(propertyValue, actualType, Type, this.ScalarStyle);");
             UnIndent(); Write("}");
             Write("public void Write(object target, object value)");
             Write("{"); Indent();
             Write("_accessor.Set(Name, target, value);");
             UnIndent(); Write("}");
-            Write("public StaticPropertyDescriptor(YamlDotNet.Serialization.IObjectAccessor accessor, string name, bool canWrite, Type type, Attribute[] attributes)");
+            Write("public StaticPropertyDescriptor(YamlDotNet.Serialization.ITypeResolver typeResolver, YamlDotNet.Serialization.IObjectAccessor accessor, string name, bool canWrite, Type type, Attribute[] attributes)");
             Write("{"); Indent();
+            Write("this._typeResolver = typeResolver;");
             Write("this._accessor = accessor;");
             Write("this._attributes = attributes;");
             Write("this.Name = name;");

--- a/YamlDotNet.Analyzers.StaticGenerator/StaticTypeInspectorFile.cs
+++ b/YamlDotNet.Analyzers.StaticGenerator/StaticTypeInspectorFile.cs
@@ -38,6 +38,12 @@ namespace YamlDotNet.Analyzers.StaticGenerator
             Write("public class StaticTypeInspector : YamlDotNet.Serialization.ITypeInspector");
             Write("{"); Indent();
 
+            Write("private readonly YamlDotNet.Serialization.ITypeResolver _typeResolver;");
+            Write("public StaticTypeInspector(YamlDotNet.Serialization.ITypeResolver typeResolver)");
+            Write("{"); Indent();
+            Write("_typeResolver = typeResolver;");
+            UnIndent(); Write("}");
+
             #region GetProperties
             Write("public IEnumerable<YamlDotNet.Serialization.IPropertyDescriptor> GetProperties(Type type, object container)");
             Write("{"); Indent();
@@ -96,7 +102,7 @@ namespace YamlDotNet.Analyzers.StaticGenerator
 
         private void WritePropertyDescriptor(string name, ITypeSymbol type, bool isReadonly, ImmutableArray<AttributeData> attributes, char finalChar)
         {
-            Write($"new StaticPropertyDescriptor(accessor, \"{name}\", {(!isReadonly).ToString().ToLower()}, typeof({type.GetFullName().Replace("?", string.Empty)}), new Attribute[] {{");
+            Write($"new StaticPropertyDescriptor(_typeResolver, accessor, \"{name}\", {(!isReadonly).ToString().ToLower()}, typeof({type.GetFullName().Replace("?", string.Empty)}), new Attribute[] {{");
             foreach (var attribute in attributes)
             {
                 switch (attribute.AttributeClass?.ToDisplayString())

--- a/YamlDotNet.Analyzers.StaticGenerator/StaticTypeResolverFile.cs
+++ b/YamlDotNet.Analyzers.StaticGenerator/StaticTypeResolverFile.cs
@@ -1,0 +1,51 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace YamlDotNet.Analyzers.StaticGenerator
+{
+    public class StaticTypeResolverFile : File
+    {
+        public StaticTypeResolverFile(Action<string, bool> write, Action indent, Action unindent, GeneratorExecutionContext context) : base(write, indent, unindent, context)
+        {
+        }
+
+        public override void Write(ClassSyntaxReceiver classSyntaxReceiver)
+        {
+            Write($"class StaticTypeResolver : YamlDotNet.Serialization.TypeResolvers.StaticTypeResolver");
+            Write("{"); Indent();
+            Write("private readonly YamlDotNet.Serialization.StaticContext _context;");
+            Write($"public StaticTypeResolver(YamlDotNet.Serialization.StaticContext context)");
+            Write("{"); Indent();
+            Write("_context = context;");
+            UnIndent(); Write("}");
+            Write("public override Type Resolve(Type staticType, object actualValue)");
+            Write("{"); Indent();
+            Write("var result = base.Resolve(staticType, actualValue);");
+            Write("if (result == staticType && actualValue != null && _context.IsKnownType(actualValue.GetType())) result = actualValue.GetType();");
+            Write("return result;");
+            UnIndent(); Write("}");
+            UnIndent(); Write("}");
+        }
+    }
+}

--- a/YamlDotNet.Analyzers.StaticGenerator/TypeFactoryGenerator.cs
+++ b/YamlDotNet.Analyzers.StaticGenerator/TypeFactoryGenerator.cs
@@ -96,6 +96,7 @@ namespace YamlDotNet.Analyzers.StaticGenerator
 
                 new StaticContextFile(write, indent, unindent, _context).Write(classSyntaxReceiver);
                 new StaticObjectFactoryFile(write, indent, unindent, _context).Write(classSyntaxReceiver);
+                new StaticTypeResolverFile(write, indent, unindent, _context).Write(classSyntaxReceiver);
                 new StaticPropertyDescriptorFile(write, indent, unindent, _context).Write(classSyntaxReceiver);
                 new StaticTypeInspectorFile(write, indent, unindent, _context).Write(classSyntaxReceiver);
                 new ObjectAccessorFileGenerator(write, indent, unindent, _context).Write(classSyntaxReceiver);

--- a/YamlDotNet.Core7AoTCompileTest/Program.cs
+++ b/YamlDotNet.Core7AoTCompileTest/Program.cs
@@ -76,6 +76,10 @@ Inherited:
   NotInherited: world
 External:
   Text: hello
+SomeObject: a
+SomeDictionary:
+  a: 1
+  b: 2
 ");
 
 var input = new StringReader(yaml);
@@ -211,6 +215,8 @@ public class PrimitiveTypes
     public List<string>? MyList { get; set; }
     public Inherited Inherited { get; set; }
     public ExternalModel External { get; set; }
+    public object SomeObject { get; set; }
+    public object SomeDictionary { get; set; }
 }
 
 public class InheritedBase

--- a/YamlDotNet.Test/Analyzers/StaticGenerator/ObjectTests.cs
+++ b/YamlDotNet.Test/Analyzers/StaticGenerator/ObjectTests.cs
@@ -18,6 +18,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
+using System.Collections.Generic;
 using Xunit;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.Callbacks;
@@ -53,6 +55,15 @@ Inner:
   Prop2: 2
 Nested:
   NestedProp: abc
+DictionaryOfArrays:
+  a:
+  - 1
+  b:
+  - 2
+SomeValue: ""abc""
+SomeDictionary:
+  a: 1
+  b: 2
 ";
             var actual = deserializer.Deserialize<RegularObjectOuter>(yaml);
             Assert.Equal("hello", actual.Prop1);
@@ -64,6 +75,11 @@ Nested:
             Assert.Equal(2, actual.Inner.Prop2);
             Assert.NotNull(actual.Nested);
             Assert.Equal("abc", actual.Nested.NestedProp);
+            Assert.Equal("1", actual.DictionaryOfArrays["a"][0]);
+            Assert.Equal("2", actual.DictionaryOfArrays["b"][0]);
+            Assert.Equal("abc", actual.SomeValue);
+            Assert.Equal("1", ((IDictionary<object, object>)actual.SomeDictionary)["a"]);
+            Assert.Equal("2", ((IDictionary<object, object>)actual.SomeDictionary)["b"]);
 
             var serializer = new StaticSerializerBuilder(new StaticContext()).Build();
             var actualYaml = serializer.Serialize(actual);
@@ -76,7 +92,15 @@ Inner:
   Prop2: 2
 Nested:
   NestedProp: abc
-";
+DictionaryOfArrays:
+  a:
+  - 1
+  b:
+  - 2
+SomeValue: abc
+SomeDictionary:
+  a: 1
+  b: 2";
             Assert.Equal(yaml.NormalizeNewLines().TrimNewLines(), actualYaml.NormalizeNewLines().TrimNewLines());
         }
 
@@ -142,6 +166,12 @@ Nested:
         public string Ignored { get; set; } = "I am ignored";
         public RegularObjectInner Inner { get; set; }
         public NestedClass Nested { get; set; }
+
+        public Dictionary<string, string[]> DictionaryOfArrays { get; set; }
+
+        public object SomeValue { get; set; }
+
+        public object SomeDictionary { get; set; }
 
         [YamlSerializable]
         public class NestedClass

--- a/YamlDotNet.Test/Analyzers/StaticGenerator/RootCollectionTests.cs
+++ b/YamlDotNet.Test/Analyzers/StaticGenerator/RootCollectionTests.cs
@@ -54,6 +54,36 @@ namespace YamlDotNet.Test.Analyzers.StaticGenerator
             Assert.Equal("hello", actual[0].Test);
             Assert.Equal("world", actual[1].Test);
         }
+
+        [Fact]
+        public void RootDictionaryWorks()
+        {
+            var deserializer = new StaticDeserializerBuilder(new StaticContext()).Build();
+            var yaml = @"
+a:
+ Test: hello
+b:
+ Test: world
+";
+
+            var actual = deserializer.Deserialize<Dictionary<string, RootObject>>(yaml);
+            Assert.Equal("hello", actual["a"].Test);
+            Assert.Equal("world", actual["b"].Test);
+        }
+
+        [Fact]
+        public void RootObjectWorks()
+        {
+            var deserializer = new StaticDeserializerBuilder(new StaticContext()).Build();
+            var yaml = @"
+a: hello
+b: world
+";
+
+            var actual = (IDictionary<object, object>) deserializer.Deserialize<object>(yaml);
+            Assert.Equal("hello", actual["a"]);
+            Assert.Equal("world", actual["b"]);
+        }
     }
     [YamlSerializable]
     public class RootObject

--- a/YamlDotNet.Test/Analyzers/StaticGenerator/RootCollectionTests.cs
+++ b/YamlDotNet.Test/Analyzers/StaticGenerator/RootCollectionTests.cs
@@ -84,6 +84,22 @@ b: world
             Assert.Equal("hello", actual["a"]);
             Assert.Equal("world", actual["b"]);
         }
+
+        [Fact]
+        public void RootNestedObjectWorks()
+        {
+            var deserializer = new StaticDeserializerBuilder(new StaticContext()).Build();
+            var yaml = @"
+a:
+ Test: hello
+b:
+ Test: world
+";
+
+            var actual = (IDictionary<object, object>) deserializer.Deserialize<object>(yaml);
+            Assert.Equal("hello", ((IDictionary<object,object>)actual["a"])["Test"]);
+            Assert.Equal("world", ((IDictionary<object,object>)actual["b"])["Test"]);
+        }
     }
     [YamlSerializable]
     public class RootObject

--- a/YamlDotNet/Serialization/StaticContext.cs
+++ b/YamlDotNet/Serialization/StaticContext.cs
@@ -30,6 +30,25 @@ namespace YamlDotNet.Serialization
     public abstract class StaticContext
     {
         /// <summary>
+        /// Gets whether the type is known to the context
+        /// </summary>
+        /// <param name="type">Type to check</param>
+        /// <returns></returns>
+        public virtual bool IsKnownType(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ITypeResolver"/> to use for serialization
+        /// </summary>
+        /// <returns></returns>
+        public virtual ITypeResolver GetTypeResolver()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Gets the factory to use for serialization and deserialization
         /// </summary>
         /// <returns></returns>

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -61,7 +61,7 @@ namespace YamlDotNet.Serialization
         /// Initializes a new <see cref="DeserializerBuilder" /> using the default component registrations.
         /// </summary>
         public StaticDeserializerBuilder(StaticContext context)
-            : base(new StaticTypeResolver())
+            : base(context.GetTypeResolver())
         {
             this.context = context;
             factory = context.GetFactory();

--- a/YamlDotNet/Serialization/TypeResolvers/StaticTypeResolver.cs
+++ b/YamlDotNet/Serialization/TypeResolvers/StaticTypeResolver.cs
@@ -24,12 +24,34 @@ using System;
 namespace YamlDotNet.Serialization.TypeResolvers
 {
     /// <summary>
-    /// The type returned will always be the static type.
+    /// Except for primitive types, the type returned will always be the static type.
     /// </summary>
-    public sealed class StaticTypeResolver : ITypeResolver
+    public class StaticTypeResolver : ITypeResolver
     {
-        public Type Resolve(Type staticType, object? actualValue)
+        public virtual Type Resolve(Type staticType, object? actualValue)
         {
+            if (actualValue != null)
+            {
+                switch (actualValue.GetType().GetTypeCode())
+                {
+                    case TypeCode.Boolean: return typeof(bool);
+                    case TypeCode.Char: return typeof(char);
+                    case TypeCode.SByte: return typeof(sbyte);
+                    case TypeCode.Byte: return typeof(byte);
+                    case TypeCode.Int16: return typeof(short);
+                    case TypeCode.UInt16: return typeof(ushort);
+                    case TypeCode.Int32: return typeof(int);
+                    case TypeCode.UInt32: return typeof(uint);
+                    case TypeCode.Int64: return typeof(long);
+                    case TypeCode.UInt64: return typeof(ulong);
+                    case TypeCode.Single: return typeof(float);
+                    case TypeCode.Double: return typeof(double);
+                    case TypeCode.Decimal: return typeof(decimal);
+                    case TypeCode.String: return typeof(string);
+                    case TypeCode.DateTime: return typeof(DateTime);
+                }
+            }
+
             return staticType;
         }
     }


### PR DESCRIPTION
This PR adds support for serialization and deserialization of 'object' as long as the type is a primitive type or is known to the static context.

Changes:

* Added a `IsKnownType()` method to the `StaticContext` to determine whether a type is known to the context.
* Added code generation for a `StaticTypeResolver` which resolves types known the context.
* Modified code generation for `StaticTypeDescriptor` to use the `StaticTypeResolver` from the context.

@EdwardCooke What do you think ? If the approach is fine I will create an issue to reference this PR.

