### PR TITLE
Cache lookups to IEnumerable<IYamlTypeConverter>

### DIFF
--- a/YamlDotNet.Benchmark/SerializationBenchmarks.cs
+++ b/YamlDotNet.Benchmark/SerializationBenchmarks.cs
@@ -19,7 +19,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using BenchmarkDotNet.Running;
-using YamlDotNet.Benchmark;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using YamlDotNet.Serialization;
 
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+namespace YamlDotNet.Benchmark;
+
+[MemoryDiagnoser]
+[MediumRunJob(RuntimeMoniker.Net80)]
+[MediumRunJob(RuntimeMoniker.Net47)]
+public class SerializationBenchmarks
+{
+    public class SampleRecord
+    {
+        public SampleRecord(string name, string description)
+        {
+            Name = name;
+            Description = description;
+        }
+
+        public string Name { get; private set; }
+        public string Description { get; private set; }
+    }
+
+    private readonly IReadOnlyCollection<SampleRecord> configs = Enumerable.Range(0, 10_000).Select(i => new SampleRecord("MyName", "MyDescription")).ToList();
+    private readonly ISerializer serializer = new SerializerBuilder().DisableAliases().Build();
+
+    [Benchmark]
+    public string Serializer()
+    {
+        return serializer.Serialize(configs);
+    }
+}

--- a/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
+++ b/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
@@ -1,14 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net47</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+      <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ObjectNodeDeserializer.cs
@@ -42,7 +42,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
         private readonly bool enforceNullability;
         private readonly bool caseInsensitivePropertyMatching;
         private readonly bool enforceRequiredProperties;
-        private readonly IEnumerable<IYamlTypeConverter> typeConverters;
+        private readonly TypeConverterCache typeConverters;
 
         public ObjectNodeDeserializer(IObjectFactory objectFactory,
             ITypeInspector typeInspector,
@@ -64,7 +64,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
             this.enforceNullability = enforceNullability;
             this.caseInsensitivePropertyMatching = caseInsensitivePropertyMatching;
             this.enforceRequiredProperties = enforceRequiredProperties;
-            this.typeConverters = typeConverters;
+            this.typeConverters = new TypeConverterCache(typeConverters);
         }
 
         public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value, ObjectDeserializer rootDeserializer)
@@ -107,7 +107,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                     object? propertyValue;
                     if (property.ConverterType != null)
                     {
-                        var typeConverter = typeConverters.Single(x => x.GetType() == property.ConverterType)!;
+                        var typeConverter = typeConverters.GetConverterByType(property.ConverterType);
                         propertyValue = typeConverter.ReadYaml(parser, property.Type, rootDeserializer);
                     }
                     else

--- a/YamlDotNet/Serialization/NodeDeserializers/TypeConverterNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/TypeConverterNodeDeserializer.cs
@@ -23,22 +23,22 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using YamlDotNet.Core;
+using YamlDotNet.Serialization.Utilities;
 
 namespace YamlDotNet.Serialization.NodeDeserializers
 {
     public sealed class TypeConverterNodeDeserializer : INodeDeserializer
     {
-        private readonly IEnumerable<IYamlTypeConverter> converters;
+        private readonly TypeConverterCache converters;
 
         public TypeConverterNodeDeserializer(IEnumerable<IYamlTypeConverter> converters)
         {
-            this.converters = converters ?? throw new ArgumentNullException(nameof(converters));
+            this.converters = new TypeConverterCache(converters);
         }
 
         public bool Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value, ObjectDeserializer rootDeserializer)
         {
-            var converter = converters.FirstOrDefault(c => c.Accepts(expectedType));
-            if (converter == null)
+            if (!converters.TryGetConverterForType(expectedType, out var converter))
             {
                 value = null;
                 return false;

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/PreProcessingPhaseObjectGraphVisitorSkeleton.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/PreProcessingPhaseObjectGraphVisitorSkeleton.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using YamlDotNet.Serialization.Utilities;
 
 namespace YamlDotNet.Serialization.ObjectGraphVisitors
@@ -30,16 +31,20 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
     /// </summary>
     public abstract class PreProcessingPhaseObjectGraphVisitorSkeleton : IObjectGraphVisitor<Nothing>
     {
-        private readonly TypeConverterCache typeConverters;
+        protected readonly IEnumerable<IYamlTypeConverter> typeConverters; // This is kept for backwards compatibility for subclasses. Use typeConverterCache instead.
+        private readonly TypeConverterCache typeConverterCache;
 
         public PreProcessingPhaseObjectGraphVisitorSkeleton(IEnumerable<IYamlTypeConverter> typeConverters)
         {
-            this.typeConverters = new TypeConverterCache(typeConverters);
+            var tcs = typeConverters?.ToArray() ?? Array.Empty<IYamlTypeConverter>();
+
+            this.typeConverters = tcs;
+            this.typeConverterCache = new TypeConverterCache(tcs);
         }
 
         bool IObjectGraphVisitor<Nothing>.Enter(IPropertyDescriptor? propertyDescriptor, IObjectDescriptor value, Nothing context, ObjectSerializer serializer)
         {
-            if (typeConverters.TryGetConverterForType(value.Type, out _))
+            if (typeConverterCache.TryGetConverterForType(value.Type, out _))
             {
                 return false;
             }

--- a/YamlDotNet/Serialization/ObjectGraphVisitors/PreProcessingPhaseObjectGraphVisitorSkeleton.cs
+++ b/YamlDotNet/Serialization/ObjectGraphVisitors/PreProcessingPhaseObjectGraphVisitorSkeleton.cs
@@ -21,7 +21,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using YamlDotNet.Serialization.Utilities;
 
 namespace YamlDotNet.Serialization.ObjectGraphVisitors
 {
@@ -30,19 +30,16 @@ namespace YamlDotNet.Serialization.ObjectGraphVisitors
     /// </summary>
     public abstract class PreProcessingPhaseObjectGraphVisitorSkeleton : IObjectGraphVisitor<Nothing>
     {
-        protected readonly IEnumerable<IYamlTypeConverter> typeConverters;
+        private readonly TypeConverterCache typeConverters;
 
         public PreProcessingPhaseObjectGraphVisitorSkeleton(IEnumerable<IYamlTypeConverter> typeConverters)
         {
-            this.typeConverters = typeConverters != null
-                ? typeConverters.ToList()
-                : Enumerable.Empty<IYamlTypeConverter>();
+            this.typeConverters = new TypeConverterCache(typeConverters);
         }
 
         bool IObjectGraphVisitor<Nothing>.Enter(IPropertyDescriptor? propertyDescriptor, IObjectDescriptor value, Nothing context, ObjectSerializer serializer)
         {
-            var typeConverter = typeConverters.FirstOrDefault(t => t.Accepts(value.Type));
-            if (typeConverter != null)
+            if (typeConverters.TryGetConverterForType(value.Type, out _))
             {
                 return false;
             }

--- a/YamlDotNet/Serialization/Utilities/TypeConverterCache.cs
+++ b/YamlDotNet/Serialization/Utilities/TypeConverterCache.cs
@@ -1,0 +1,104 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace YamlDotNet.Serialization.Utilities
+{
+    /// <summary>
+    /// A cache / map for <see cref="IYamlTypeConverter"/> instances.
+    /// </summary>
+    internal sealed class TypeConverterCache
+    {
+        private readonly IYamlTypeConverter[] typeConverters;
+        private readonly Dictionary<Type, (bool HasMatch, IYamlTypeConverter TypeConverter)> cache = new();
+
+        public TypeConverterCache(IEnumerable<IYamlTypeConverter>? typeConverters)
+        {
+            this.typeConverters = typeConverters != null
+                ? typeConverters.ToArray()
+                : Array.Empty<IYamlTypeConverter>();
+        }
+
+        /// <summary>
+        /// Returns the first <see cref="IYamlTypeConverter"/> that accepts the given type.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to lookup.</param>
+        /// <param name="typeConverter">The <see cref="IYamlTypeConverter" /> that accepts this type or <see langword="false" /> if no converter is found.</param>
+        /// <returns><see langword="true"/> if a type converter was found; <see langword="false"/> otherwise.</returns>
+        public bool TryGetConverterForType(Type type, [NotNullWhen(true)] out IYamlTypeConverter? typeConverter)
+        {
+            if (cache.TryGetValue(type, out var result))
+            {
+                typeConverter = result.TypeConverter;
+                return result.HasMatch;
+            }
+
+            typeConverter = LookupTypeConverter(type);
+
+            var found = typeConverter is not null;
+            cache[type] = (found, typeConverter!);
+
+            return found;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="IYamlTypeConverter"/> of the given type.
+        /// </summary>
+        /// <param name="converter">The type of the converter.</param>
+        /// <returns>The <see cref="IYamlTypeConverter"/> of the given type.</returns>
+        /// <exception cref="ArgumentException">If no type converter of the given type is found.</exception>
+        /// <remarks>
+        /// Note that this method searches on the type of the <see cref="IYamlTypeConverter"/> itself. If you want to find a type converter
+        /// that accepts a given <see cref="Type"/>, use <see cref="TryGetConverterForType(Type, out IYamlTypeConverter?)"/> instead.
+        /// </remarks>
+        public IYamlTypeConverter GetConverterByType(Type converter)
+        {
+            // Intentially avoids LINQ as this is on a hot path
+            foreach (var typeConverter in typeConverters)
+            {
+                if (typeConverter.GetType() == converter)
+                {
+                    return typeConverter;
+                }
+            }
+
+            throw new ArgumentException($"{nameof(IYamlTypeConverter)} of type {converter.FullName} not found", nameof(converter));
+        }
+
+        private IYamlTypeConverter? LookupTypeConverter(Type type)
+        {
+            // Intentially avoids LINQ as this is on a hot path
+            foreach (var typeConverter in typeConverters)
+            {
+                if (typeConverter.Accepts(type))
+                {
+                    return typeConverter;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/YamlDotNet/Serialization/Utilities/TypeConverterCache.cs
+++ b/YamlDotNet/Serialization/Utilities/TypeConverterCache.cs
@@ -34,11 +34,13 @@ namespace YamlDotNet.Serialization.Utilities
         private readonly IYamlTypeConverter[] typeConverters;
         private readonly Dictionary<Type, (bool HasMatch, IYamlTypeConverter TypeConverter)> cache = new();
 
-        public TypeConverterCache(IEnumerable<IYamlTypeConverter>? typeConverters)
+        public TypeConverterCache(IEnumerable<IYamlTypeConverter>? typeConverters) : this(typeConverters?.ToArray() ?? Array.Empty<IYamlTypeConverter>())
         {
-            this.typeConverters = typeConverters != null
-                ? typeConverters.ToArray()
-                : Array.Empty<IYamlTypeConverter>();
+        }
+
+        public TypeConverterCache(IYamlTypeConverter[] typeConverters)
+        {
+            this.typeConverters = typeConverters;
         }
 
         /// <summary>


### PR DESCRIPTION
Several types accept an `IEnumerable<IYamlTypeConverter>`, and then repeatedly traverse the list searching for a converter that accepts the type to be serialized. Traversing an IEnumerable with LINQ results in an enumerator (to walk the `IEnumerable`) and a Func (to filter the enumerable) allocation per visitor per object serialized. In the benchmark setup this results in 12 allocations per object serialized.

To avoid the repeated lookups and allocations, I introduced an internal `TypeConverterCache` that accepts the collection of type converters and maps the type to convert to the first `IYamlTypeConverter` that accepts the type (the same as the previous behavior). This eliminates all 12 allocations and has a small CPU time win as well.

To avoid a breaking change, I left the `protected IEnumerable<IYamlTypeConverter>` and added a `private TypeConverterCache` on `PreProcessingPhaseObjectGraphVisitorSkeleton`. If / when we want to remove cruft and can accept breaking changes we can remove this field.

Note that each type that previously was doing list traversal has its own cache. If it's OK to change the constructor signature on these types, we could instead construct a single cache in the builder (e.g. in `BuilderSkeleton.BuildTypeConverters`) and pass it in. However, I assume the builder is designed for public extension, so I avoided that in this change.

In the provided benchmark, this results in a 15% - 25% reduction in allocations:

## Before

```
// * Summary *

BenchmarkDotNet v0.14.0, Windows 11 (10.0.22635.4010)
Intel Core i9-10940X CPU 3.30GHz, 1 CPU, 28 logical and 14 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]                       : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  MediumRun-.NET 8.0           : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  MediumRun-.NET Framework 4.7 : .NET Framework 4.8.1 (4.8.9261.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

| Method     | Job                          | Runtime            | Mean      | Error    | StdDev   | Gen0      | Gen1     | Gen2     | Allocated |
|----------- |----------------------------- |------------------- |----------:|---------:|---------:|----------:|---------:|---------:|----------:|
| Serializer | MediumRun-.NET 8.0           | .NET 8.0           |  49.16 ms | 1.436 ms | 2.105 ms | 2000.0000 | 500.0000 |        - |  24.44 MB |
| Serializer | MediumRun-.NET Framework 4.7 | .NET Framework 4.7 | 109.79 ms | 2.546 ms | 3.569 ms | 7800.0000 | 600.0000 | 200.0000 |     48 MB |

// * Warnings *
MinIterationTime
  SerializationBenchmarks.Serializer: MediumRun-.NET 8.0 -> The minimum observed iteration time is 91.906ms which is very small. It's recommended to increase it to at least 100ms using more operations.

// * Hints *
Outliers
  SerializationBenchmarks.Serializer: MediumRun-.NET 8.0           -> 1 outlier  was  removed (57.76 ms)
  SerializationBenchmarks.Serializer: MediumRun-.NET Framework 4.7 -> 2 outliers were removed (121.75 ms, 123.43 ms)
```

## After

```
// * Summary *

BenchmarkDotNet v0.14.0, Windows 11 (10.0.22635.4010)
Intel Core i9-10940X CPU 3.30GHz, 1 CPU, 28 logical and 14 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]                       : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  MediumRun-.NET 8.0           : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  MediumRun-.NET Framework 4.7 : .NET Framework 4.8.1 (4.8.9261.0), X64 RyuJIT VectorSize=256

IterationCount=15  LaunchCount=2  WarmupCount=10

| Method     | Job                          | Runtime            | Mean      | Error    | StdDev   | Gen0      | Gen1     | Gen2     | Allocated |
|----------- |----------------------------- |------------------- |----------:|---------:|---------:|----------:|---------:|---------:|----------:|
| Serializer | MediumRun-.NET 8.0           | .NET 8.0           |  46.67 ms | 1.620 ms | 2.425 ms | 1500.0000 | 500.0000 |        - |  17.95 MB |
| Serializer | MediumRun-.NET Framework 4.7 | .NET Framework 4.7 | 108.68 ms | 3.342 ms | 5.002 ms | 6600.0000 | 600.0000 | 200.0000 |  41.49 MB |

// * Warnings *
MultimodalDistribution
  SerializationBenchmarks.Serializer: MediumRun-.NET 8.0 -> It seems that the distribution can have several modes (mValue = 2.83)
MinIterationTime
  SerializationBenchmarks.Serializer: MediumRun-.NET 8.0 -> The minimum observed iteration time is 85.323ms which is very small. It's recommended to increase it to at least 100ms using more operations.

// * Hints *
Outliers
  SerializationBenchmarks.Serializer: MediumRun-.NET 8.0           -> 1 outlier  was  removed (52.89 ms)
  SerializationBenchmarks.Serializer: MediumRun-.NET Framework 4.7 -> 1 outlier  was  removed (122.13 ms)
```