### PR TITLE
Fix build warnings in linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod
 RUN dpkg -i packages-microsoft-prod.deb
 RUN apt update
 RUN apt install -y dotnet-sdk-6.0
-RUN apt install -y dotnet-sdk-7.0
 
 FROM builder AS build
 WORKDIR /src
@@ -32,6 +31,7 @@ COPY YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.c
 COPY YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
 COPY YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj
 COPY YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.fsproj YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.fsproj
+COPY YamlDotNet.Fsharp.Test/YamlDotNet.Fsharp.Test.fsproj YamlDotNet.Fsharp.Test/YamlDotNet.Fsharp.Test.fsproj
 
 RUN dotnet restore YamlDotNet.sln
 
@@ -41,13 +41,11 @@ RUN dotnet build -c Release --framework net47 YamlDotNet/YamlDotNet.csproj -o /o
 RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.0
 RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
 RUN dotnet build -c Release --framework net6.0 YamlDotNet/YamlDotNet.csproj -o /output/net6.0
-RUN dotnet build -c Release --framework net7.0 YamlDotNet/YamlDotNet.csproj -o /output/net7.0
 RUN dotnet build -c Release --framework net8.0 YamlDotNet/YamlDotNet.csproj -o /output/net8.0
 
 RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
 
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net8.0 --logger:"trx;LogFileName=/output/tests-net8.0.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net7.0 --logger:"trx;LogFileName=/output/tests-net7.0.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net6.0 --logger:"trx;LogFileName=/output/tests-net6.0.trx" --logger:"console;Verbosity=detailed"
 
 FROM alpine

--- a/Dockerfile.NonEnglish
+++ b/Dockerfile.NonEnglish
@@ -18,7 +18,6 @@ RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod
 RUN dpkg -i packages-microsoft-prod.deb
 RUN apt update
 RUN apt install -y dotnet-sdk-6.0
-RUN apt install -y dotnet-sdk-7.0
 
 
 FROM builder AS build
@@ -34,6 +33,7 @@ COPY YamlDotNet.Analyzers.StaticGenerator/YamlDotNet.Analyzers.StaticGenerator.c
 COPY YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
 COPY YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj
 COPY YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.fsproj YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.fsproj
+COPY YamlDotNet.Fsharp.Test/YamlDotNet.Fsharp.Test.fsproj YamlDotNet.Fsharp.Test/YamlDotNet.Fsharp.Test.fsproj
 
 RUN dotnet restore YamlDotNet.sln
 
@@ -43,7 +43,6 @@ RUN dotnet build -c Release --framework net47 YamlDotNet/YamlDotNet.csproj -o /o
 RUN dotnet build -c Release --framework netstandard2.0 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.0
 RUN dotnet build -c Release --framework netstandard2.1 YamlDotNet/YamlDotNet.csproj -o /output/netstandard2.1
 RUN dotnet build -c Release --framework net6.0 YamlDotNet/YamlDotNet.csproj -o /output/net6.0
-RUN dotnet build -c Release --framework net7.0 YamlDotNet/YamlDotNet.csproj -o /output/net7.0
 RUN dotnet build -c Release --framework net8.0 YamlDotNet/YamlDotNet.csproj -o /output/net8.0
 
 RUN dotnet pack -c Release YamlDotNet/YamlDotNet.csproj -o /output/package /p:Version=$PACKAGE_VERSION
@@ -63,7 +62,6 @@ RUN echo -n "${LC_ALL}" > /etc/locale.gen && \
     locale-gen
 
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net8.0 --logger:"trx;LogFileName=/output/tests-net8.0.trx" --logger:"console;Verbosity=detailed"
-RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net7.0 --logger:"trx;LogFileName=/output/tests-net7.0.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework net6.0 --logger:"trx;LogFileName=/output/tests-net6.0.trx" --logger:"console;Verbosity=detailed"
 RUN dotnet test -c Release YamlDotNet.Test/YamlDotNet.Test.csproj --framework netcoreapp3.1 --logger:"trx;LogFileName=/output/tests-netcoreapp3.1.trx" --logger:"console;Verbosity=detailed"
 

--- a/YamlDotNet.Test/Serialization/TypeConverterAttributeTests.cs
+++ b/YamlDotNet.Test/Serialization/TypeConverterAttributeTests.cs
@@ -58,7 +58,7 @@ namespace YamlDotNet.Test.Serialization
             };
             var actual = serializer.Serialize(o).NormalizeNewLines().TrimNewLines();
             var expected = @"Value:
-  abc: def";
+  abc: def".NormalizeNewLines().TrimNewLines();
             Assert.Equal(expected, actual);
         }
 

--- a/YamlDotNet/Helpers/FsharpHelper.cs
+++ b/YamlDotNet/Helpers/FsharpHelper.cs
@@ -1,3 +1,24 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using YamlDotNet.Serialization;
 

--- a/YamlDotNet/Properties/AssemblyInfo.template
+++ b/YamlDotNet/Properties/AssemblyInfo.template
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#pragma warning disable IDE0055
 #if !UNITY
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -42,3 +43,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyInformationalVersion("<%assemblyInformationalVersion%>")]
 
 #endif
+#pragma warning restore IDE0055

--- a/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -27,6 +27,7 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace YamlDotNet.Serialization
 {
+#pragma warning disable IDE0055 // Fix formatting
     /// <summary>
     /// Common implementation of <see cref="SerializerBuilder" /> and <see cref="DeserializerBuilder" />.
     /// </summary>
@@ -35,6 +36,7 @@ namespace YamlDotNet.Serialization
 #pragma warning restore CA1708
         where TBuilder : BuilderSkeleton<TBuilder>
     {
+#pragma warning restore IDE0055
         internal INamingConvention namingConvention = NullNamingConvention.Instance;
         internal INamingConvention enumNamingConvention = NullNamingConvention.Instance;
         internal ITypeResolver typeResolver;

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -37,7 +37,7 @@ using YamlDotNet.Serialization.TypeResolvers;
 
 namespace YamlDotNet.Serialization
 {
-
+#pragma warning disable IDE0055 // Fix formatting
     /// <summary>
     /// Creates and configures instances of <see cref="Serializer" />.
     /// This class is used to customize the behavior of <see cref="Serializer" />. Use the relevant methods
@@ -50,6 +50,7 @@ namespace YamlDotNet.Serialization
 #endif
     public sealed class SerializerBuilder : BuilderSkeleton<SerializerBuilder>
     {
+#pragma warning restore IDE0055
         private ObjectGraphTraversalStrategyFactory objectGraphTraversalStrategyFactory;
         private readonly LazyComponentRegistrationList<IEnumerable<IYamlTypeConverter>, IObjectGraphVisitor<Nothing>> preProcessingPhaseObjectGraphVisitorFactories;
         private readonly LazyComponentRegistrationList<EmissionPhaseObjectGraphVisitorArgs, IObjectGraphVisitor<IEmitter>> emissionPhaseObjectGraphVisitorFactories;

--- a/YamlDotNet/Serialization/Utilities/TypeConverter.cs
+++ b/YamlDotNet/Serialization/Utilities/TypeConverter.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.ComponentModel;
 using YamlDotNet.Helpers;
@@ -224,24 +225,12 @@ namespace YamlDotNet.Serialization.Utilities
             // Default to the Convert class
             return Convert.ChangeType(value, destinationType, CultureInfo.InvariantCulture);
         }
-    }
-}
 
-#if !(NETSTANDARD1_3 || UNITY)
-namespace YamlDotNet.Serialization.Utilities
-{
-    using System.Linq;
-
-    partial class TypeConverter
-    {
         /// <summary>
         /// Registers a <see cref="System.ComponentModel.TypeConverter"/> dynamically.
         /// </summary>
         /// <typeparam name="TConvertible">The type to which the converter should be associated.</typeparam>
         /// <typeparam name="TConverter">The type of the converter.</typeparam>
-#if NET20 || NET35 || NET45
-        [System.Security.Permissions.PermissionSet(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
-#endif
         public static void RegisterTypeConverter<TConvertible, TConverter>()
             where TConverter : System.ComponentModel.TypeConverter
         {
@@ -257,4 +246,3 @@ namespace YamlDotNet.Serialization.Utilities
 
     }
 }
-#endif


### PR DESCRIPTION
Fixes the dockerfile and the build warnings (formatting and a file header) in Linux. Note. Those warnings did not show up on Windows.

Should help with #968 