### PR TITLE
ArrayNodeDeserializer can now deserialize circular references.

### DIFF
--- a/YamlDotNet/Serialization/NodeDeserializers/ArrayNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ArrayNodeDeserializer.cs
@@ -22,7 +22,7 @@
 using System;
 using System.Collections;
 using YamlDotNet.Core;
-using YamlDotNet.Serialization.ObjectFactories;
+using YamlDotNet.Serialization.Utilities;
 
 namespace YamlDotNet.Serialization.NodeDeserializers
 {
@@ -46,13 +46,24 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             var itemType = expectedType.GetElementType()!; // Arrays always have an element type
 
             var items = new ArrayList();
-            CollectionNodeDeserializer.DeserializeHelper(itemType, parser, nestedObjectDeserializer, items, true, enumNamingConvention);
+            Array? array = null;
+            CollectionNodeDeserializer.DeserializeHelper(itemType, parser, nestedObjectDeserializer, items, true, enumNamingConvention, PromiseResolvedHandler);
 
-            var array = Array.CreateInstance(itemType, items.Count);
+            array = Array.CreateInstance(itemType, items.Count);
             items.CopyTo(array, 0);
 
             value = array;
             return true;
+
+            void PromiseResolvedHandler(int index, object? value)
+            {
+                if (array == null)
+                {
+                    throw new InvalidOperationException("Destination array is still null");
+                }
+
+                array.SetValue(TypeConverter.ChangeType(value, itemType, enumNamingConvention), index);
+            }
         }
 
         private sealed class ArrayList : IList


### PR DESCRIPTION
Resolves #933 

The `ArrayNodeDeserializer` delegates the deserialization of elements to the `CollectionNodeDeserializer.DeserializeHelper`.  This, in turn, handles circular references by relying on the `IValuePromise.ValueAvailable` event to write all the resolved references to its `IList result` parameter.

However, because `ArrayNodeDeserializer` doesn't know the size of its resulting array beforehand, it uses a temporary `ArrayList` which it passes to `CollectionNodeDeserializer.DeserializeHelper`.  As a result, all resolved ValuePromise values are written to the temporary `ArrayList` instead of the final `Array`.

This PR fixes this by adding an optional `Action<int, object?>? promiseResolvedHandler` to `CollectionNodeDeserializer.DeserializeHelper`.  When provided, it is used when ValuePromises are resolved.  Otherwise, the existing behaviour is preserved.
