### PR TITLE
Avoid closures in CachedTypeInspector

### DIFF
--- a/YamlDotNet.Benchmark/SerializationBenchmarks.cs
+++ b/YamlDotNet.Benchmark/SerializationBenchmarks.cs
@@ -19,7 +19,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using BenchmarkDotNet.Running;
-using YamlDotNet.Benchmark;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using YamlDotNet.Serialization;
 
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+namespace YamlDotNet.Benchmark;
+
+[MemoryDiagnoser]
+[MediumRunJob(RuntimeMoniker.Net80)]
+[MediumRunJob(RuntimeMoniker.Net47)]
+public class SerializationBenchmarks
+{
+    public class SampleRecord
+    {
+        public SampleRecord(string name, string description)
+        {
+            Name = name;
+            Description = description;
+        }
+
+        public string Name { get; private set; }
+        public string Description { get; private set; }
+    }
+
+    private readonly IReadOnlyCollection<SampleRecord> configs = Enumerable.Range(0, 10_000).Select(i => new SampleRecord("MyName", "MyDescription")).ToList();
+    private readonly ISerializer serializer = new SerializerBuilder().DisableAliases().Build();
+
+    [Benchmark]
+    public string Serializer()
+    {
+        return serializer.Serialize(configs);
+    }
+}

--- a/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
+++ b/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
@@ -1,14 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net47</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+      <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/YamlDotNet/Helpers/DictionaryExtensions.cs
+++ b/YamlDotNet/Helpers/DictionaryExtensions.cs
@@ -19,6 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
+using System.Collections.Concurrent;
+
 namespace YamlDotNet.Helpers
 {
     internal static class DictionaryExtensions
@@ -33,6 +36,29 @@ namespace YamlDotNet.Helpers
 
             dictionary.Add(key, value);
             return true;
+        }
+#endif
+
+#if NETSTANDARD2_0 || NETFRAMEWORK
+        public static TValue GetOrAdd<TKey, TValue, TArg>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg arg)
+        {
+            if (dictionary == null) { throw new ArgumentNullException("dictionary"); }
+            if (key == null) { throw new ArgumentNullException("key"); }
+            if (valueFactory == null) { throw new ArgumentNullException("valueFactory"); }
+
+            while (true)
+            {
+                if (dictionary.TryGetValue(key, out var value))
+                {
+                    return value;
+                }
+
+                value = valueFactory(key, arg);
+                if (dictionary.TryAdd(key, value))
+                {
+                    return value;
+                }
+            }
         }
 #endif
     }


### PR DESCRIPTION
The `CachedTypeInspector` creates a closure in order to capture the method parameters. This results in 2 allocations per object serialized. I switched to using the `ConcurrentDictionary.GetOrAdd()` method that takes a third context parameter in order to avoid allocations.

I also added an extension method as described in https://github.com/dotnet/runtime/issues/13978 for runtimes where the overload doesn't exist. I also updated the language version from 8 to 9 in order to get access to [static lambdas](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/static-anonymous-functions) in order to ensure that the lambdas don't capture.

This reduces allocations by about ~4% in the benchmark:

## Before

```
// * Summary *

BenchmarkDotNet v0.14.0, Windows 11 (10.0.22635.4010)
Intel Core i9-10940X CPU 3.30GHz, 1 CPU, 28 logical and 14 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]                       : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  MediumRun-.NET 8.0           : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  MediumRun-.NET Framework 4.7 : .NET Framework 4.8.1 (4.8.9261.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

| Method     | Job                          | Runtime            | Mean      | Error    | StdDev   | Gen0      | Gen1     | Gen2     | Allocated |
|----------- |----------------------------- |------------------- |----------:|---------:|---------:|----------:|---------:|---------:|----------:|
| Serializer | MediumRun-.NET 8.0           | .NET 8.0           |  50.25 ms | 1.055 ms | 1.578 ms | 2000.0000 | 500.0000 |        - |  24.44 MB |
| Serializer | MediumRun-.NET Framework 4.7 | .NET Framework 4.7 | 118.87 ms | 3.662 ms | 5.367 ms | 7800.0000 | 600.0000 | 200.0000 |     48 MB |

// * Warnings *
MinIterationTime
  SerializationBenchmarks.Serializer: MediumRun-.NET 8.0 -> The minimum observed iteration time is 93.442ms which is very small. It's recommended to increase it to at least 100ms using more operations.
```

## After

```
// * Summary *

BenchmarkDotNet v0.14.0, Windows 11 (10.0.22635.4010)
Intel Core i9-10940X CPU 3.30GHz, 1 CPU, 28 logical and 14 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]                       : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  MediumRun-.NET 8.0           : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  MediumRun-.NET Framework 4.7 : .NET Framework 4.8.1 (4.8.9261.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

| Method     | Job                          | Runtime            | Mean      | Error    | StdDev   | Gen0      | Gen1     | Allocated |
|----------- |----------------------------- |------------------- |----------:|---------:|---------:|----------:|---------:|----------:|
| Serializer | MediumRun-.NET 8.0           | .NET 8.0           |  49.40 ms | 1.186 ms | 1.701 ms | 2000.0000 | 500.0000 |  23.52 MB |
| Serializer | MediumRun-.NET Framework 4.7 | .NET Framework 4.7 | 115.33 ms | 5.518 ms | 8.259 ms | 7500.0000 | 500.0000 |  47.08 MB |

// * Warnings *
MinIterationTime
  SerializationBenchmarks.Serializer: MediumRun-.NET 8.0 -> The minimum observed iteration time is 89.875ms which is very small. It's recommended to increase it to at least 100ms using more operations.
```