### PR TITLE
Fix for issue 943: improper parsing of hexadecimal and octal scalars

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -174,9 +174,7 @@ namespace YamlDotNet.Test.Serialization
                 .WithAttemptingUnquotedStringTypeDeserialization()
                 .Build();
 
-            var expected = yaml;
-
-            var result = deserializer.Deserialize<object>(new StringReader(expected));
+            var result = deserializer.Deserialize<object>(new StringReader(yaml));
 
             result.Should().Be(value);
         }
@@ -191,9 +189,7 @@ namespace YamlDotNet.Test.Serialization
                 .WithAttemptingUnquotedStringTypeDeserialization()
                 .Build();
 
-            var expected = yaml;
-
-            var result = deserializer.Deserialize<object>(new StringReader(expected));
+            var result = deserializer.Deserialize<object>(new StringReader(yaml));
 
             result.Should().Be(value);
         }

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -164,6 +164,34 @@ namespace YamlDotNet.Test.Serialization
             result.Should().Be(77744246530L);
         }
 
+        [Fact]
+        public void DeserializeScalarBase16FromUnknown()
+        {
+            IDeserializer deserializer = new DeserializerBuilder()
+                .WithAttemptingUnquotedStringTypeDeserialization()
+                .Build();
+
+            var expected = "0x8000";
+
+            var result = deserializer.Deserialize<object>(new StringReader(expected));
+
+            result.Should().Be((ulong)32768);
+        }
+
+        [Fact]
+        public void DeserializeScalarBase8FromUnknown()
+        {
+            IDeserializer deserializer = new DeserializerBuilder()
+                .WithAttemptingUnquotedStringTypeDeserialization()
+                .Build();
+
+            var expected = "0o100000";
+
+            var result = deserializer.Deserialize<object>(new StringReader(expected));
+
+            result.Should().Be((ulong)32768);
+        }
+
         [Theory]
         [InlineData(EnumExample.One)]
         [InlineData(EnumExample.One | EnumExample.Two)]

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -164,32 +164,38 @@ namespace YamlDotNet.Test.Serialization
             result.Should().Be(77744246530L);
         }
 
-        [Fact]
-        public void DeserializeScalarBase16FromUnknown()
+        [Theory]
+        [InlineData("0o0", 0)]
+        [InlineData("0x8000", 32768)]
+        [InlineData("0xFFFFFFFFFFFFFFFF", 18_446_744_073_709_551_615)]
+        public void DeserializeScalarBase16FromUnknown(string yaml, ulong value)
         {
             IDeserializer deserializer = new DeserializerBuilder()
                 .WithAttemptingUnquotedStringTypeDeserialization()
                 .Build();
 
-            var expected = "0x8000";
+            var expected = yaml;
 
             var result = deserializer.Deserialize<object>(new StringReader(expected));
 
-            result.Should().Be((ulong)32768);
+            result.Should().Be(value);
         }
 
-        [Fact]
-        public void DeserializeScalarBase8FromUnknown()
+        [Theory]
+        [InlineData("0o0", 0)]
+        [InlineData("0o100000", 32768)]
+        [InlineData("0o1777777777777777777777", 18_446_744_073_709_551_615)]
+        public void DeserializeScalarBase8FromUnknown(string yaml, ulong value)
         {
             IDeserializer deserializer = new DeserializerBuilder()
                 .WithAttemptingUnquotedStringTypeDeserialization()
                 .Build();
 
-            var expected = "0o100000";
+            var expected = yaml;
 
             var result = deserializer.Deserialize<object>(new StringReader(expected));
 
-            result.Should().Be((ulong)32768);
+            result.Should().Be(value);
         }
 
         [Theory]

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -355,24 +355,16 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                 default:
                     if (Regex.IsMatch(v, "0x[0-9a-fA-F]+")) //base16 number
                     {
-                        if (TryAndSwallow(() => Convert.ToByte(v, 16), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt16(v, 16), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt32(v, 16), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt64(v, 16), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToUInt64(v, 16), out result)) { }
+                        if (TryAndSwallow(() => Convert.ToUInt64(v, 16), out result)) { }
                         else
                         {
                             //we couldn't parse it, default to a string. It's probably to big.
                             result = v;
                         }
                     }
-                    else if (Regex.IsMatch(v, "0o[0-9a-fA-F]+")) //base8 number
+                    else if (Regex.IsMatch(v, "0o[0-7]+")) //base8 number
                     {
-                        if (TryAndSwallow(() => Convert.ToByte(v, 8), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt16(v, 8), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt32(v, 8), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt64(v, 8), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToUInt64(v, 8), out result)) { }
+                        if (TryAndSwallow(() => Convert.ToUInt64(v.Substring(2), 8), out result)) { }
                         else
                         {
                             //we couldn't parse it, default to a string. It's probably to big.


### PR DESCRIPTION
This is a fix for [issue 943](https://github.com/aaubry/YamlDotNet/issues/943) that I reported. The root of the issue is that parsing sometimes surprisingly resulted in negative numbers and there was no way to specify some positive values with hexadecimal or octal scalars. The problem stems from trying to guess the width of the value because YAML does not provide a means of doing this (see [issue 943](https://github.com/aaubry/YamlDotNet/issues/943) for details).

This changes the behavior for hexadecimal deserialization so I'm prepared for there to be some controversy here, but I think this is more in line with how a developer using the library might expect the deserialization to behave. 

This also fixes the issue with octal parsing which was not functioning properly before.
