### PR TITLE
Include symbols and deterministic build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ TestResults
 *.orig
 Help/*
 release/*
-/_ReSharper.*
+_ReSharper.*
 *.pidb
 *.userprefs
 packages

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -21,6 +21,10 @@
 
     <NetStandard>false</NetStandard>
     <RealTargetFramework>$(TargetFramework)</RealTargetFramework>
+
+    <DebugSymbols>true</DebugSymbols>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
@@ -49,6 +53,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="../README.md" Pack="true" PackagePath="README.md" />
     <None Include="../LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
 
@@ -58,37 +63,28 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE;TRACE;SIGNED</DefineConstants>
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetStandard)' == 'false'">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
   <ItemGroup Condition="'$(NetStandard)' == 'false'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(NetStandard)' == 'true'">
-    <PackageReference Include="System.Runtime.Serialization.Formatters">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.ComponentModel.TypeConverter">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Diagnostics.Debug">
-      <Version>4.3.0</Version>
-    </PackageReference>
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
   </ItemGroup>
 
   <Target Name="Info" BeforeTargets="CoreCompile">
-    <PropertyGroup>
-      <Empty></Empty>
-    </PropertyGroup>
     <Message Importance="high" Text=" " Condition="'$(RealTargetFramework)' != ''" />
     <Message Importance="high" Text="==== Building $(RealTargetFramework) $(Empty.PadRight($([MSBuild]::Subtract(100, $(RealTargetFramework.Length))), '='))" Condition="'$(RealTargetFramework)' != ''" />
   </Target>

--- a/YamlDotNet/YamlDotNet.nuspec
+++ b/YamlDotNet/YamlDotNet.nuspec
@@ -13,6 +13,7 @@
         <icon>images/yamldotnet.png</icon>
         <repository type="git" url="https://github.com/aaubry/YamlDotNet.git" />
         <tags>yaml parser development library serialization</tags>
+        <readme>README.md</readme>
         <dependencies>
             <group targetFramework=".NETFramework4.7" />
             <group targetFramework=".NETStandard2.0" />
@@ -24,23 +25,30 @@
     </metadata>
     <files>
         <file src="bin/Release/net47/YamlDotNet.dll" target="lib/net47" />
+        <file src="bin/Release/net47/YamlDotNet.pdb" target="lib/net47" />
         <file src="bin/Release/net47/YamlDotNet.xml" target="lib/net47" />
 
         <file src="bin/Release/net6.0/YamlDotNet.dll" target="lib/net6.0" />
+        <file src="bin/Release/net6.0/YamlDotNet.pdb" target="lib/net6.0" />
         <file src="bin/Release/net6.0/YamlDotNet.xml" target="lib/net6.0" />
 
         <file src="bin/Release/net7.0/YamlDotNet.dll" target="lib/net7.0" />
+        <file src="bin/Release/net7.0/YamlDotNet.pdb" target="lib/net7.0" />
         <file src="bin/Release/net7.0/YamlDotNet.xml" target="lib/net7.0" />
 
         <file src="bin/Release/net8.0/YamlDotNet.dll" target="lib/net8.0" />
+        <file src="bin/Release/net8.0/YamlDotNet.pdb" target="lib/net8.0" />
         <file src="bin/Release/net8.0/YamlDotNet.xml" target="lib/net8.0" />
 
         <file src="bin/Release/netstandard2.0/YamlDotNet.dll" target="lib/netstandard2.0" />
+        <file src="bin/Release/netstandard2.0/YamlDotNet.pdb" target="lib/netstandard2.0" />
         <file src="bin/Release/netstandard2.0/YamlDotNet.xml" target="lib/netstandard2.0" />
 
         <file src="bin/Release/netstandard2.1/YamlDotNet.dll" target="lib/netstandard2.1" />
+        <file src="bin/Release/netstandard2.1/YamlDotNet.pdb" target="lib/netstandard2.1" />
         <file src="bin/Release/netstandard2.1/YamlDotNet.xml" target="lib/netstandard2.1" />
 
+        <file src="../README.md" target="" />
         <file src="../LICENSE.txt" target="" />
         <file src="../yamldotnet.png" target="images/" />
     </files>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,3 +45,4 @@ artifacts:
     name: Release-Net80
 
   - path: YamlDotNet\bin\*.nupkg
+  - path: YamlDotNet\bin\*.snupkg

--- a/tools/build/BuildDefinition.cs
+++ b/tools/build/BuildDefinition.cs
@@ -125,7 +125,7 @@ namespace build
         public static Task<SuccessfulBuild> Build(Options options, MetadataSet _)
         {
             var verbosity = options.Verbose ? "detailed" : "minimal";
-            Run("dotnet", $"build YamlDotNet.sln --configuration Release --verbosity {verbosity}", BasePath);
+            Run("dotnet", $"build YamlDotNet.sln --configuration Release --verbosity {verbosity} -p:ContinuousIntegrationBuild=true", BasePath);
 
             return Task.FromResult(new SuccessfulBuild());
         }
@@ -143,14 +143,14 @@ namespace build
             var result = new List<NuGetPackage>();
             var verbosity = options.Verbose ? "detailed" : "minimal";
             var buildDir = Path.Combine(BasePath, "YamlDotNet");
-            Run("nuget", $"pack YamlDotNet.nuspec -Version {version.NuGetVersion} -OutputDirectory bin", buildDir);
+            Run("nuget", $"pack YamlDotNet.nuspec -Version {version.NuGetVersion} -OutputDirectory bin -Symbols -SymbolPackageFormat snupkg", buildDir);
             var packagePath = Path.Combine(buildDir, "bin", $"YamlDotNet.{version.NuGetVersion}.nupkg");
             result.Add(new NuGetPackage(packagePath, "YamlDotNet"));
 
             if (PushSerializer)
             {
                 buildDir = Path.Combine(BasePath, "YamlDotNet.Analyzers.StaticGenerator");
-                Run("nuget", $"pack YamlDotNet.Analyzers.StaticGenerator.nuspec -Version {version.NuGetVersion} -OutputDirectory bin", buildDir);
+                Run("nuget", $"pack YamlDotNet.Analyzers.StaticGenerator.nuspec -Version {version.NuGetVersion} -OutputDirectory bin -Symbols -SymbolPackageFormat snupkg", buildDir);
                 packagePath = Path.Combine(buildDir, "bin", $"YamlDotNet.Analyzers.StaticGenerator.{version.NuGetVersion}.nupkg");
                 result.Add(new NuGetPackage(packagePath, "YamlDotNet.Analyzers.StaticGenerator"));
             }


### PR DESCRIPTION
Here I'm basically trying to fix problems that can be seen in NuGet Package explorer:  https://nuget.info/packages/YamlDotNet/15.1.1 . Creating symbols and using deterministic build, including repository readme as package readme as NuGet likes to complain about missing readmes.

The build infrastructure is a bit hard to use so let's see if this produces to correct outcome...

As build now passes, should somehow also include `snupkg` as part of NuGet release push.