### PR TITLE
Switch to using PackageLicenseExpression

### DIFF
--- a/YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.nuspec
+++ b/YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.nuspec
@@ -8,7 +8,7 @@
         <description>Roslyn Code Generator that will generate a static context for use with YamlDotNet to support ahead-of-time and library trimming.</description>
         <summary>Static context generator for YamlDotNet.</summary>
         <language>en-US</language>
-        <license type="file">LICENSE.txt</license>
+        <license type="expression">MIT</license>
         <projectUrl>https://github.com/aaubry/YamlDotNet/wiki</projectUrl>
         <iconUrl>http://aaubry.net/images/yamldotnet.png</iconUrl>
         <icon>images/yamldotnet.png</icon>

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -6,7 +6,7 @@
     <PackageProjectUrl>https://github.com/aaubry/YamlDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/aaubry/YamlDotNet</RepositoryUrl>
     <Description>YamlDotNet is a .NET library for YAML. YamlDotNet provides low level parsing and emitting of YAML as well as a high level object model similar to XmlDocument. A serialization library is also included that allows to read and write objects from and to YAML streams.</Description>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright (c) Antoine Aubry and contributors</Copyright>
     <Configurations>Debug;Release</Configurations>
     <AssemblyOriginatorKeyFile>..\YamlDotNet.snk</AssemblyOriginatorKeyFile>

--- a/YamlDotNet/YamlDotNet.nuspec
+++ b/YamlDotNet/YamlDotNet.nuspec
@@ -7,7 +7,7 @@
         <description>A .NET library for YAML. YamlDotNet provides low level parsing and emitting of YAML as well as a high level object model similar to XmlDocument.</description>
         <summary>This package contains the YAML parser and serializer.</summary>
         <language>en-US</language>
-        <license type="file">LICENSE.txt</license>
+        <license type="expression">MIT</license>
         <projectUrl>https://github.com/aaubry/YamlDotNet/wiki</projectUrl>
         <iconUrl>http://aaubry.net/images/yamldotnet.png</iconUrl>
         <icon>images/yamldotnet.png</icon>


### PR DESCRIPTION
By using license expression nuget.org is able to directly show the license information and also license checkers can directly get the compliance info. In comparison:

Current [YamlDotNet](https://www.nuget.org/packages/YamlDotNet):

![image](https://github.com/aaubry/YamlDotNet/assets/171892/842d9e28-2012-4514-966c-14b5bce6e89c)


Current [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json):

![image](https://github.com/aaubry/YamlDotNet/assets/171892/18fb281f-c9c4-44fd-b84f-3d65b0ec78a2)

fixes #918
