### PR TITLE
Process inline comments with DictionaryDeserializer.

### DIFF
--- a/YamlDotNet.Samples/DeserializeWithComment.cs
+++ b/YamlDotNet.Samples/DeserializeWithComment.cs
@@ -1,0 +1,84 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.IO;
+using Xunit.Abstractions;
+using YamlDotNet.Samples.Helpers;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+
+namespace YamlDotNet.Samples
+{
+    public class DeserializeWithComment
+    {
+        private readonly ITestOutputHelper output;
+
+        public DeserializeWithComment(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Sample(
+            DisplayName = "Deserializing with comments",
+            Description = "Shows how to process comments"
+        )]
+        public void Main()
+        {
+            var deserializer = new DeserializerBuilder()
+                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                    .Build();
+            var serializer = new SerializerBuilder()
+                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                    .JsonCompatible()
+                    .Build();
+
+            var content = WithInlineCommentsAndList;
+
+            var parser = new Core.Parser(new Core.Scanner(new StringReader(content), false));
+            var yamlObject = deserializer.Deserialize<object>(parser);
+
+            var json = serializer.Serialize(yamlObject);
+
+            output.WriteLine(json);
+            Console.WriteLine(json);
+
+        }
+
+        private const string WithInlineCommentsAndList =
+@"# document starts with comment
+valuelist:
+   - string1  #{1st comment}
+   - string2
+# block comment
+   - string3  #{2nd comment}
+simplevalue: 12
+objectlist:
+  - att1: 12
+    att2: v1
+  - att1: 13
+    att2: v2
+  - att1: 14 #3rd comment
+    att2: v3    #4th comment
+";
+    }
+}

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1647,6 +1647,42 @@ y:
             Assert.Equal("The value", parsed.Value);
         }
 
+[Fact]
+        public void ChildrenWithInlineComments()
+        {
+            var input = @"# document starts with comment
+valuelist:
+   - string1  #{1st comment}
+   - string2
+# block comment
+   - string3  #{2nd comment}
+simplevalue: 12
+objectlist:
+  - att1: 12
+    att2: v1
+  - att1: 13
+    att2: v2
+  - att1: 14 #3rd comment
+    att2: v3    #4th comment
+";
+
+            var expected = @"{""valuelist"": [{""value"": ""string1"", ""comment"": ""{1st comment}""}, {""value"": ""string2"", ""comment"": """"}, {""value"": ""string3"", ""comment"": ""{2nd comment}""}], ""simplevalue"": {""value"": ""12"", ""comment"": """"}, ""objectlist"": [{""att1"": {""value"": ""12"", ""comment"": """"}, ""att2"": {""value"": ""v1"", ""comment"": """"}}, {""att1"": {""value"": ""13"", ""comment"": """"}, ""att2"": {""value"": ""v2"", ""comment"": """"}}, {""att1"": {""value"": ""14"", ""comment"": ""3rd comment""}, ""att2"": {""value"": ""v3"", ""comment"": ""4th comment""}}]}
+";
+
+            var deserializer = new DeserializerBuilder()
+                   .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                   .Build();
+            var serializer = new SerializerBuilder()
+                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                    .JsonCompatible()
+                    .Build();
+            var parser = new Parser(new Scanner(new StringReader(input), false));
+
+            var yamlObject = deserializer.Deserialize<object>(parser);
+            var actual = serializer.Serialize(yamlObject);
+
+            Assert.Equal(expected, actual);
+        }
         public class CommentWrapper<T> : IYamlConvertible
         {
             public string Comment { get; set; }

--- a/YamlDotNet/Basic/ValueWithComment.cs
+++ b/YamlDotNet/Basic/ValueWithComment.cs
@@ -19,45 +19,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using YamlDotNet.Core.Tokens;
-
-namespace YamlDotNet.Core
+namespace YamlDotNet.Basic
 {
-    /// <summary>
-    /// Defines the interface for a stand-alone YAML scanner that
-    /// converts a sequence of characters into a sequence of YAML tokens.
-    /// </summary>
-    public interface IScanner
+    public class ValueWithComment
     {
-        /// <summary>
-        /// Gets the current position inside the input stream.
-        /// </summary>
-        /// <value>The current position.</value>
-        Mark CurrentPosition { get; }
+        public ValueWithComment(object? value, string comment)
+        {
+            this.Value = value;
+            this.Comment = comment;
+        }
+        public object? Value { get; }
 
-        /// <summary>
-        /// Gets the current token.
-        /// </summary>
-        Token? Current { get; }
-
-        /// <summary>
-        /// Moves to the next token and consumes the current token.
-        /// </summary>
-        bool MoveNext();
-
-        /// <summary>
-        /// Moves to the next token without consuming the current token.
-        /// </summary>
-        bool MoveNextWithoutConsuming();
-
-        /// <summary>
-        /// Consumes the current token.
-        /// </summary>
-        void ConsumeCurrent();
-
-        /// <summary>
-        /// Gets the SkipComments setting.
-        /// </summary>
-        bool SkipComments { get; }
+        public string Comment { get; }
     }
 }

--- a/YamlDotNet/Core/IParser.cs
+++ b/YamlDotNet/Core/IParser.cs
@@ -39,5 +39,15 @@ namespace YamlDotNet.Core
         /// </summary>
         /// <returns>Returns true if there are more events available, otherwise returns false.</returns>
         bool MoveNext();
+
+        /// <summary>
+        /// Skips following comment events.
+        /// </summary>
+        void SkipFollowingComments();
+
+        /// <summary>
+        /// Gets the SkipComments value from its scanner.
+        /// </summary>
+        bool SkipComments { get; }
     }
 }

--- a/YamlDotNet/Core/MergingParser.cs
+++ b/YamlDotNet/Core/MergingParser.cs
@@ -47,6 +47,8 @@ namespace YamlDotNet.Core
 
         public ParsingEvent? Current => iterator.Current?.Value;
 
+        public bool SkipComments => innerParser.SkipComments;
+
         public bool MoveNext()
         {
             if (!merged)
@@ -58,6 +60,13 @@ namespace YamlDotNet.Core
             }
 
             return iterator.MoveNext();
+        }
+
+        public void SkipFollowingComments()
+        {
+            while (this.TryConsume<Comment>(out var _))
+            {
+            }
         }
 
         private void Merge()

--- a/YamlDotNet/Core/Parser.cs
+++ b/YamlDotNet/Core/Parser.cs
@@ -55,6 +55,7 @@ namespace YamlDotNet.Core
                     {
                         pendingEvents.Enqueue(new Events.Comment(commentToken.Value, commentToken.IsInline, commentToken.Start, commentToken.End));
                         scanner.ConsumeCurrent();
+                        currentToken = scanner.Current;
                     }
                     else
                     {
@@ -87,6 +88,8 @@ namespace YamlDotNet.Core
         /// </summary>
         public ParsingEvent? Current { get; private set; }
 
+        public bool SkipComments => scanner.SkipComments;
+
         private readonly EventQueue pendingEvents = new EventQueue();
 
         /// <summary>
@@ -109,6 +112,13 @@ namespace YamlDotNet.Core
 
             Current = pendingEvents.Dequeue();
             return true;
+        }
+
+        public void SkipFollowingComments()
+        {
+            while (this.TryConsume<Events.Comment>(out var _))
+            {
+            }
         }
 
         private ParsingEvent StateMachine()

--- a/YamlDotNet/Serialization/BufferedDeserialization/ParserBuffer.cs
+++ b/YamlDotNet/Serialization/BufferedDeserialization/ParserBuffer.cs
@@ -44,6 +44,7 @@ namespace YamlDotNet.Serialization.BufferedDeserialization
         /// <exception cref="ArgumentOutOfRangeException">If parser does not fit within the max depth and length specified.</exception>
         public ParserBuffer(IParser parserToBuffer, int maxDepth, int maxLength)
         {
+            SkipComments = parserToBuffer.SkipComments;
             buffer = new LinkedList<ParsingEvent>();
             buffer.AddLast(parserToBuffer.Consume<MappingStart>());
             var depth = 0;
@@ -71,6 +72,8 @@ namespace YamlDotNet.Serialization.BufferedDeserialization
         /// </summary>
         public ParsingEvent? Current => current?.Value;
 
+        public bool SkipComments { get; }
+
         /// <summary>
         /// Moves to the next event.
         /// </summary>
@@ -87,6 +90,13 @@ namespace YamlDotNet.Serialization.BufferedDeserialization
         public void Reset()
         {
             current = buffer.First;
+        }
+
+        public void SkipFollowingComments()
+        {
+            while (this.TryConsume<Comment>(out var _))
+            {
+            }
         }
     }
 }

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -97,7 +97,8 @@ namespace YamlDotNet.Serialization
                 { typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value, duplicateKeyChecking) },
                 { typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value) },
                 { typeof(EnumerableNodeDeserializer), _ => new EnumerableNodeDeserializer() },
-                { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(objectFactory.Value, BuildTypeInspector(), ignoreUnmatched, duplicateKeyChecking, typeConverter) }
+                { typeof(CommentNodeDeserializer), _ => new CommentNodeDeserializer() },
+                { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(objectFactory.Value, BuildTypeInspector(), ignoreUnmatched, duplicateKeyChecking, typeConverter) },
             };
 
             nodeTypeResolverFactories = new LazyComponentRegistrationList<Nothing, INodeTypeResolver>

--- a/YamlDotNet/Serialization/NodeDeserializers/CommentNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/CommentNodeDeserializer.cs
@@ -19,45 +19,27 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using YamlDotNet.Core.Tokens;
+using System;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 
-namespace YamlDotNet.Core
+namespace YamlDotNet.Serialization.NodeDeserializers
 {
-    /// <summary>
-    /// Defines the interface for a stand-alone YAML scanner that
-    /// converts a sequence of characters into a sequence of YAML tokens.
-    /// </summary>
-    public interface IScanner
+    internal class CommentNodeDeserializer : INodeDeserializer
     {
-        /// <summary>
-        /// Gets the current position inside the input stream.
-        /// </summary>
-        /// <value>The current position.</value>
-        Mark CurrentPosition { get; }
+        public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        {
+            value = null;
+            if (parser.Accept<Comment>(out var _))
+            {
+                if (parser.TryConsume<Comment>(out var comment))
+                {
+                    value = comment;
+                    return true;
+                }
+            }
 
-        /// <summary>
-        /// Gets the current token.
-        /// </summary>
-        Token? Current { get; }
-
-        /// <summary>
-        /// Moves to the next token and consumes the current token.
-        /// </summary>
-        bool MoveNext();
-
-        /// <summary>
-        /// Moves to the next token without consuming the current token.
-        /// </summary>
-        bool MoveNextWithoutConsuming();
-
-        /// <summary>
-        /// Consumes the current token.
-        /// </summary>
-        void ConsumeCurrent();
-
-        /// <summary>
-        /// Gets the SkipComments setting.
-        /// </summary>
-        bool SkipComments { get; }
+            return false;
+        }
     }
 }

--- a/YamlDotNet/Serialization/NodeDeserializers/DictionaryDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/DictionaryDeserializer.cs
@@ -21,6 +21,9 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Basic;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
@@ -46,71 +49,160 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 
         protected virtual void Deserialize(Type tKey, Type tValue, IParser parser, Func<IParser, Type, object?> nestedObjectDeserializer, IDictionary result)
         {
+            if (!parser.SkipComments)
+            {
+                DeserializeWithComments(tKey, tValue, parser, nestedObjectDeserializer, result);
+                return;
+            }
+
             var property = parser.Consume<MappingStart>();
             while (!parser.TryConsume<MappingEnd>(out var _))
             {
                 var key = nestedObjectDeserializer(parser, tKey);
                 var value = nestedObjectDeserializer(parser, tValue);
                 var valuePromise = value as IValuePromise;
+                AddKeyValue(result, property, key, value, valuePromise);
+            }
+        }
 
-                if (key is IValuePromise keyPromise)
+        private void AddKeyValue(IDictionary result, MappingStart property, object? key, object? value, IValuePromise? valuePromise)
+        {
+            if (key is IValuePromise keyPromise)
+            {
+                if (valuePromise == null)
                 {
-                    if (valuePromise == null)
-                    {
-                        // Key is pending, value is known
-                        keyPromise.ValueAvailable += v => result[v!] = value!;
-                    }
-                    else
-                    {
-                        // Both key and value are pending. We need to wait until both of them become available.
-                        var hasFirstPart = false;
-
-                        keyPromise.ValueAvailable += v =>
-                        {
-                            if (hasFirstPart)
-                            {
-                                TryAssign(result, v!, value!, property);
-                            }
-                            else
-                            {
-                                key = v!;
-                                hasFirstPart = true;
-                            }
-                        };
-
-                        valuePromise.ValueAvailable += v =>
-                        {
-                            if (hasFirstPart)
-                            {
-                                TryAssign(result, key, v!, property);
-                            }
-                            else
-                            {
-                                value = v;
-                                hasFirstPart = true;
-                            }
-                        };
-                    }
+                    // Key is pending, value is known
+                    keyPromise.ValueAvailable += v => result[v!] = value!;
                 }
                 else
                 {
-                    if (key == null)
-                    {
-                        throw new ArgumentException("Empty key names are not supported yet.", "key");
-                    }
+                    // Both key and value are pending. We need to wait until both of them become available.
+                    var hasFirstPart = false;
 
-                    if (valuePromise == null)
+                    keyPromise.ValueAvailable += v =>
                     {
-                        // Happy path: both key and value are known
-                        TryAssign(result, key, value!, property);
+                        if (hasFirstPart)
+                        {
+                            TryAssign(result, v!, value!, property);
+                        }
+                        else
+                        {
+                            key = v!;
+                            hasFirstPart = true;
+                        }
+                    };
+
+                    valuePromise.ValueAvailable += v =>
+                    {
+                        if (hasFirstPart)
+                        {
+                            TryAssign(result, key, v!, property);
+                        }
+                        else
+                        {
+                            value = v;
+                            hasFirstPart = true;
+                        }
+                    };
+                }
+            }
+            else
+            {
+                if (key == null)
+                {
+                    throw new ArgumentException("Empty key names are not supported yet.", "key");
+                }
+
+                if (valuePromise == null)
+                {
+                    // Happy path: both key and value are known
+                    TryAssign(result, key, value!, property);
+                }
+                else
+                {
+                    // Key is known, value is pending
+                    valuePromise.ValueAvailable += v => result[key!] = v!;
+                }
+            }
+        }
+
+        private void DeserializeWithComments(Type tKey, Type tValue, IParser parser, Func<IParser, Type, object?> nestedObjectDeserializer, IDictionary result)
+        {
+            parser.TryConsume<Comment>(out var fileStartComment);
+            var property = parser.Consume<MappingStart>();
+            while (!parser.TryConsume<MappingEnd>(out var _))
+            {
+                parser.SkipFollowingComments();
+                var key = nestedObjectDeserializer(parser, tKey);
+                parser.SkipFollowingComments();
+                var originalValue = nestedObjectDeserializer(parser, tValue);
+                var valueWithComment = ParseStringWithComment(parser, originalValue);
+                var listValueWithComment = ParseListWithComment(valueWithComment);
+                var valuePromise = listValueWithComment as IValuePromise;
+                AddKeyValue(result, property, key, listValueWithComment, valuePromise);
+            }
+        }
+
+        private static object? ParseListWithComment(object? value)
+        {
+            if (value is List<object> list)
+            {
+                var newValue = new List<ValueWithComment>();
+                var stringValue = string.Empty;
+                var comment = string.Empty;
+
+                foreach (var listItem in list)
+                {
+                    if (listItem is string)
+                    {
+                        if (!string.IsNullOrEmpty(stringValue))
+                        {
+                            newValue.Add(new ValueWithComment(stringValue, comment));
+                        }
+                        stringValue = (string)listItem;
+                        comment = string.Empty;
+                    }
+                    if (listItem is Comment && ((Comment)listItem).IsInline)
+                    {
+                        comment = ((Comment)listItem).Value;
+                    }
+                }
+                if (!string.IsNullOrEmpty(stringValue))
+                {
+                    newValue.Add(new ValueWithComment(stringValue, comment));
+                }
+                if (newValue.Any())
+                {
+                    if (newValue.Any(v => !string.IsNullOrEmpty(v.Comment)))
+                    {
+                        value = newValue;
                     }
                     else
                     {
-                        // Key is known, value is pending
-                        valuePromise.ValueAvailable += v => result[key!] = v!;
+                        value = newValue.Select(v => v.Value).ToList();
                     }
                 }
             }
+
+            return value;
+        }
+
+        private static object? ParseStringWithComment(IParser parser, object? value)
+        {
+            if (value is string)
+            {
+                var comment = string.Empty;
+                if (parser.TryConsume<Comment>(out var valueComment))
+                {
+                    if (value is string && valueComment.IsInline)
+                    {
+                        comment = valueComment.Value;
+                    }
+                    parser.SkipFollowingComments();
+                }
+                value = new ValueWithComment(value, comment);
+            }
+            return value;
         }
     }
 }

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -91,6 +91,7 @@ namespace YamlDotNet.Serialization
                 { typeof(StaticArrayNodeDeserializer), _ => new StaticArrayNodeDeserializer(factory) },
                 { typeof(StaticDictionaryNodeDeserializer), _ => new StaticDictionaryNodeDeserializer(factory, duplicateKeyChecking) },
                 { typeof(StaticCollectionNodeDeserializer), _ => new StaticCollectionNodeDeserializer(factory) },
+                { typeof(CommentNodeDeserializer), _ => new CommentNodeDeserializer() },
                 { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(factory, BuildTypeInspector(), ignoreUnmatched, duplicateKeyChecking, typeConverter) },
             };
 

--- a/YamlDotNet/Serialization/TypeInspectors/ReadableFieldsTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadableFieldsTypeInspector.cs
@@ -64,6 +64,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
             public int Order { get; set; }
             public bool CanWrite { get { return !fieldInfo.IsInitOnly; } }
             public ScalarStyle ScalarStyle { get; set; }
+            public string? Comment { get; set; }
 
             public void Write(object target, object? value)
             {

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -78,6 +78,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
             public int Order { get; set; }
             public bool CanWrite => propertyInfo.CanWrite;
             public ScalarStyle ScalarStyle { get; set; }
+            public string? Comment { get; set; }
 
             public void Write(object target, object? value)
             {

--- a/YamlDotNet/Serialization/TypeInspectors/WritablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/WritablePropertiesTypeInspector.cs
@@ -79,6 +79,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
             public int Order { get; set; }
             public bool CanWrite => propertyInfo.CanWrite;
             public ScalarStyle ScalarStyle { get; set; }
+            public string? Comment { get; set; }
 
             public void Write(object target, object? value)
             {


### PR DESCRIPTION
Dear Antoine, Edward,

We need to process some data from comments in yaml files. In these comments we usually got some descriptions about data types, ranges, available values.
So I've tried to use your solution to process the yaml files, and created a CommentNodeDeserializer to process all simple values into a ValueWithComment pair and then use it in the DictionaryDeserializer. I set this behavior only if the skipComments is set to false.
I hope you can accept my solution, as we really need this feature to process our input files.

Best regards,
and many thanks,
Eva.
