### PR TITLE
Handle TargetInvocationException when reading a property

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -478,6 +478,11 @@ namespace YamlDotNet.Test.Serialization
         public string Value { get; set; }
     }
 
+    public class ThrowingPropertyExample
+    {
+        public string Value => throw new InvalidOperationException();
+    }
+
     public class CustomGenericDictionary : IDictionary<string, string>
     {
         private readonly Dictionary<string, string> dictionary = new Dictionary<string, string>();

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1115,6 +1115,19 @@ y:
 
             serialized.Should().Contain("Value");
         }
+        
+        [Fact]
+        public void SerializationHandlesThrowingProperties()
+        {
+            var writer = new StringWriter();
+            var obj = new ThrowingPropertyExample();
+
+            Serializer.Serialize(writer, obj);
+            var serialized = writer.ToString();
+
+            serialized.Should()
+                .Be("Value: Exception of type System.InvalidOperationException was thrown\r\n".NormalizeNewLines());
+        }
 
         [Fact]
         public void SerializingAGenericDictionaryShouldNotThrowTargetException()

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1117,16 +1117,26 @@ y:
         }
         
         [Fact]
-        public void SerializationHandlesThrowingProperties()
+        public void SerializationHandlesTargetInvocationException()
         {
+            var serializer = new SerializerBuilder().WithTargetInvocationExceptionsHandling().Build();
             var writer = new StringWriter();
             var obj = new ThrowingPropertyExample();
 
-            Serializer.Serialize(writer, obj);
+            serializer.Serialize(writer, obj);
             var serialized = writer.ToString();
 
             serialized.Should()
                 .Be("Value: Exception of type System.InvalidOperationException was thrown\r\n".NormalizeNewLines());
+        }
+        
+        [Fact]
+        public void SerializationDoesntHandleTargetInvocationExceptionByDefault()
+        {
+            var writer = new StringWriter();
+            var obj = new ThrowingPropertyExample();
+
+            Assert.Throws<InvalidOperationException>(() => Serializer.Serialize(writer, obj));
         }
 
         [Fact]

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -62,6 +62,7 @@ namespace YamlDotNet.Serialization
         private ScalarStyle defaultScalarStyle = ScalarStyle.Any;
         private bool quoteNecessaryStrings;
         private bool quoteYaml1_1Strings;
+        private bool handleTargetInvocationExceptions;
 
         public SerializerBuilder()
             : base(new DynamicTypeResolver())
@@ -117,6 +118,15 @@ namespace YamlDotNet.Serialization
         {
             quoteNecessaryStrings = true;
             this.quoteYaml1_1Strings = quoteYaml1_1Strings;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables handling TargetInvocationExceptions thrown by a property so that information about exception is serialized as string value of the property. .
+        /// </summary>
+        public SerializerBuilder WithTargetInvocationExceptionsHandling()
+        {
+            handleTargetInvocationExceptions = true;
             return this;
         }
 
@@ -598,7 +608,7 @@ namespace YamlDotNet.Serialization
 
         internal ITypeInspector BuildTypeInspector()
         {
-            ITypeInspector innerInspector = new ReadablePropertiesTypeInspector(typeResolver, includeNonPublicProperties);
+            ITypeInspector innerInspector = new ReadablePropertiesTypeInspector(typeResolver, includeNonPublicProperties, handleTargetInvocationExceptions);
 
             if (!ignoreFields)
             {

--- a/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadablePropertiesTypeInspector.cs
@@ -92,7 +92,17 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
             public IObjectDescriptor Read(object target)
             {
-                var propertyValue = propertyInfo.ReadValue(target);
+                object? propertyValue;
+                try
+                {
+                    propertyValue = propertyInfo.ReadValue(target);
+                }
+                catch (TargetInvocationException e)
+                {
+                    return new ObjectDescriptor(
+                        $"Exception of type {e.InnerException!.GetType().FullName} was thrown",
+                        typeof(string), typeof(string), ScalarStyle.Any);
+                }
                 var actualType = TypeOverride ?? typeResolver.Resolve(Type, propertyValue);
                 return new ObjectDescriptor(propertyValue, actualType, Type, ScalarStyle);
             }


### PR DESCRIPTION
In my project I use YamlDotNet to serialize arbitrary objects. I can't mark properties of the objects with [YamlIgnore] but I want serializer not to fail in cases when an erroneous property is met. Could you add an ability to serialize such properties as YAML strings literals with a simple error message?