### PR TITLE
Add a regression test for #656

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -2460,7 +2460,7 @@ Null: true
         public void NestedDictionaryTypes_ShouldRoundtrip()
         {
             var serializer = new SerializerBuilder().EnsureRoundtrip().Build();
-            var yaml = serializer.Serialize(new HasNestedDictionary(), typeof(HasNestedDictionary));
+            var yaml = serializer.Serialize(new HasNestedDictionary { Lookups = { [1] = new HasNestedDictionary.Payload { I = 1 } } }, typeof(HasNestedDictionary));
             var dct = new DeserializerBuilder().Build().Deserialize<HasNestedDictionary>(yaml);
             Assert.Contains(new KeyValuePair<int, HasNestedDictionary.Payload>(1, new HasNestedDictionary.Payload { I = 1 }), dct.Lookups);
         }
@@ -2559,7 +2559,7 @@ Null: true
 
         public sealed class HasNestedDictionary
         {
-            public Dictionary<int, Payload> Lookups { get; set; } = new Dictionary<int, Payload> { [1] = new Payload { I = 1 } };
+            public Dictionary<int, Payload> Lookups { get; set; } = new Dictionary<int, Payload>();
 
             public struct Payload
             {

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -2455,6 +2455,16 @@ Null: true
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        [Trait("motive", "issue #656")]
+        public void NestedDictionaryTypes_ShouldRoundtrip()
+        {
+            var serializer = new SerializerBuilder().EnsureRoundtrip().Build();
+            var yaml = serializer.Serialize(new HasNestedDictionary(), typeof(HasNestedDictionary));
+            var dct = new DeserializerBuilder().Build().Deserialize<HasNestedDictionary>(yaml);
+            Assert.Contains(new KeyValuePair<int, HasNestedDictionary.Payload>(1, new HasNestedDictionary.Payload { I = 1 }), dct.Lookups);
+        }
+
         public class TestState
         {
             public int OnSerializedCallCount { get; set; }
@@ -2544,6 +2554,16 @@ Null: true
             public void WriteYaml(IEmitter emitter, object value, Type type)
             {
                 emitter.Emit(new Scalar(((NonSerializable)value).Text));
+            }
+        }
+
+        public sealed class HasNestedDictionary
+        {
+            public Dictionary<int, Payload> Lookups { get; set; } = new Dictionary<int, Payload> { [1] = new Payload { I = 1 } };
+
+            public struct Payload
+            {
+                public int I { get; set; }
             }
         }
     }


### PR DESCRIPTION
Resolves #656

I came here to fix that linked issue, but it turns out that the issue no longer reproduces on the latest version.

Digging around, I can confirm that commit e1986a459599772699a9cdaa712193da5db6de55 was the one that fixed it. I can't quite tell why that would be, but this exact automated test definitely passes at that version and definitely fails immediately before. :shrug:

Regardless, before I call it "good enough", I would appreciate it if you could add this automated test to the repository as a safeguard, especially since I can't tell why that commit "ought" to have fixed this.