### PR TITLE
Enquote value in JSonEmitter when it is an infinity float or double

### DIFF
--- a/YamlDotNet/Serialization/EventEmitters/JsonEventEmitter.cs
+++ b/YamlDotNet/Serialization/EventEmitters/JsonEventEmitter.cs
@@ -83,8 +83,16 @@ namespace YamlDotNet.Serialization.EventEmitters
 
                     case TypeCode.Single:
                     case TypeCode.Double:
+                        double doubleCast = (double)value;
+                        if (double.IsInfinity(doubleCast) || double.IsNaN(doubleCast))
+                        {
+                            eventInfo.Style = ScalarStyle.DoubleQuoted;
+                        }
+                        eventInfo.RenderedValue = YamlFormatter.FormatNumber(value);
+                        break;
+
                     case TypeCode.Decimal:
-                        eventInfo.RenderedValue = formatter.FormatNumber(value);
+                        eventInfo.RenderedValue = YamlFormatter.FormatNumber(value);
                         break;
 
                     case TypeCode.String:


### PR DESCRIPTION
Stub for fixing https://github.com/aaubry/YamlDotNet/issues/893
Incomplete - missing unit test, and this might not be the best way to handle it either (i haven't looked too much into it). but I guess it's a start?