### PR TITLE
Make DefaultObjectFactory thread safe

### DIFF
--- a/YamlDotNet/Serialization/ObjectFactories/DefaultObjectFactory.cs
+++ b/YamlDotNet/Serialization/ObjectFactories/DefaultObjectFactory.cs
@@ -148,17 +148,13 @@ namespace YamlDotNet.Serialization.ObjectFactories
         {
             var stateDictionary = _stateMethods[attributeType];
 
-            if (stateDictionary.TryGetValue(valueType, out var methods))
+            return stateDictionary.GetOrAdd(valueType, type =>
             {
-                return methods;
-            }
-
-            methods = valueType.GetMethods(BindingFlags.Public |
-                                          BindingFlags.Instance |
-                                          BindingFlags.NonPublic);
-            methods = methods.Where(x => x.GetCustomAttributes(attributeType, true).Any()).ToArray();
-            stateDictionary.TryAdd(valueType, methods);
-            return methods;
+                var methods = type.GetMethods(BindingFlags.Public |
+                                              BindingFlags.Instance |
+                                              BindingFlags.NonPublic);
+                return methods.Where(x => x.GetCustomAttributes(attributeType, true).Any()).ToArray();
+            });
         }
     }
 }

--- a/YamlDotNet/Serialization/ObjectFactories/DefaultObjectFactory.cs
+++ b/YamlDotNet/Serialization/ObjectFactories/DefaultObjectFactory.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -33,12 +34,12 @@ namespace YamlDotNet.Serialization.ObjectFactories
     /// </summary>
     public sealed class DefaultObjectFactory : ObjectFactoryBase
     {
-        private readonly Dictionary<Type, Dictionary<Type, MethodInfo[]>> _stateMethods = new Dictionary<Type, Dictionary<Type, MethodInfo[]>>
+        private readonly Dictionary<Type, ConcurrentDictionary<Type, MethodInfo[]>> _stateMethods = new Dictionary<Type, ConcurrentDictionary<Type, MethodInfo[]>>
         {
-            { typeof(OnDeserializedAttribute), new Dictionary<Type, MethodInfo[]>() },
-            { typeof(OnDeserializingAttribute), new Dictionary<Type, MethodInfo[]>() },
-            { typeof(OnSerializedAttribute), new Dictionary<Type, MethodInfo[]>() },
-            { typeof(OnSerializingAttribute), new Dictionary<Type, MethodInfo[]>() },
+            { typeof(OnDeserializedAttribute), new ConcurrentDictionary<Type, MethodInfo[]>() },
+            { typeof(OnDeserializingAttribute), new ConcurrentDictionary<Type, MethodInfo[]>() },
+            { typeof(OnSerializedAttribute), new ConcurrentDictionary<Type, MethodInfo[]>() },
+            { typeof(OnSerializingAttribute), new ConcurrentDictionary<Type, MethodInfo[]>() },
         };
 
         private readonly Dictionary<Type, Type> DefaultGenericInterfaceImplementations = new Dictionary<Type, Type>
@@ -156,7 +157,7 @@ namespace YamlDotNet.Serialization.ObjectFactories
                                           BindingFlags.Instance |
                                           BindingFlags.NonPublic);
             methods = methods.Where(x => x.GetCustomAttributes(attributeType, true).Any()).ToArray();
-            stateDictionary[valueType] = methods;
+            stateDictionary.TryAdd(valueType, methods);
             return methods;
         }
     }


### PR DESCRIPTION
https://github.com/kubernetes-client/csharp/issues/1537 raised that deserialization (and serialization) is not currently thread-safe, due to concurrent access to the non-thread-safe `_stateMethods` dictionary in `DefaultObjectFactory`.

This PR changes the nested inner  `Dictionary<Type, MethodInfo[]>`s in `_stateMethods` to `ConcurrentDictionary`s to make concurrent access safe.

## Testing
I've added tests to concurrently serialize and deserialize simple YAML. These reproduced the issue before the fix most of the time, but were not 100% reliable (i.e. occasionally suffered false-positive results). I'm open to suggestions for a better way of testing this for thread-safety.