### PR TITLE
Prevent forced quoting of strings with leading backslash

### DIFF
--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -450,6 +450,7 @@ namespace YamlDotNet.Test.Core
             var events = StreamOf(DocumentWith(new Scalar(input)));
             var yaml = EmittedTextFrom(events);
             yaml.Should().NotContain("\'");
+            yaml.Should().NotContain("\"");
         }
 
         private string Lines(params string[] lines)

--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -445,7 +445,7 @@ namespace YamlDotNet.Test.Core
 
         [Theory]
         [InlineData(@"\hello world")]
-        public void LeadingBackslashIsNotQuotedUnlessNecessary(string input)
+        public void LeadingBackslashIsNotQuoted(string input)
         {
             var events = StreamOf(DocumentWith(new Scalar(input)));
             var yaml = EmittedTextFrom(events);

--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -443,6 +443,15 @@ namespace YamlDotNet.Test.Core
             yaml.Should().NotContain("\"");
         }
 
+        [Theory]
+        [InlineData(@"\hello world")]
+        public void LeadingBackslashIsNotQuotedUnlessNecessary(string input)
+        {
+            var events = StreamOf(DocumentWith(new Scalar(input)));
+            var yaml = EmittedTextFrom(events);
+            yaml.Should().NotContain("\'");
+        }
+
         private string Lines(params string[] lines)
         {
             return string.Join(Environment.NewLine, lines);

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -340,7 +340,7 @@ namespace YamlDotNet.Core
             {
                 if (isFirst)
                 {
-                    if (buffer.Check(@"#,[]{}&*!|>\""%@`'"))
+                    if (buffer.Check(@"#,[]{}&*!|>""%@`'"))
                     {
                         flowIndicators = true;
                         blockIndicators = true;


### PR DESCRIPTION
The Emitter is currently treating the backslash character (\\) as a block/flow indicator and forcing quoting of Scalars that begin with "\\". 

According to spec https://yaml.org/spec/1.2.2/#indicator-characters backslash is not an indicator character and should not need quoting.
