### PR TITLE
Adding async methods to serialization API

### DIFF
--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using YamlDotNet.Core;
@@ -401,6 +402,19 @@ stringWriter.ToString().NormalizeNewLines().TrimNewLines());
                 }
 
                 Assert.False(scalar.IsQuotedImplicit);
+            }
+
+            public Task EmitAsync(ParsingEvent @event)
+            {
+                try
+                {
+                    Emit(@event);
+                    return Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromException(ex);
+                }
             }
         }
     }

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -25,6 +25,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Helpers;
 using ParsingEvent = YamlDotNet.Core.Events.ParsingEvent;
@@ -177,6 +178,15 @@ namespace YamlDotNet.Core
                     events.Dequeue();
                 }
             }
+        }
+
+        public async Task EmitAsync(ParsingEvent @event)
+        {
+            // This will require either a parallel StateMachineAsync method stack essentially
+            // duplicating all the code in this class, or deeply refactoring the StateMachine method
+            // down to the Write and WriteBreak methods to allow the state mutation to be reused
+            // between this method and Emit.
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/YamlDotNet/Core/IEmitter.cs
+++ b/YamlDotNet/Core/IEmitter.cs
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Threading.Tasks;
 using YamlDotNet.Core.Events;
 
 namespace YamlDotNet.Core
@@ -32,5 +33,7 @@ namespace YamlDotNet.Core
         /// Emits an event.
         /// </summary>
         void Emit(ParsingEvent @event);
+
+        Task EmitAsync(ParsingEvent @event);
     }
 }

--- a/YamlDotNet/Serialization/Deserializer.cs
+++ b/YamlDotNet/Serialization/Deserializer.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization.Utilities;
@@ -77,9 +78,19 @@ namespace YamlDotNet.Serialization
             return Deserialize<T>(new Parser(input));
         }
 
+        public async Task<T> DeserializeAsync<T>(TextReader input)
+        {
+            return await DeserializeAsync<T>(new Parser(input));
+        }
+
         public T Deserialize<T>(IParser parser)
         {
             return (T)Deserialize(parser, typeof(T))!; // We really want an exception if we are trying to deserialize null into a non-nullable type
+        }
+
+        public async Task<T> DeserializeAsync<T>(IParser parser)
+        {
+            return (T)(await DeserializeAsync(parser, typeof(T)))!;
         }
 
         public object? Deserialize(string input)
@@ -92,9 +103,19 @@ namespace YamlDotNet.Serialization
             return Deserialize(input, typeof(object));
         }
 
+        public async Task<object?> DeserializeAsync(TextReader input)
+        {
+            return await DeserializeAsync(input, typeof(object));
+        }
+
         public object? Deserialize(IParser parser)
         {
             return Deserialize(parser, typeof(object));
+        }
+
+        public async Task<object?> DeserializeAsync(IParser parser)
+        {
+            return await DeserializeAsync(parser, typeof(object));
         }
 
         public object? Deserialize(string input, Type type)
@@ -106,6 +127,11 @@ namespace YamlDotNet.Serialization
         public object? Deserialize(TextReader input, Type type)
         {
             return Deserialize(new Parser(input), type);
+        }
+
+        public async Task<object?> DeserializeAsync(TextReader input, Type type)
+        {
+            return await DeserializeAsync(new Parser(input), type);
         }
 
         /// <summary>
@@ -149,6 +175,17 @@ namespace YamlDotNet.Serialization
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Deserializes an object of the specified type.
+        /// </summary>
+        /// <param name="parser">The <see cref="IParser" /> from where to deserialize the object.</param>
+        /// <param name="type">The static type of the object to deserialize.</param>
+        /// <returns>A task that contains the deserialized object on success.</returns>
+        public async Task<object?> DeserializeAsync(IParser parser, Type type)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/YamlDotNet/Serialization/IDeserializer.cs
+++ b/YamlDotNet/Serialization/IDeserializer.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization
@@ -29,13 +30,18 @@ namespace YamlDotNet.Serialization
     {
         T Deserialize<T>(string input);
         T Deserialize<T>(TextReader input);
+        Task<T> DeserializeAsync<T>(TextReader input);
         T Deserialize<T>(IParser parser);
+        Task<T> DeserializeAsync<T>(IParser parser);
 
         object? Deserialize(string input);
         object? Deserialize(TextReader input);
+        Task<object?> DeserializeAsync(TextReader input);
         object? Deserialize(IParser parser);
+        Task<object?> DeserializeAsync(IParser parser);
         object? Deserialize(string input, Type type);
         object? Deserialize(TextReader input, Type type);
+        Task<object?> DeserializeAsync(TextReader reader, Type type);
 
         /// <summary>
         /// Deserializes an object of the specified type.
@@ -44,5 +50,13 @@ namespace YamlDotNet.Serialization
         /// <param name="type">The static type of the object to deserialize.</param>
         /// <returns>Returns the deserialized object.</returns>
         object? Deserialize(IParser parser, Type type);
+
+        /// <summary>
+        /// Deserializes an object of the specified type.
+        /// </summary>
+        /// <param name="parser">The <see cref="IParser" /> from where to deserialize the object.</param>
+        /// <param name="type">The static type of the object to deserialize.</param>
+        /// <returns>A task that contains the deserialized object on success.</returns>
+        Task<object?> DeserializeAsync(IParser parser, Type type);
     }
 }

--- a/YamlDotNet/Serialization/IObjectGraphTraversalStrategy.cs
+++ b/YamlDotNet/Serialization/IObjectGraphTraversalStrategy.cs
@@ -19,6 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Threading.Tasks;
+
 namespace YamlDotNet.Serialization
 {
     /// <summary>
@@ -33,5 +35,7 @@ namespace YamlDotNet.Serialization
         /// <param name="visitor">An <see cref="IObjectGraphVisitor{TContext}"/> that is to be notified during the traversal.</param>
         /// <param name="context">A <typeparamref name="TContext" /> that will be passed to the <paramref name="visitor" />.</param>
         void Traverse<TContext>(IObjectDescriptor graph, IObjectGraphVisitor<TContext> visitor, TContext context);
+
+        Task TraverseAsync<TContext>(IObjectDescriptor graph, IObjectGraphVisitor<TContext> visitor, TContext context);
     }
 }

--- a/YamlDotNet/Serialization/IObjectGraphVisitor.cs
+++ b/YamlDotNet/Serialization/IObjectGraphVisitor.cs
@@ -26,6 +26,9 @@ namespace YamlDotNet.Serialization
     /// <summary>
     /// Defined the interface of a type that can be notified during an object graph traversal.
     /// </summary>
+
+    // This will need to be updated to include Async versions of methods due to use in
+    // IObjectGraphTraversalStrategy and its implementations
     public interface IObjectGraphVisitor<TContext>
     {
         /// <summary>

--- a/YamlDotNet/Serialization/ISerializer.cs
+++ b/YamlDotNet/Serialization/ISerializer.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization
@@ -52,8 +53,25 @@ namespace YamlDotNet.Serialization
         /// </summary>
         /// <param name="writer">The <see cref="TextWriter" /> where to serialize the object.</param>
         /// <param name="graph">The object to serialize.</param>
+        /// <returns>A task that represents the asynchronous serialization operation</returns>
+        Task SerializeAsync(TextWriter writer, object? graph);
+
+        /// <summary>
+        /// Serializes the specified object.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter" /> where to serialize the object.</param>
+        /// <param name="graph">The object to serialize.</param>
         /// <param name="type">The static type of the object to serialize.</param>
         void Serialize(TextWriter writer, object? graph, Type type);
+
+        /// <summary>
+        /// Serializes the specified object.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter" /> where to serialize the object.</param>
+        /// <param name="graph">The object to serialize.</param>
+        /// <param name="type">The static type of the object to serialize.</param>
+        /// <returns>A task that represents the asynchronous serialization operation</returns>
+        Task SerializeAsync(TextWriter writer, object? graph, Type type);
 
         /// <summary>
         /// Serializes the specified object.
@@ -67,7 +85,24 @@ namespace YamlDotNet.Serialization
         /// </summary>
         /// <param name="emitter">The <see cref="IEmitter" /> where to serialize the object.</param>
         /// <param name="graph">The object to serialize.</param>
+        /// <returns>A task that represents the asynchronous serialization operation</returns>
+        Task SerializeAsync(IEmitter emitter, object? graph);
+
+        /// <summary>
+        /// Serializes the specified object.
+        /// </summary>
+        /// <param name="emitter">The <see cref="IEmitter" /> where to serialize the object.</param>
+        /// <param name="graph">The object to serialize.</param>
         /// <param name="type">The static type of the object to serialize.</param>
         void Serialize(IEmitter emitter, object? graph, Type type);
+
+        /// <summary>
+        /// Serializes the specified object.
+        /// </summary>
+        /// <param name="emitter">The <see cref="IEmitter" /> where to serialize the object.</param>
+        /// <param name="graph">The object to serialize.</param>
+        /// <param name="type">The static type of the object to serialize.</param>
+        /// <returns>A task that represents the asynchronous serialization operation</returns>
+        Task SerializeAsync(IEmitter emitter, object? graph, Type type);
     }
 }

--- a/YamlDotNet/Serialization/IValueSerializer.cs
+++ b/YamlDotNet/Serialization/IValueSerializer.cs
@@ -20,6 +20,7 @@
 // SOFTWARE.
 
 using System;
+using System.Threading.Tasks;
 using YamlDotNet.Core;
 
 namespace YamlDotNet.Serialization
@@ -27,5 +28,7 @@ namespace YamlDotNet.Serialization
     public interface IValueSerializer
     {
         void SerializeValue(IEmitter emitter, object? value, Type? type);
+
+        Task SerializeValueAsync(IEmitter emitter, object? value, Type? type);
     }
 }

--- a/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/YamlDotNet/Serialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using YamlDotNet.Core;
 using YamlDotNet.Helpers;
 using YamlDotNet.Serialization.Utilities;
@@ -60,6 +61,11 @@ namespace YamlDotNet.Serialization.ObjectGraphTraversalStrategies
         void IObjectGraphTraversalStrategy.Traverse<TContext>(IObjectDescriptor graph, IObjectGraphVisitor<TContext> visitor, TContext context)
         {
             Traverse("<root>", graph, visitor, context, new Stack<ObjectPathSegment>(maxRecursion));
+        }
+
+        public async Task TraverseAsync<TContext>(IObjectDescriptor graph, IObjectGraphVisitor<TContext> visitor, TContext context)
+        {
+            throw new NotImplementedException();
         }
 
         protected struct ObjectPathSegment

--- a/YamlDotNet/Serialization/Serializer.cs
+++ b/YamlDotNet/Serialization/Serializer.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
@@ -95,6 +96,11 @@ namespace YamlDotNet.Serialization
             Serialize(new Emitter(writer, emitterSettings), graph);
         }
 
+        public async Task SerializeAsync(TextWriter writer, object? graph)
+        {
+            await SerializeAsync(new Emitter(writer, emitterSettings), graph);
+        }
+
         /// <summary>
         /// Serializes the specified object.
         /// </summary>
@@ -104,6 +110,11 @@ namespace YamlDotNet.Serialization
         public void Serialize(TextWriter writer, object? graph, Type type)
         {
             Serialize(new Emitter(writer, emitterSettings), graph, type);
+        }
+
+        public async Task SerializeAsync(TextWriter writer, object? graph, Type type)
+        {
+            await SerializeAsync(new Emitter(writer, emitterSettings), graph, type);
         }
 
         /// <summary>
@@ -119,6 +130,16 @@ namespace YamlDotNet.Serialization
             }
 
             EmitDocument(emitter, graph, null);
+        }
+
+        public async Task SerializeAsync(IEmitter emitter, object? graph)
+        {
+            if (emitter == null)
+            {
+                throw new ArgumentNullException(nameof(emitter));
+            }
+
+            await EmitDocumentAsync(emitter, graph, null);
         }
 
         /// <summary>
@@ -142,6 +163,21 @@ namespace YamlDotNet.Serialization
             EmitDocument(emitter, graph, type);
         }
 
+        public async Task SerializeAsync(IEmitter emitter, object? graph, Type type)
+        {
+            if (emitter == null)
+            {
+                throw new ArgumentNullException(nameof(emitter));
+            }
+
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            await EmitDocumentAsync(emitter, graph, type);
+        }
+
         private void EmitDocument(IEmitter emitter, object? graph, Type? type)
         {
             emitter.Emit(new StreamStart());
@@ -151,6 +187,17 @@ namespace YamlDotNet.Serialization
 
             emitter.Emit(new DocumentEnd(true));
             emitter.Emit(new StreamEnd());
+        }
+
+        private async Task EmitDocumentAsync(IEmitter emitter, object? graph, Type? type)
+        {
+            await emitter.EmitAsync(new StreamStart());
+            await emitter.EmitAsync(new DocumentStart());
+
+            await valueSerializer.SerializeValueAsync(emitter, graph, type);
+
+            await emitter.EmitAsync(new DocumentEnd(true));
+            await emitter.EmitAsync(new StreamEnd());
         }
     }
 }

--- a/YamlDotNet/Serialization/StaticSerializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticSerializerBuilder.cs
@@ -21,6 +21,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+
 #if NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -747,6 +749,13 @@ namespace YamlDotNet.Serialization
                 );
 
                 traversalStrategy.Traverse(graph, emittingVisitor, emitter);
+            }
+
+            public async Task SerializeValueAsync(IEmitter emitter, object? value, Type? type)
+            {
+                // This will need to reimplement SerializeValue to call the emitter's EmitAsync
+                // method and the traversalStrategy's TraverseAsync instead.
+                throw new NotImplementedException();
             }
         }
     }


### PR DESCRIPTION
This draft is to bring up the question of adding Async versions of the Serialize and Deserialize APIs, and all of the complexity that that will entail. This was brought up originally in issue #430. So far my branch only contains more or less what the closed pull request #457 had.

Before I go any further I want to make sure that I address a series of architectural questions and concerns (which I'll put in the following comment) that might block the implementation due to how deeply the code will have to be modified.