### PR TITLE
Dont use enummember attribute when it's null or empty

### DIFF
--- a/YamlDotNet.Analyzers.StaticGenerator/SerializableSyntaxReceiver.cs
+++ b/YamlDotNet.Analyzers.StaticGenerator/SerializableSyntaxReceiver.cs
@@ -210,7 +210,10 @@ namespace YamlDotNet.Analyzers.StaticGenerator
                         if (enumMember != null)
                         {
                             var argument = enumMember.NamedArguments.FirstOrDefault(x => x.Key == "Value");
-                            memberValue = (string)argument.Value.Value!;
+                            if (!string.IsNullOrWhiteSpace(argument.Value.Value as string))
+                            {
+                                memberValue = (string)argument.Value.Value!;
+                            }
                         }
                         mappings.Add(new EnumMappings(type, memberName, memberValue));
                     }

--- a/YamlDotNet.Test/Analyzers/StaticGenerator/ObjectTests.cs
+++ b/YamlDotNet.Test/Analyzers/StaticGenerator/ObjectTests.cs
@@ -202,11 +202,45 @@ SomeDictionary:
         }
 
         [Fact]
+        public void EnumDeserializedUsesEnumNameWhenMemberIsEmpty()
+        {
+            var deserializer = new StaticDeserializerBuilder(new StaticContext()).Build();
+            var yaml = "EmptyValue";
+            var actual = deserializer.Deserialize<EnumMemberedEnum>(yaml);
+            Assert.Equal(EnumMemberedEnum.EmptyValue, actual);
+        }
+
+        [Fact]
+        public void EnumDeserializedUsesEnumNameWhenMemberIsNull()
+        {
+            var deserializer = new StaticDeserializerBuilder(new StaticContext()).Build();
+            var yaml = "NullValue";
+            var actual = deserializer.Deserialize<EnumMemberedEnum>(yaml);
+            Assert.Equal(EnumMemberedEnum.NullValue, actual);
+        }
+
+        [Fact]
         public void EnumSerializationUsesEnumMemberAttribute()
         {
             var serializer = new StaticSerializerBuilder(new StaticContext()).Build();
             var actual = serializer.Serialize(EnumMemberedEnum.Hello);
             Assert.Equal("goodbye", actual.TrimNewLines());
+        }
+
+        [Fact]
+        public void EnumSerializationUsesEnumMemberAttributeWithEmptyValue()
+        {
+            var serializer = new StaticSerializerBuilder(new StaticContext()).Build();
+            var actual = serializer.Serialize(EnumMemberedEnum.EmptyValue);
+            Assert.Equal("EmptyValue", actual.TrimNewLines());
+        }
+
+        [Fact]
+        public void EnumSerializationUsesEnumMemberAttributeWithNullValue()
+        {
+            var serializer = new StaticSerializerBuilder(new StaticContext()).Build();
+            var actual = serializer.Serialize(EnumMemberedEnum.NullValue);
+            Assert.Equal("NullValue", actual.TrimNewLines());
         }
 
         [YamlSerializable]
@@ -215,7 +249,13 @@ SomeDictionary:
             No = 0,
 
             [System.Runtime.Serialization.EnumMember(Value = "goodbye")]
-            Hello = 1
+            Hello = 1,
+
+            [System.Runtime.Serialization.EnumMember(Value = "")]
+            EmptyValue = 2,
+
+            [System.Runtime.Serialization.EnumMember()]
+            NullValue = 3
         }
 #endif
         [Fact]

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -516,12 +516,36 @@ Property: test-property";
             Assert.Equal(EnumMemberedEnum.Hello, actual);
         }
 
+        [Fact]
+        public void EnumDeserializedUsesEnumNameWhenMemberIsEmpty()
+        {
+            var deserializer = new DeserializerBuilder().Build();
+            var yaml = "EmptyValue";
+            var actual = deserializer.Deserialize<EnumMemberedEnum>(yaml);
+            Assert.Equal(EnumMemberedEnum.EmptyValue, actual);
+        }
+
+        [Fact]
+        public void EnumDeserializedUsesEnumNameWhenMemberIsNull()
+        {
+            var deserializer = new DeserializerBuilder().Build();
+            var yaml = "NullValue";
+            var actual = deserializer.Deserialize<EnumMemberedEnum>(yaml);
+            Assert.Equal(EnumMemberedEnum.NullValue, actual);
+        }
+
         public enum EnumMemberedEnum
         {
             No = 0,
 
             [System.Runtime.Serialization.EnumMember(Value = "goodbye")]
-            Hello = 1
+            Hello = 1,
+
+            [System.Runtime.Serialization.EnumMember(Value = "")]
+            EmptyValue = 2,
+
+            [System.Runtime.Serialization.EnumMember()]
+            NullValue = 3
 
         }
 #endif

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -1498,10 +1498,32 @@ y:
             Assert.Equal("goodbye", actual.TrimNewLines());
         }
 
+        [Fact]
+        public void EnumSerializationUsesEnumMemberAttributeWithEmptyValue()
+        {
+            var serializer = new SerializerBuilder().Build();
+            var actual = serializer.Serialize(EnumMemberedEnum.EmptyValue);
+            Assert.Equal("EmptyValue", actual.TrimNewLines());
+        }
+
+        [Fact]
+        public void EnumSerializationUsesEnumMemberAttributeWithNullValue()
+        {
+            var serializer = new SerializerBuilder().Build();
+            var actual = serializer.Serialize(EnumMemberedEnum.NullValue);
+            Assert.Equal("NullValue", actual.TrimNewLines());
+        }
+
         public enum EnumMemberedEnum
         {
             [System.Runtime.Serialization.EnumMember(Value = "goodbye")]
-            Hello = 1
+            Hello = 1,
+
+            [System.Runtime.Serialization.EnumMember(Value = "")]
+            EmptyValue = 2,
+
+            [System.Runtime.Serialization.EnumMember()]
+            NullValue = 3
         }
 #endif
 

--- a/YamlDotNet/Serialization/TypeInspectors/ReflectionTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReflectionTypeInspector.cs
@@ -59,7 +59,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
             if (enumMembers.Length > 0)
             {
                 var attribute = enumMembers[0].GetCustomAttribute<EnumMemberAttribute>();
-                if (attribute != null)
+                if (!string.IsNullOrWhiteSpace(attribute?.Value))
                 {
                     result = attribute.Value;
                 }


### PR DESCRIPTION
Fixes #966 