### PR TITLE
use correct framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,15 +40,15 @@ COPY . .
 RUN dotnet build -c Release --framework net47 YamlDotNet/YamlDotNet.csproj -o /output/net47
 RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.0
 RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
-RUN dotnet build -c Release --framework net60 YamlDotNet/YamlDotNet.csproj -o /output/net60
-RUN dotnet build -c Release --framework net70 YamlDotNet/YamlDotNet.csproj -o /output/net70
-RUN dotnet build -c Release --framework net80 YamlDotNet/YamlDotNet.csproj -o /output/net80
+RUN dotnet build -c Release --framework net6.0 YamlDotNet/YamlDotNet.csproj -o /output/net6.0
+RUN dotnet build -c Release --framework net7.0 YamlDotNet/YamlDotNet.csproj -o /output/net7.0
+RUN dotnet build -c Release --framework net8.0 YamlDotNet/YamlDotNet.csproj -o /output/net8.0
 
 RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
 
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net80 --logger:"trx;LogFileName=/output/tests.net80.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net8.0 --logger:"trx;LogFileName=/output/tests-net8.0.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net7.0 --logger:"trx;LogFileName=/output/tests-net7.0.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net6.0 --logger:"trx;LogFileName=/output/tests-net6.0.trx" --logger:"console;Verbosity=detailed"
 
 FROM alpine
 VOLUME /output

--- a/Dockerfile.NonEnglish
+++ b/Dockerfile.NonEnglish
@@ -42,9 +42,9 @@ COPY . .
 RUN dotnet build -c Release --framework net47 YamlDotNet/YamlDotNet.csproj -o /output/net47
 RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.0
 RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
-RUN dotnet build -c Release --framework net60 YamlDotNet/YamlDotNet.csproj -o /output/net60
-RUN dotnet build -c Release --framework net70 YamlDotNet/YamlDotNet.csproj -o /output/net70
-RUN dotnet build -c Release --framework net80 YamlDotNet/YamlDotNet.csproj -o /output/net80
+RUN dotnet build -c Release --framework net6.0 YamlDotNet/YamlDotNet.csproj -o /output/net6.0
+RUN dotnet build -c Release --framework net7.0 YamlDotNet/YamlDotNet.csproj -o /output/net7.0
+RUN dotnet build -c Release --framework net8.0 YamlDotNet/YamlDotNet.csproj -o /output/net8.0
 
 RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
 
@@ -62,10 +62,10 @@ RUN echo -n "${LC_ALL}" > /etc/locale.gen && \
     apt install -y locales && \
     locale-gen
 
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net80 --logger:"trx;LogFileName=/output/tests.net80.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net70 --logger:"trx;LogFileName=/output/tests.net70.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net60 --logger:"trx;LogFileName=/output/tests.net60.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests.netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net8.0 --logger:"trx;LogFileName=/output/tests-net8.0.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net7.0 --logger:"trx;LogFileName=/output/tests-net7.0.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net6.0 --logger:"trx;LogFileName=/output/tests-net6.0.trx" --logger:"console;Verbosity=detailed"
+RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests-netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
 
 FROM alpine
 VOLUME /output

--- a/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
+++ b/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net80</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj
+++ b/YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net70</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
+++ b/YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net70</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <PublishAot>true</PublishAot>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <Nullable>enable</Nullable>

--- a/YamlDotNet.Samples/YamlDotNet.Samples.csproj
+++ b/YamlDotNet.Samples/YamlDotNet.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -265,7 +265,7 @@ b: &number 1
                 yield return new object[] { decimal.MaxValue, typeof(decimal) };
                 yield return new object[] { char.MaxValue, typeof(char) };
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
                 yield return new object[] { float.MinValue, typeof(float) };
                 yield return new object[] { float.MaxValue, typeof(float) };
                 yield return new object[] { double.MinValue, typeof(double) };

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1538,7 +1538,7 @@ y:
                         new FloatTestCase("float.Epsilon", float.Epsilon, float.Epsilon.ToString("G", CultureInfo.InvariantCulture)),
                         new FloatTestCase("float.26.67", 26.67F, "26.67"),
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
                         new FloatTestCase("double.MinValue", double.MinValue, double.MinValue.ToString("G", CultureInfo.InvariantCulture)),
                         new FloatTestCase("double.MaxValue", double.MaxValue, double.MaxValue.ToString("G", CultureInfo.InvariantCulture)),
                         new FloatTestCase("float.MinValue", float.MinValue, float.MinValue.ToString("G", CultureInfo.InvariantCulture)),

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net80;net70;net60;net47</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net47</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>..\YamlDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/YamlDotNet/Helpers/OrderedDictionary.cs
+++ b/YamlDotNet/Helpers/OrderedDictionary.cs
@@ -136,14 +136,14 @@ namespace YamlDotNet.Helpers
             list.RemoveAt(index);
         }
 
-#if !(NETCOREAPP3_1)
+#if !NET
 #pragma warning disable 8767 // Nullability of reference types in type of parameter ... doesn't match implicitly implemented member
 #endif
 
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) =>
             dictionary.TryGetValue(key, out value);
 
-#if !(NETCOREAPP3_1)
+#if !NET
 #pragma warning restore 8767
 #endif
 

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;net70;net60;netstandard2.0;netstandard2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0;netstandard2.1;net47</TargetFrameworks>
 
     <PackageProjectUrl>https://github.com/aaubry/YamlDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/aaubry/YamlDotNet</RepositoryUrl>
@@ -23,7 +23,7 @@
     <RealTargetFramework>$(TargetFramework)</RealTargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <!-- Since the BCL is not yet annotated in other platforms, disable the nullable warnings when compiling for those -->
     <NoWarn>1591;1574;8600;8602;8604</NoWarn>
   </PropertyGroup>
@@ -36,15 +36,15 @@
     <NetStandard>true</NetStandard>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net60'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <NetStandard>true</NetStandard>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net70'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <NetStandard>true</NetStandard>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net80'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <NetStandard>true</NetStandard>
   </PropertyGroup>
 
@@ -66,7 +66,7 @@
   <PropertyGroup Condition="'$(NetStandard)' == 'false'">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup Condition="'$(NetStandard)' == 'false'">

--- a/YamlDotNet/YamlDotNet.nuspec
+++ b/YamlDotNet/YamlDotNet.nuspec
@@ -26,14 +26,14 @@
         <file src="bin/Release/net47/YamlDotNet.dll" target="lib/net47" />
         <file src="bin/Release/net47/YamlDotNet.xml" target="lib/net47" />
 
-        <file src="bin/Release/net60/YamlDotNet.dll" target="lib/net6.0" />
-        <file src="bin/Release/net60/YamlDotNet.xml" target="lib/net6.0" />
+        <file src="bin/Release/net6.0/YamlDotNet.dll" target="lib/net6.0" />
+        <file src="bin/Release/net6.0/YamlDotNet.xml" target="lib/net6.0" />
 
-        <file src="bin/Release/net70/YamlDotNet.dll" target="lib/net7.0" />
-        <file src="bin/Release/net70/YamlDotNet.xml" target="lib/net7.0" />
+        <file src="bin/Release/net7.0/YamlDotNet.dll" target="lib/net7.0" />
+        <file src="bin/Release/net7.0/YamlDotNet.xml" target="lib/net7.0" />
 
-        <file src="bin/Release/net80/YamlDotNet.dll" target="lib/net8.0" />
-        <file src="bin/Release/net80/YamlDotNet.xml" target="lib/net8.0" />
+        <file src="bin/Release/net8.0/YamlDotNet.dll" target="lib/net8.0" />
+        <file src="bin/Release/net8.0/YamlDotNet.xml" target="lib/net8.0" />
 
         <file src="bin/Release/netstandard2.0/YamlDotNet.dll" target="lib/netstandard2.0" />
         <file src="bin/Release/netstandard2.0/YamlDotNet.xml" target="lib/netstandard2.0" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,13 +35,13 @@ artifacts:
   - path: YamlDotNet\bin\Release\net47
     name: Release-Net47
 
-  - path: YamlDotNet\bin\Release\net60
+  - path: YamlDotNet\bin\Release\net6.0
     name: Release-Net60
 
-  - path: YamlDotNet\bin\Release\net70
+  - path: YamlDotNet\bin\Release\net7.0
     name: Release-Net70
 
-  - path: YamlDotNet\bin\Release\net80
+  - path: YamlDotNet\bin\Release\net8.0
     name: Release-Net80
 
   - path: YamlDotNet\bin\*.nupkg

--- a/tools/build/build.csproj
+++ b/tools/build/build.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net80</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Platforms>AnyCPU</Platforms>
         <Nullable>Enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks