### PR TITLE
Support keys larger > 1024 characters

### DIFF
--- a/YamlDotNet.Test/Core/ScannerTests.cs
+++ b/YamlDotNet.Test/Core/ScannerTests.cs
@@ -311,6 +311,23 @@ namespace YamlDotNet.Test.Core
         }
 
         [Fact]
+        public void SupportRealyLongStrings()
+        {
+            var longKey = string.Concat(Enumerable.Repeat("x", 1500));
+            var yamlString = $"{longKey}: value";
+            var scanner = new Scanner(new StringReader(yamlString), true, 1500);
+            AssertSequenceOfTokensFrom(scanner,
+                StreamStart,
+                BlockMappingStart,
+                Key,
+                PlainScalar(longKey),
+                Value,
+                PlainScalar("value"),
+                BlockEnd,
+                StreamEnd);
+        }
+
+        [Fact]
         public void CommentsAreReturnedWhenRequested()
         {
             AssertSequenceOfTokensFrom(new Scanner(Yaml.ReaderForText(@"

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -79,6 +79,7 @@ namespace YamlDotNet.Core
         private Token? previous;
         private Anchor? previousAnchor;
         private Scalar? lastScalar = null;
+        private readonly int maxKeySize;
 
         private bool IsDocumentStart() =>
             !analyzer.EndOfInput &&
@@ -116,11 +117,23 @@ namespace YamlDotNet.Core
         /// </summary>
         /// <param name="input">The input.</param>
         /// <param name="skipComments">Indicates whether comments should be ignored</param>
-        public Scanner(TextReader input, bool skipComments = true)
+        public Scanner(TextReader input, bool skipComments = true):
+            this(input, skipComments, 1024)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Scanner"/> class.
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="skipComments">Indicates whether comments should be ignored</param>
+        /// <param name="maxKeySize">Override the default of 1024 characters for the max key size</param>
+        public Scanner(TextReader input, bool skipComments, int maxKeySize)
         {
             analyzer = new CharacterAnalyzer<LookAheadBuffer>(new LookAheadBuffer(input, 1024));
             cursor = new Cursor();
             SkipComments = skipComments;
+            this.maxKeySize = maxKeySize;
         }
 
         /// <summary>
@@ -265,7 +278,7 @@ namespace YamlDotNet.Core
                 //  - is shorter than 1024 characters.
 
 
-                if (key.IsPossible && (key.Line < cursor.Line || key.Index + 1024 < cursor.Index))
+                if (key.IsPossible && (key.Line < cursor.Line || key.Index + maxKeySize < cursor.Index))
                 {
 
                     // Check if the potential simple key to be removed is required.

--- a/YamlDotNet/Core/Scanner.cs
+++ b/YamlDotNet/Core/Scanner.cs
@@ -117,8 +117,8 @@ namespace YamlDotNet.Core
         /// </summary>
         /// <param name="input">The input.</param>
         /// <param name="skipComments">Indicates whether comments should be ignored</param>
-        public Scanner(TextReader input, bool skipComments = true):
-            this(input, skipComments, 1024)
+        public Scanner(TextReader input, bool skipComments = true)
+            : this(input, skipComments, 1024)
         {
         }
 


### PR DESCRIPTION
Fixes #942 
To use, new up the scanner and specify the overriden maximum key length, when deserializing use the scanner. Here is an example:

```csharp
[Fact]
public void SupportRealyLongStrings()
{
    var longKey = string.Concat(Enumerable.Repeat("x", 1500));
    var yamlString = $"{longKey}: value";
    var scanner = new Scanner(new StringReader(yamlString), true, 1500);
    var deserializer = new DeserializerBuilder().Build();
    var yaml = deserializer.Deserialize<Dictionary<string, object>>(scanner);
    Assert.Equal(longKey, $"'{yaml.Keys.First()}'");
}
```