### PR TITLE
Ec net80 enumsasnumbers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
 RUN apt update && \
     apt install -y \
         apt-transport-https \
@@ -16,7 +16,7 @@ RUN apt install -y wget
 RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 RUN apt update
-RUN apt install -y dotnet-sdk-3.1 dotnet-sdk-6.0
+RUN apt install -y dotnet-sdk-6.0
 
 FROM builder AS build
 WORKDIR /src
@@ -30,6 +30,8 @@ COPY YamlDotNet.Samples/YamlDotNet.Samples.csproj YamlDotNet.Samples/YamlDotNet.
 COPY YamlDotNet.Test/YamlDotNet.Test.csproj YamlDotNet.Test/YamlDotNet.Test.csproj
 COPY YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.csproj YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.csproj
 COPY YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
+COPY YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj
+COPY YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.fsproj YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.fsproj
 
 RUN dotnet restore YamlDotNet.sln
 
@@ -43,12 +45,13 @@ RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csp
 RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
 RUN dotnet build -c Release --framework net60 YamlDotNet/YamlDotNet.csproj -o /output/net60
 RUN dotnet build -c Release --framework net70 YamlDotNet/YamlDotNet.csproj -o /output/net70
+RUN dotnet build -c Release --framework net80 YamlDotNet/YamlDotNet.csproj -o /output/net80
 
 RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
 
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net80 --logger:"trx;LogFileName=/output/tests.net80.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests.netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
 
 FROM alpine
 VOLUME /output

--- a/Dockerfile.NonEnglish
+++ b/Dockerfile.NonEnglish
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
 RUN apt update && \
     apt install -y \
         apt-transport-https \
@@ -17,7 +17,7 @@ RUN apt install -y wget
 RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 RUN apt update
-RUN apt install -y dotnet-sdk-3.1 dotnet-sdk-6.0
+RUN apt install -y dotnet-sdk-6.0
 
 
 FROM builder AS build
@@ -32,6 +32,8 @@ COPY YamlDotNet.Samples/YamlDotNet.Samples.csproj YamlDotNet.Samples/YamlDotNet.
 COPY YamlDotNet.Test/YamlDotNet.Test.csproj YamlDotNet.Test/YamlDotNet.Test.csproj
 COPY YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.csproj YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.csproj
 COPY YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
+COPY YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj
+COPY YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.csproj YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.csproj
 
 RUN dotnet restore YamlDotNet.sln
 
@@ -45,6 +47,7 @@ RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csp
 RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
 RUN dotnet build -c Release --framework net60 YamlDotNet/YamlDotNet.csproj -o /output/net60
 RUN dotnet build -c Release --framework net70 YamlDotNet/YamlDotNet.csproj -o /output/net70
+RUN dotnet build -c Release --framework net80 YamlDotNet/YamlDotNet.csproj -o /output/net80
 
 RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
 
@@ -62,6 +65,7 @@ RUN echo -n "${LC_ALL}" > /etc/locale.gen && \
     apt install -y locales && \
     locale-gen
 
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net80 --logger:"trx;LogFileName=/output/tests.net80.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests.netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"

--- a/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
+++ b/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net80</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/YamlDotNet.Samples/YamlDotNet.Samples.csproj
+++ b/YamlDotNet.Samples/YamlDotNet.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net80</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/YamlDotNet.Test/Analyzers/StaticGenerator/ObjectTests.cs
+++ b/YamlDotNet.Test/Analyzers/StaticGenerator/ObjectTests.cs
@@ -21,8 +21,10 @@
 
 using System.Collections.Generic;
 using Xunit;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.Callbacks;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace YamlDotNet.Test.Analyzers.StaticGenerator
 {
@@ -118,6 +120,25 @@ SomeDictionary:
             yaml = serializer.Serialize(test);
             Assert.Equal(1, test.OnSerializedCallCount);
             Assert.Equal(1, test.OnSerializingCallCount);
+        }
+
+        [Fact]
+        public void NamingConventionAppliedToEnum()
+        {
+            var serializer = new StaticSerializerBuilder(new StaticContext()).WithEnumNamingConvention(CamelCaseNamingConvention.Instance).Build();
+            ScalarStyle style = ScalarStyle.Plain;
+            var serialized = serializer.Serialize(style);
+            Assert.Equal("plain", serialized.TrimNewLines());
+        }
+
+        [Fact]
+        public void NamingConventionAppliedToEnumWhenDeserializing()
+        {
+            var serializer = new StaticDeserializerBuilder(new StaticContext()).WithEnumNamingConvention(UnderscoredNamingConvention.Instance).Build();
+            var yaml = "Double_Quoted";
+            ScalarStyle expected = ScalarStyle.DoubleQuoted;
+            var actual = serializer.Deserialize<ScalarStyle>(yaml);
+            Assert.Equal(expected, actual);
         }
 
         [YamlSerializable]

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -33,6 +33,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using FakeItEasy;
 using FluentAssertions;
+using FluentAssertions.Common;
 using Xunit;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
@@ -2412,7 +2413,7 @@ Null: true
         {
             var serializer = new SerializerBuilder().WithYamlFormatter(new YamlFormatter
             {
-                FormatEnum = (o) => ((int)o).ToString(),
+                FormatEnum = (o, namingConvention) => ((int)o).ToString(),
                 PotentiallyQuoteEnums = (_) => false
             }).Build();
             var deserializer = DeserializerBuilder.Build();
@@ -2435,6 +2436,24 @@ Null: true
             Test2 = 2
         }
 
+        [Fact]
+        public void NamingConventionAppliedToEnum()
+        {
+            var serializer = new SerializerBuilder().WithEnumNamingConvention(CamelCaseNamingConvention.Instance).Build();
+            ScalarStyle style = ScalarStyle.Plain;
+            var serialized = serializer.Serialize(style);
+            Assert.Equal("plain", serialized.RemoveNewLines());
+        }
+
+        [Fact]
+        public void NamingConventionAppliedToEnumWhenDeserializing()
+        {
+            var serializer = new DeserializerBuilder().WithEnumNamingConvention(UnderscoredNamingConvention.Instance).Build();
+            var yaml = "Double_Quoted";
+            ScalarStyle expected = ScalarStyle.DoubleQuoted;
+            var actual = serializer.Deserialize<ScalarStyle>(yaml);
+            Assert.Equal(expected, actual);
+        }
 
         public class TestState
         {

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -2407,6 +2407,35 @@ Null: true
             Assert.Equal(1, test.OnSerializingCallCount);
         }
 
+        [Fact]
+        public void SerializeEnumAsNumber()
+        {
+            var serializer = new SerializerBuilder().WithYamlFormatter(new YamlFormatter
+            {
+                FormatEnum = (o) => ((int)o).ToString(),
+                PotentiallyQuoteEnums = (_) => false
+            }).Build();
+            var deserializer = DeserializerBuilder.Build();
+
+            var value = serializer.Serialize(TestEnumAsNumber.Test1);
+            Assert.Equal("1", value.TrimNewLines());
+            var v = deserializer.Deserialize<TestEnumAsNumber>(value);
+            Assert.Equal(TestEnumAsNumber.Test1, v);
+
+            value = serializer.Serialize(TestEnumAsNumber.Test1 | TestEnumAsNumber.Test2);
+            Assert.Equal("3", value.TrimNewLines());
+            v = deserializer.Deserialize<TestEnumAsNumber>(value);
+            Assert.Equal(TestEnumAsNumber.Test1 | TestEnumAsNumber.Test2, v);
+        }
+
+        [Flags]
+        private enum TestEnumAsNumber
+        {
+            Test1 = 1,
+            Test2 = 2
+        }
+
+
         public class TestState
         {
             public int OnSerializedCallCount { get; set; }

--- a/YamlDotNet.Test/Serialization/TypeConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/TypeConverterTests.cs
@@ -20,6 +20,7 @@
 // SOFTWARE.
 
 using Xunit;
+using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Serialization.Utilities;
 
 namespace YamlDotNet.Test.Serialization
@@ -60,7 +61,7 @@ namespace YamlDotNet.Test.Serialization
         public void Implicit_conversion_operator_is_used()
         {
             var data = new ImplicitConversionIntWrapper(2);
-            var actual = TypeConverter.ChangeType<int>(data);
+            var actual = TypeConverter.ChangeType<int>(data, NullNamingConvention.Instance);
             Assert.Equal(data.value, actual);
         }
 
@@ -68,7 +69,7 @@ namespace YamlDotNet.Test.Serialization
         public void Explicit_conversion_operator_is_used()
         {
             var data = new ExplicitConversionIntWrapper(2);
-            var actual = TypeConverter.ChangeType<int>(data);
+            var actual = TypeConverter.ChangeType<int>(data, NullNamingConvention.Instance);
             Assert.Equal(data.value, actual);
         }
     }

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net70;net60;net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net80;net70;net60;net47</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>..\YamlDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/YamlDotNet/Serialization/BufferedDeserialization/TypeDiscriminatingNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/BufferedDeserialization/TypeDiscriminatingNodeDeserializer.cs
@@ -1,4 +1,4 @@
-// This file is part of YamlDotNet - A .NET library for YAML.
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
 // Copyright (c) Antoine Aubry and contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -35,6 +35,7 @@ namespace YamlDotNet.Serialization
         where TBuilder : BuilderSkeleton<TBuilder>
     {
         internal INamingConvention namingConvention = NullNamingConvention.Instance;
+        internal INamingConvention enumNamingConvention = NullNamingConvention.Instance;
         internal ITypeResolver typeResolver;
         internal readonly YamlAttributeOverrides overrides;
         internal readonly LazyComponentRegistrationList<Nothing, IYamlTypeConverter> typeConverterFactories;
@@ -95,6 +96,17 @@ namespace YamlDotNet.Serialization
         public TBuilder WithNamingConvention(INamingConvention namingConvention)
         {
             this.namingConvention = namingConvention ?? throw new ArgumentNullException(nameof(namingConvention));
+            return Self;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="INamingConvention"/> to use when handling enum's.
+        /// </summary>
+        /// <param name="enumNamingConvention">Naming convention to use when handling enum's</param>
+        /// <returns></returns>
+        public TBuilder WithEnumNamingConvention(INamingConvention enumNamingConvention)
+        {
+            this.enumNamingConvention = enumNamingConvention;
             return Self;
         }
 

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -92,12 +92,19 @@ namespace YamlDotNet.Serialization
                 { typeof(YamlSerializableNodeDeserializer), _ => new YamlSerializableNodeDeserializer(objectFactory.Value) },
                 { typeof(TypeConverterNodeDeserializer), _ => new TypeConverterNodeDeserializer(BuildTypeConverters()) },
                 { typeof(NullNodeDeserializer), _ => new NullNodeDeserializer() },
-                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization, typeConverter, yamlFormatter) },
-                { typeof(ArrayNodeDeserializer), _ => new ArrayNodeDeserializer() },
+                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization, typeConverter, yamlFormatter, enumNamingConvention) },
+                { typeof(ArrayNodeDeserializer), _ => new ArrayNodeDeserializer(enumNamingConvention) },
                 { typeof(DictionaryNodeDeserializer), _ => new DictionaryNodeDeserializer(objectFactory.Value, duplicateKeyChecking) },
-                { typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value) },
+                { typeof(CollectionNodeDeserializer), _ => new CollectionNodeDeserializer(objectFactory.Value, enumNamingConvention) },
                 { typeof(EnumerableNodeDeserializer), _ => new EnumerableNodeDeserializer() },
-                { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(objectFactory.Value, BuildTypeInspector(), ignoreUnmatched, duplicateKeyChecking, typeConverter) }
+                {
+                    typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(objectFactory.Value,
+                        BuildTypeInspector(),
+                        ignoreUnmatched,
+                        duplicateKeyChecking,
+                        typeConverter,
+                        enumNamingConvention)
+                }
             };
 
             nodeTypeResolverFactories = new LazyComponentRegistrationList<Nothing, INodeTypeResolver>
@@ -454,7 +461,8 @@ namespace YamlDotNet.Serialization
                 new NodeValueDeserializer(
                     nodeDeserializerFactories.BuildComponentList(),
                     nodeTypeResolverFactories.BuildComponentList(),
-                    typeConverter
+                    typeConverter,
+                    enumNamingConvention
                 )
             );
         }

--- a/YamlDotNet/Serialization/EventEmitters/JsonEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/JsonEventEmitter.cs
@@ -22,22 +22,20 @@
 using System;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace YamlDotNet.Serialization.EventEmitters
 {
     public sealed class JsonEventEmitter : ChainedEventEmitter
     {
         private readonly YamlFormatter formatter;
+        private readonly INamingConvention enumNamingConvention;
 
-        public JsonEventEmitter(IEventEmitter nextEmitter, YamlFormatter formatter)
+        public JsonEventEmitter(IEventEmitter nextEmitter, YamlFormatter formatter, INamingConvention enumNamingConvention)
             : base(nextEmitter)
         {
             this.formatter = formatter;
-        }
-
-        public JsonEventEmitter(IEventEmitter nextEmitter)
-            : this(nextEmitter, YamlFormatter.Default)
-        {
+            this.enumNamingConvention = enumNamingConvention;
         }
 
         public override void Emit(AliasEventInfo eventInfo, IEmitter emitter)
@@ -75,7 +73,7 @@ namespace YamlDotNet.Serialization.EventEmitters
                         var valueIsEnum = eventInfo.Source.Type.IsEnum();
                         if (valueIsEnum)
                         {
-                            eventInfo.RenderedValue = formatter.FormatEnum(value);
+                            eventInfo.RenderedValue = formatter.FormatEnum(value, enumNamingConvention);
                             eventInfo.Style = formatter.PotentiallyQuoteEnums(value) ? ScalarStyle.DoubleQuoted : ScalarStyle.Plain;
                             break;
                         }

--- a/YamlDotNet/Serialization/EventEmitters/JsonEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/JsonEventEmitter.cs
@@ -75,8 +75,8 @@ namespace YamlDotNet.Serialization.EventEmitters
                         var valueIsEnum = eventInfo.Source.Type.IsEnum();
                         if (valueIsEnum)
                         {
-                            eventInfo.RenderedValue = value.ToString()!;
-                            eventInfo.Style = ScalarStyle.DoubleQuoted;
+                            eventInfo.RenderedValue = formatter.FormatEnum(value);
+                            eventInfo.Style = formatter.PotentiallyQuoteEnums(value) ? ScalarStyle.DoubleQuoted : ScalarStyle.Plain;
                             break;
                         }
 

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -148,9 +148,11 @@ namespace YamlDotNet.Serialization.EventEmitters
                         if (eventInfo.Source.Type.IsEnum)
                         {
                             eventInfo.Tag = FailsafeSchema.Tags.Str;
-                            eventInfo.RenderedValue = value.ToString()!;
+                            eventInfo.RenderedValue = formatter.FormatEnum(value);
 
-                            if (quoteNecessaryStrings && IsSpecialStringValue(eventInfo.RenderedValue))
+                            if (quoteNecessaryStrings &&
+                                IsSpecialStringValue(eventInfo.RenderedValue) &&
+                                formatter.PotentiallyQuoteEnums(value))
                             {
                                 suggestedStyle = ScalarStyle.DoubleQuoted;
                             }

--- a/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/TypeAssigningEventEmitter.cs
@@ -26,6 +26,7 @@ using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization.Schemas;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace YamlDotNet.Serialization.EventEmitters
 {
@@ -69,8 +70,16 @@ namespace YamlDotNet.Serialization.EventEmitters
 
         private readonly ScalarStyle defaultScalarStyle = ScalarStyle.Any;
         private readonly YamlFormatter formatter;
+        private readonly INamingConvention enumNamingConvention;
 
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings, ScalarStyle defaultScalarStyle, YamlFormatter formatter)
+        public TypeAssigningEventEmitter(IEventEmitter nextEmitter,
+            bool requireTagWhenStaticAndActualTypesAreDifferent,
+            IDictionary<Type, TagName> tagMappings,
+            bool quoteNecessaryStrings,
+            bool quoteYaml1_1Strings,
+            ScalarStyle defaultScalarStyle,
+            YamlFormatter formatter,
+            INamingConvention enumNamingConvention)
             : base(nextEmitter)
         {
             this.defaultScalarStyle = defaultScalarStyle;
@@ -86,34 +95,7 @@ namespace YamlDotNet.Serialization.EventEmitters
 #else
             isSpecialStringValue_Regex = new Regex(specialStringValuePattern, RegexOptions.Compiled);
 #endif
-        }
-
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings, ScalarStyle defaultScalarStyle)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle, YamlFormatter.Default)
-        {
-        }
-
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, ScalarStyle defaultScalarStyle)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, quoteNecessaryStrings, false, defaultScalarStyle, YamlFormatter.Default)
-        {
-        }
-
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings, bool quoteYaml1_1Strings)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, ScalarStyle.Any)
-        {
-        }
-
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings, bool quoteNecessaryStrings)
-            : this(nextEmitter, requireTagWhenStaticAndActualTypesAreDifferent, tagMappings, quoteNecessaryStrings, false)
-        {
-        }
-
-        public TypeAssigningEventEmitter(IEventEmitter nextEmitter, bool requireTagWhenStaticAndActualTypesAreDifferent, IDictionary<Type, TagName> tagMappings)
-            : base(nextEmitter)
-        {
-            this.requireTagWhenStaticAndActualTypesAreDifferent = requireTagWhenStaticAndActualTypesAreDifferent;
-            this.tagMappings = tagMappings ?? throw new ArgumentNullException(nameof(tagMappings));
-            formatter = YamlFormatter.Default;
+            this.enumNamingConvention = enumNamingConvention;
         }
 
         public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)
@@ -148,7 +130,7 @@ namespace YamlDotNet.Serialization.EventEmitters
                         if (eventInfo.Source.Type.IsEnum)
                         {
                             eventInfo.Tag = FailsafeSchema.Tags.Str;
-                            eventInfo.RenderedValue = formatter.FormatEnum(value);
+                            eventInfo.RenderedValue = formatter.FormatEnum(value, enumNamingConvention);
 
                             if (quoteNecessaryStrings &&
                                 IsSpecialStringValue(eventInfo.RenderedValue) &&

--- a/YamlDotNet/Serialization/INamingConvention.cs
+++ b/YamlDotNet/Serialization/INamingConvention.cs
@@ -28,5 +28,6 @@ namespace YamlDotNet.Serialization
     public interface INamingConvention
     {
         string Apply(string value);
+        string Reverse(string value);
     }
 }

--- a/YamlDotNet/Serialization/NamingConventions/CamelCaseNamingConvention.cs
+++ b/YamlDotNet/Serialization/NamingConventions/CamelCaseNamingConvention.cs
@@ -39,6 +39,12 @@ namespace YamlDotNet.Serialization.NamingConventions
             return value.ToCamelCase();
         }
 
+        public string Reverse(string value)
+        {
+            var result = value.ToPascalCase();
+            return result;
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
         public static readonly INamingConvention Instance = new CamelCaseNamingConvention();
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/YamlDotNet/Serialization/NamingConventions/HyphenatedNamingConvention.cs
+++ b/YamlDotNet/Serialization/NamingConventions/HyphenatedNamingConvention.cs
@@ -37,6 +37,12 @@ namespace YamlDotNet.Serialization.NamingConventions
             return value.FromCamelCase("-");
         }
 
+        public string Reverse(string value)
+        {
+            var result = value.ToPascalCase();
+            return result;
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
         public static readonly INamingConvention Instance = new HyphenatedNamingConvention();
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/YamlDotNet/Serialization/NamingConventions/LowerCaseNamingConvention.cs
+++ b/YamlDotNet/Serialization/NamingConventions/LowerCaseNamingConvention.cs
@@ -36,6 +36,19 @@ namespace YamlDotNet.Serialization.NamingConventions
             return value.ToCamelCase().ToLower();
         }
 
+        public string Reverse(string value)
+        {
+            // lower case values don't have any context as to what should be upper or not. So we only do the first character
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            var result = char.ToUpperInvariant(value[0]) + value.Substring(1);
+            return result;
+
+        }
+
         public static readonly INamingConvention Instance = new LowerCaseNamingConvention();
     }
 }

--- a/YamlDotNet/Serialization/NamingConventions/NullNamingConvention.cs
+++ b/YamlDotNet/Serialization/NamingConventions/NullNamingConvention.cs
@@ -21,6 +21,7 @@
 
 
 using System;
+using YamlDotNet.Serialization.Utilities;
 
 namespace YamlDotNet.Serialization.NamingConventions
 {
@@ -33,6 +34,11 @@ namespace YamlDotNet.Serialization.NamingConventions
         public NullNamingConvention() { }
 
         public string Apply(string value)
+        {
+            return value;
+        }
+
+        public string Reverse(string value)
         {
             return value;
         }

--- a/YamlDotNet/Serialization/NamingConventions/PascalCaseNamingConvention.cs
+++ b/YamlDotNet/Serialization/NamingConventions/PascalCaseNamingConvention.cs
@@ -39,6 +39,12 @@ namespace YamlDotNet.Serialization.NamingConventions
             return value.ToPascalCase();
         }
 
+        public string Reverse(string value)
+        {
+            var result = value.ToPascalCase();
+            return result;
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
         public static readonly INamingConvention Instance = new PascalCaseNamingConvention();
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/YamlDotNet/Serialization/NamingConventions/UnderscoredNamingConvention.cs
+++ b/YamlDotNet/Serialization/NamingConventions/UnderscoredNamingConvention.cs
@@ -37,6 +37,12 @@ namespace YamlDotNet.Serialization.NamingConventions
             return value.FromCamelCase("_");
         }
 
+        public string Reverse(string value)
+        {
+            var result = value.ToPascalCase();
+            return result;
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
         public static readonly INamingConvention Instance = new UnderscoredNamingConvention();
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/YamlDotNet/Serialization/NodeDeserializers/ArrayNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ArrayNodeDeserializer.cs
@@ -28,6 +28,13 @@ namespace YamlDotNet.Serialization.NodeDeserializers
 {
     public sealed class ArrayNodeDeserializer : INodeDeserializer
     {
+        private readonly INamingConvention enumNamingConvention;
+
+        public ArrayNodeDeserializer(INamingConvention enumNamingConvention)
+        {
+            this.enumNamingConvention = enumNamingConvention;
+        }
+
         public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
         {
             if (!expectedType.IsArray)
@@ -39,7 +46,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             var itemType = expectedType.GetElementType()!; // Arrays always have an element type
 
             var items = new ArrayList();
-            CollectionNodeDeserializer.DeserializeHelper(itemType, parser, nestedObjectDeserializer, items, true);
+            CollectionNodeDeserializer.DeserializeHelper(itemType, parser, nestedObjectDeserializer, items, true, enumNamingConvention);
 
             var array = Array.CreateInstance(itemType, items.Count);
             items.CopyTo(array, 0);

--- a/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
@@ -35,14 +35,21 @@ namespace YamlDotNet.Serialization.NodeDeserializers
         private readonly bool ignoreUnmatched;
         private readonly bool duplicateKeyChecking;
         private readonly ITypeConverter typeConverter;
+        private readonly INamingConvention enumNamingConvention;
 
-        public ObjectNodeDeserializer(IObjectFactory objectFactory, ITypeInspector typeDescriptor, bool ignoreUnmatched, bool duplicateKeyChecking, ITypeConverter typeConverter)
+        public ObjectNodeDeserializer(IObjectFactory objectFactory,
+            ITypeInspector typeDescriptor,
+            bool ignoreUnmatched,
+            bool duplicateKeyChecking,
+            ITypeConverter typeConverter,
+            INamingConvention enumNamingConvention)
         {
             this.objectFactory = objectFactory ?? throw new ArgumentNullException(nameof(objectFactory));
             this.typeDescriptor = typeDescriptor ?? throw new ArgumentNullException(nameof(typeDescriptor));
             this.ignoreUnmatched = ignoreUnmatched;
             this.duplicateKeyChecking = duplicateKeyChecking;
             this.typeConverter = typeConverter ?? throw new ArgumentNullException(nameof(typeConverter));
+            this.enumNamingConvention = enumNamingConvention ?? throw new ArgumentNullException(nameof(enumNamingConvention));
         }
 
         public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
@@ -82,13 +89,13 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                         var valueRef = value;
                         propertyValuePromise.ValueAvailable += v =>
                         {
-                            var convertedValue = typeConverter.ChangeType(v, property.Type);
+                            var convertedValue = typeConverter.ChangeType(v, property.Type, enumNamingConvention);
                             property.Write(valueRef, convertedValue);
                         };
                     }
                     else
                     {
-                        var convertedValue = typeConverter.ChangeType(propertyValue, property.Type);
+                        var convertedValue = typeConverter.ChangeType(propertyValue, property.Type, enumNamingConvention);
                         property.Write(value, convertedValue);
                     }
                 }

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -98,7 +98,17 @@ namespace YamlDotNet.Serialization
 
             eventEmitterFactories = new LazyComponentRegistrationList<IEventEmitter, IEventEmitter>
             {
-                { typeof(TypeAssigningEventEmitter), inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle, yamlFormatter) }
+                {
+                    typeof(TypeAssigningEventEmitter), inner =>
+                        new TypeAssigningEventEmitter(inner,
+                            false,
+                            tagMappings,
+                            quoteNecessaryStrings,
+                            quoteYaml1_1Strings,
+                            defaultScalarStyle,
+                            yamlFormatter,
+                            enumNamingConvention)
+                }
             };
 
             objectFactory = new DefaultObjectFactory();
@@ -282,7 +292,17 @@ namespace YamlDotNet.Serialization
                 settings,
                 objectFactory
             );
-            WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, true, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle, yamlFormatter), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+
+            WithEventEmitter(inner =>
+                new TypeAssigningEventEmitter(inner,
+                    true,
+                    tagMappings,
+                    quoteNecessaryStrings,
+                    quoteYaml1_1Strings,
+                    defaultScalarStyle,
+                    yamlFormatter,
+                    enumNamingConvention), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+
             return WithTypeInspector(inner => new ReadableAndWritablePropertiesTypeInspector(inner), loc => loc.OnBottom());
         }
 
@@ -339,7 +359,7 @@ namespace YamlDotNet.Serialization
                 .WithTypeConverter(new DateOnlyConverter(doubleQuotes: true))
                 .WithTypeConverter(new TimeOnlyConverter(doubleQuotes: true))
 #endif
-                .WithEventEmitter(inner => new JsonEventEmitter(inner, yamlFormatter), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+                .WithEventEmitter(inner => new JsonEventEmitter(inner, yamlFormatter, enumNamingConvention), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/StaticBuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/StaticBuilderSkeleton.cs
@@ -35,6 +35,7 @@ namespace YamlDotNet.Serialization
         where TBuilder : StaticBuilderSkeleton<TBuilder>
     {
         internal INamingConvention namingConvention = NullNamingConvention.Instance;
+        internal INamingConvention enumNamingConvention = NullNamingConvention.Instance;
         internal ITypeResolver typeResolver;
         internal readonly LazyComponentRegistrationList<Nothing, IYamlTypeConverter> typeConverterFactories;
         internal readonly LazyComponentRegistrationList<ITypeInspector, ITypeInspector> typeInspectorFactories;
@@ -62,6 +63,17 @@ namespace YamlDotNet.Serialization
         public TBuilder WithNamingConvention(INamingConvention namingConvention)
         {
             this.namingConvention = namingConvention ?? throw new ArgumentNullException(nameof(namingConvention));
+            return Self;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="INamingConvention"/> to use when handling enum's.
+        /// </summary>
+        /// <param name="enumNamingConvention">Naming convention to use when handling enum's</param>
+        /// <returns></returns>
+        public TBuilder WithEnumNamingConvention(INamingConvention enumNamingConvention)
+        {
+            this.enumNamingConvention = enumNamingConvention ?? throw new ArgumentNullException(nameof(enumNamingConvention));
             return Self;
         }
 

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -87,11 +87,11 @@ namespace YamlDotNet.Serialization
                 { typeof(YamlSerializableNodeDeserializer), _ => new YamlSerializableNodeDeserializer(factory) },
                 { typeof(TypeConverterNodeDeserializer), _ => new TypeConverterNodeDeserializer(BuildTypeConverters()) },
                 { typeof(NullNodeDeserializer), _ => new NullNodeDeserializer() },
-                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization, typeConverter, yamlFormatter) },
+                { typeof(ScalarNodeDeserializer), _ => new ScalarNodeDeserializer(attemptUnknownTypeDeserialization, typeConverter, yamlFormatter, enumNamingConvention) },
                 { typeof(StaticArrayNodeDeserializer), _ => new StaticArrayNodeDeserializer(factory) },
                 { typeof(StaticDictionaryNodeDeserializer), _ => new StaticDictionaryNodeDeserializer(factory, duplicateKeyChecking) },
                 { typeof(StaticCollectionNodeDeserializer), _ => new StaticCollectionNodeDeserializer(factory) },
-                { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(factory, BuildTypeInspector(), ignoreUnmatched, duplicateKeyChecking, typeConverter) },
+                { typeof(ObjectNodeDeserializer), _ => new ObjectNodeDeserializer(factory, BuildTypeInspector(), ignoreUnmatched, duplicateKeyChecking, typeConverter, enumNamingConvention) },
             };
 
             nodeTypeResolverFactories = new LazyComponentRegistrationList<Nothing, INodeTypeResolver>
@@ -413,7 +413,8 @@ namespace YamlDotNet.Serialization
                 new NodeValueDeserializer(
                     nodeDeserializerFactories.BuildComponentList(),
                     nodeTypeResolverFactories.BuildComponentList(),
-                    typeConverter
+                    typeConverter,
+                    enumNamingConvention
                 )
             );
         }

--- a/YamlDotNet/Serialization/StaticSerializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticSerializerBuilder.cs
@@ -97,7 +97,17 @@ namespace YamlDotNet.Serialization
 
             eventEmitterFactories = new LazyComponentRegistrationList<IEventEmitter, IEventEmitter>
             {
-                { typeof(TypeAssigningEventEmitter), inner => new TypeAssigningEventEmitter(inner, false, tagMappings, quoteNecessaryStrings, quoteYaml1_1Strings, defaultScalarStyle, yamlFormatter) }
+                {
+                    typeof(TypeAssigningEventEmitter), inner =>
+                        new TypeAssigningEventEmitter(inner,
+                            false,
+                            tagMappings,
+                            quoteNecessaryStrings,
+                            quoteYaml1_1Strings,
+                            defaultScalarStyle,
+                            yamlFormatter,
+                            enumNamingConvention)
+                }
             };
 
             objectGraphTraversalStrategyFactory = (typeInspector, typeResolver, typeConverters, maximumRecursion) =>
@@ -288,7 +298,15 @@ namespace YamlDotNet.Serialization
                 settings,
                 factory
             );
-            WithEventEmitter(inner => new TypeAssigningEventEmitter(inner, true, tagMappings, quoteNecessaryStrings), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+            WithEventEmitter(inner => new TypeAssigningEventEmitter(inner,
+                true,
+                tagMappings,
+                quoteNecessaryStrings,
+                false,
+                ScalarStyle.Plain,
+                YamlFormatter.Default,
+                enumNamingConvention
+                ), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
             return WithTypeInspector(inner => new ReadableAndWritablePropertiesTypeInspector(inner), loc => loc.OnBottom());
         }
 
@@ -345,7 +363,7 @@ namespace YamlDotNet.Serialization
                 .WithTypeConverter(new DateOnlyConverter(doubleQuotes: true))
                 .WithTypeConverter(new TimeOnlyConverter(doubleQuotes: true))
 #endif
-                .WithEventEmitter(inner => new JsonEventEmitter(inner, yamlFormatter), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
+                .WithEventEmitter(inner => new JsonEventEmitter(inner, yamlFormatter, enumNamingConvention), loc => loc.InsteadOf<TypeAssigningEventEmitter>());
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/Utilities/ITypeConverter.cs
+++ b/YamlDotNet/Serialization/Utilities/ITypeConverter.cs
@@ -30,7 +30,8 @@ namespace YamlDotNet.Serialization.Utilities
         /// </summary>
         /// <param name="value"></param>
         /// <param name="expectedType"></param>
+        /// <param name="enumNamingConvention">Naming convention to use on enums in the type converter.</param>
         /// <returns></returns>
-        object? ChangeType(object? value, Type expectedType);
+        object? ChangeType(object? value, Type expectedType, INamingConvention enumNamingConvention);
     }
 }

--- a/YamlDotNet/Serialization/Utilities/NullTypeConverter.cs
+++ b/YamlDotNet/Serialization/Utilities/NullTypeConverter.cs
@@ -25,6 +25,6 @@ namespace YamlDotNet.Serialization.Utilities
 {
     public class NullTypeConverter : ITypeConverter
     {
-        public object? ChangeType(object? value, Type expectedType) => value;
+        public object? ChangeType(object? value, Type expectedType, INamingConvention enumNamingConvention) => value;
     }
 }

--- a/YamlDotNet/Serialization/Utilities/ReflectionTypeConverter.cs
+++ b/YamlDotNet/Serialization/Utilities/ReflectionTypeConverter.cs
@@ -20,11 +20,14 @@
 // SOFTWARE.
 
 using System;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace YamlDotNet.Serialization.Utilities
 {
     public class ReflectionTypeConverter : ITypeConverter
     {
-        public object? ChangeType(object? value, Type expectedType) => TypeConverter.ChangeType(value, expectedType);
+        public object? ChangeType(object? value, Type expectedType) => ChangeType(value, expectedType, NullNamingConvention.Instance);
+        public object? ChangeType(object? value, Type expectedType, INamingConvention enumNamingConvention) => TypeConverter.ChangeType(value, expectedType, enumNamingConvention);
+
     }
 }

--- a/YamlDotNet/Serialization/ValueDeserializers/NodeValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/NodeValueDeserializer.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Serialization.Utilities;
 
 namespace YamlDotNet.Serialization.ValueDeserializers
@@ -32,12 +33,17 @@ namespace YamlDotNet.Serialization.ValueDeserializers
         private readonly IList<INodeDeserializer> deserializers;
         private readonly IList<INodeTypeResolver> typeResolvers;
         private readonly ITypeConverter typeConverter;
+        private readonly INamingConvention enumNamingConvention;
 
-        public NodeValueDeserializer(IList<INodeDeserializer> deserializers, IList<INodeTypeResolver> typeResolvers, ITypeConverter typeConverter)
+        public NodeValueDeserializer(IList<INodeDeserializer> deserializers,
+            IList<INodeTypeResolver> typeResolvers,
+            ITypeConverter typeConverter,
+            INamingConvention enumNamingConvention)
         {
             this.deserializers = deserializers ?? throw new ArgumentNullException(nameof(deserializers));
             this.typeResolvers = typeResolvers ?? throw new ArgumentNullException(nameof(typeResolvers));
             this.typeConverter = typeConverter ?? throw new ArgumentNullException(nameof(typeConverter));
+            this.enumNamingConvention = enumNamingConvention ?? throw new ArgumentNullException(nameof(enumNamingConvention));
         }
 
         public object? DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
@@ -51,7 +57,7 @@ namespace YamlDotNet.Serialization.ValueDeserializers
                 {
                     if (deserializer.Deserialize(parser, nodeType, (r, t) => nestedObjectDeserializer.DeserializeValue(r, t, state, nestedObjectDeserializer), out var value))
                     {
-                        return typeConverter.ChangeType(value, expectedType);
+                        return typeConverter.ChangeType(value, expectedType, enumNamingConvention);
                     }
                 }
             }

--- a/YamlDotNet/Serialization/YamlFormatter.cs
+++ b/YamlDotNet/Serialization/YamlFormatter.cs
@@ -75,17 +75,26 @@ namespace YamlDotNet.Serialization
         }
 
         /// <summary>
-        /// Converts an enum to it's string representation. By default it will be the string representation of the enum
+        /// Converts an enum to it's string representation.
+        /// By default it will be the string representation of the enum passed through the naming convention.
         /// </summary>
         /// <returns>A string representation of the enum</returns>
-        public virtual Func<object, string> FormatEnum { get; set; } = (value) =>
+        public virtual Func<object, INamingConvention, string> FormatEnum { get; set; } = (value, enumNamingConvention) =>
         {
+            var result = string.Empty;
+
             if (value == null)
             {
-                return string.Empty;
+                result = string.Empty;
+            }
+            else
+            {
+                result = value.ToString();
             }
 
-            return value.ToString();
+            result = enumNamingConvention.Apply(result);
+
+            return result;
         };
 
         /// <summary>

--- a/YamlDotNet/Serialization/YamlFormatter.cs
+++ b/YamlDotNet/Serialization/YamlFormatter.cs
@@ -73,5 +73,24 @@ namespace YamlDotNet.Serialization
         {
             return ((TimeSpan)timeSpan).ToString();
         }
+
+        /// <summary>
+        /// Converts an enum to it's string representation. By default it will be the string representation of the enum
+        /// </summary>
+        /// <returns>A string representation of the enum</returns>
+        public virtual Func<object, string> FormatEnum { get; set; } = (value) =>
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            return value.ToString();
+        };
+
+        /// <summary>
+        /// If this function returns true, the serializer will put quotes around the formatted enum value if necessary. Defaults to true.
+        /// </summary>
+        public virtual Func<object, bool> PotentiallyQuoteEnums { get; set; } = (_) => true;
     }
 }

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net70;netstandard2.0;netstandard2.1;net35;net40;net45;net47;net60</TargetFrameworks>
+    <TargetFrameworks>net80;net70;net60;netstandard2.0;netstandard2.1;net35;net40;net45;net47</TargetFrameworks>
 
     <PackageProjectUrl>https://github.com/aaubry/YamlDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/aaubry/YamlDotNet</RepositoryUrl>
@@ -45,6 +45,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net70'">
+    <NetStandard>true</NetStandard>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net80'">
     <NetStandard>true</NetStandard>
   </PropertyGroup>
 


### PR DESCRIPTION
Enables #773 

Adds naming conventions for convert enums to/from scalars
Adds .NET8 binaries
Adds support for custom formatting of enums, easy to expose enums as integers or whatever else.
Quotes necessary enum strings (Null for example)

**Breaking: For those that get impacted pass in `NullNamingConvention.Instance` to the `EnumNamingConvetion` arguments on the constructor**
**Breaking: Removed many of the redundant constructors for the classes, pass in the old default values to the new constructors**
