### PR TITLE
Warnings as errors and compiler error cleanup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <WarningLevel>9999</WarningLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="$(Configuration) == 'Release'" Label="Code style enforcement">
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="FakeItEasy" Version="6.2.1" />
     <PackageVersion Include="FluentAssertions" Version="4.19.2" />
+    <PackageVersion Include="FSharp.Core" Version="8.0.400" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />

--- a/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
+++ b/YamlDotNet.Benchmark/YamlDotNet.Benchmark.csproj
@@ -1,27 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net472</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
 
-    <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-      <PackageReference Include="System.Collections.Immutable" />
-      <PackageReference Include="System.Reflection.Metadata" />
-    </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Reflection.Metadata" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\YamlDotNet\YamlDotNet.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\YamlDotNet\YamlDotNet.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Update="Resources\*" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="Resources\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 
 </Project>

--- a/YamlDotNet.Core7AoTCompileTest.Model/ExternalModel.cs
+++ b/YamlDotNet.Core7AoTCompileTest.Model/ExternalModel.cs
@@ -1,4 +1,25 @@
-﻿namespace YamlDotNet.Core7AoTCompileTest.Model;
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace YamlDotNet.Core7AoTCompileTest.Model;
 
 public class ExternalModel
 {

--- a/YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj
+++ b/YamlDotNet.Core7AoTCompileTest.Model/YamlDotNet.Core7AoTCompileTest.Model.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
+++ b/YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
@@ -6,7 +6,6 @@
     <PublishAot>true</PublishAot>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <Nullable>enable</Nullable>
-    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-AOT|AnyCPU' ">
@@ -17,7 +16,6 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/YamlDotNet.Fsharp.Test/DeserializerTests.fs
+++ b/YamlDotNet.Fsharp.Test/DeserializerTests.fs
@@ -8,29 +8,33 @@ open YamlDotNet.Serialization.NamingConventions
 open System.ComponentModel
 
 [<CLIMutable>]
-type Spec = {
-    EngineType: string
-    DriveType: string
-}
+type Spec =
+    {
+        EngineType: string
+        DriveType: string
+    }
 
 [<CLIMutable>]
-type Car = {
-    Name: string
-    Year: int
-    Spec: Spec option
-    Nickname: string option
-}
+type Car =
+    {
+        Name: string
+        Year: int
+        Spec: Spec option
+        Nickname: string option
+    }
 
 [<CLIMutable>]
-type Person = {
-    Name: string
-    MomentOfBirth: DateTime
-    Cars: Car array
-}
+type Person =
+    {
+        Name: string
+        MomentOfBirth: DateTime
+        Cars: Car array
+    }
 
 [<Fact>]
-let Deserialize_YamlWithScalarOptions() =
-    let yaml = """
+let Deserialize_YamlWithScalarOptions () =
+    let yaml =
+        """
 name: Jack
 momentOfBirth: 1983-04-21T20:21:03.0041599Z
 cars:
@@ -40,21 +44,24 @@ cars:
 - name: Honda
   year: 2021
 """
-    let sut = DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build()
+
+    let sut =
+        DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build()
 
     let person = sut.Deserialize<Person>(yaml)
     Assert.Equal("Jack", person.Name)
     Assert.Equal(2, person.Cars.Length)
     Assert.Equal("Mercedes", person.Cars[0].Name)
-    Assert.Equal(Some "Jessy", person.Cars[0].Nickname)// |> should equal (Some "Jessy")
+    Assert.Equal(Some "Jessy", person.Cars[0].Nickname) // |> should equal (Some "Jessy")
     Assert.Equal("Honda", person.Cars[1].Name)
     Assert.Equal(None, person.Cars[1].Nickname)
 
 [<Fact>]
-let Deserialize_YamlWithObjectOptions() =
-    let yaml = """
+let Deserialize_YamlWithObjectOptions () =
+    let yaml =
+        """
 name: Jack
 momentOfBirth: 1983-04-21T20:21:03.0041599Z
 cars:
@@ -66,48 +73,56 @@ cars:
 - name: Honda
   year: 2021
 """
-    let sut = DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build()
+
+    let sut =
+        DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build()
 
     let person = sut.Deserialize<Person>(yaml)
     Assert.Equal("Jack", person.Name)
     Assert.Equal(2, person.Cars.Length)
-    
+
     Assert.Equal("Mercedes", person.Cars[0].Name)
     Assert.NotNull(person.Cars[0].Spec)
     Assert.True(person.Cars[0].Spec |> Option.isSome)
     Assert.Equal("V6", person.Cars[0].Spec.Value.EngineType)
     Assert.Equal("AWD", person.Cars[0].Spec.Value.DriveType)
-    
+
     Assert.Equal("Honda", person.Cars[1].Name)
     Assert.Null(person.Cars[1].Spec)
     Assert.Equal(None, person.Cars[1].Spec)
     Assert.Equal(None, person.Cars[1].Nickname)
 
-
 [<CLIMutable>]
-type TestSeq = {
-  name: string
-  numbers: int seq
-}
+[<NoComparison>]
+type TestSeq = { name: string; numbers: int seq }
 
 [<Fact>]
-let Deserialize_YamlSeq() =
-    let jackTheDriver = {
-        name = "Jack"
-        numbers = seq { 12; 2; 2 }
-    }
+let Deserialize_YamlSeq () =
+    let jackTheDriver =
+        {
+            name = "Jack"
+            numbers =
+                seq {
+                    12
+                    2
+                    2
+                }
+        }
 
-    let yaml = """name: Jack
+    let yaml =
+        """name: Jack
 numbers:
 - 12
 - 2
 - 2
 """
-    let sut = DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build()
+
+    let sut =
+        DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build()
 
     let person = sut.Deserialize<TestSeq>(yaml)
     Assert.Equal(jackTheDriver.name, person.name)
@@ -118,27 +133,28 @@ numbers:
     Assert.Equal(2, numbers[2])
 
 [<CLIMutable>]
-type TestList = {
-  name: string
-  numbers: int list
-}
+type TestList = { name: string; numbers: int list }
 
 [<Fact>]
-let Deserialize_YamlList() =
-    let jackTheDriver = {
-        name = "Jack"
-        numbers = [ 12; 2; 2 ]
-    }
+let Deserialize_YamlList () =
+    let jackTheDriver =
+        {
+            name = "Jack"
+            numbers = [ 12; 2; 2 ]
+        }
 
-    let yaml = """name: Jack
+    let yaml =
+        """name: Jack
 numbers:
 - 12
 - 2
 - 2
 """
-    let sut = DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build()
+
+    let sut =
+        DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build()
 
     let person = sut.Deserialize<TestList>(yaml)
     Assert.Equal(jackTheDriver.name, person.name)
@@ -148,29 +164,29 @@ numbers:
     Assert.Equal(2, numbers[1])
     Assert.Equal(2, numbers[2])
 
-
 [<CLIMutable>]
-type TestArray = {
-  name: string
-  numbers: int array
-}
+type TestArray = { name: string; numbers: int array }
 
 [<Fact>]
-let Deserialize_YamlArray() =
-    let jackTheDriver = {
-        name = "Jack"
-        numbers = [| 12; 2; 2 |]
-    }
+let Deserialize_YamlArray () =
+    let jackTheDriver =
+        {
+            name = "Jack"
+            numbers = [| 12; 2; 2 |]
+        }
 
-    let yaml = """name: Jack
+    let yaml =
+        """name: Jack
 numbers:
 - 12
 - 2
 - 2
 """
-    let sut = DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build()
+
+    let sut =
+        DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build()
 
     let person = sut.Deserialize<TestArray>(yaml)
     Assert.Equal(jackTheDriver.name, person.name)

--- a/YamlDotNet.Fsharp.Test/SerializerTests.fs
+++ b/YamlDotNet.Fsharp.Test/SerializerTests.fs
@@ -8,46 +8,56 @@ open YamlDotNet.Core
 open YamlDotNet.Fsharp.Test
 
 [<CLIMutable>]
-type Spec = {
-    EngineType: string
-    DriveType: string
-}
-
-[<CLIMutable>]
-type Car = {
-    Name: string
-    Year: int
-    Spec: Spec option
-    Nickname: string option
-}
-
-[<CLIMutable>]
-type Person = {
-    Name: string
-    MomentOfBirth: DateTime
-    KidsSeat: int option
-    Cars: Car array
-}
-
-[<Fact>]
-let Serialize_YamlWithScalarOptions() =
-    let jackTheDriver = {
-        Name = "Jack"
-        MomentOfBirth = DateTime(1983, 4, 21, 20, 21, 03, 4)
-        KidsSeat = Some 1
-        Cars = [|
-            { Name = "Mercedes"
-              Year = 2018
-              Nickname = Some "Jessy"
-              Spec = None };
-            { Name = "Honda"
-              Year = 2021
-              Nickname = None
-              Spec = None }
-        |]
+type Spec =
+    {
+        EngineType: string
+        DriveType: string
     }
 
-    let yaml = """name: Jack
+[<CLIMutable>]
+type Car =
+    {
+        Name: string
+        Year: int
+        Spec: Spec option
+        Nickname: string option
+    }
+
+[<CLIMutable>]
+type Person =
+    {
+        Name: string
+        MomentOfBirth: DateTime
+        KidsSeat: int option
+        Cars: Car array
+    }
+
+[<Fact>]
+let Serialize_YamlWithScalarOptions () =
+    let jackTheDriver =
+        {
+            Name = "Jack"
+            MomentOfBirth = DateTime(1983, 4, 21, 20, 21, 03, 4)
+            KidsSeat = Some 1
+            Cars =
+                [|
+                    {
+                        Name = "Mercedes"
+                        Year = 2018
+                        Nickname = Some "Jessy"
+                        Spec = None
+                    }
+                    {
+                        Name = "Honda"
+                        Year = 2021
+                        Nickname = None
+                        Spec = None
+                    }
+                |]
+        }
+
+    let yaml =
+        """name: Jack
 momentOfBirth: 1983-04-21T20:21:03.0040000
 kidsSeat: 1
 cars:
@@ -60,32 +70,41 @@ cars:
   spec: 
   nickname: 
 """
-    let sut = SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build()
+
+    let sut =
+        SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build()
 
     let person = sut.Serialize(jackTheDriver)
     Assert.Equal(yaml.Clean(), person.Clean())
 
 [<Fact>]
-let Serialize_YamlWithScalarOptions_OmitNull() =
-    let jackTheDriver = {
-        Name = "Jack"
-        MomentOfBirth = DateTime(1983, 4, 21, 20, 21, 03, 4)
-        KidsSeat = Some 1
-        Cars = [|
-            { Name = "Mercedes"
-              Year = 2018
-              Nickname = Some "Jessy"
-              Spec = None };
-            { Name = "Honda"
-              Year = 2021
-              Nickname = None
-              Spec = None }
-        |]
-    }
+let Serialize_YamlWithScalarOptions_OmitNull () =
+    let jackTheDriver =
+        {
+            Name = "Jack"
+            MomentOfBirth = DateTime(1983, 4, 21, 20, 21, 03, 4)
+            KidsSeat = Some 1
+            Cars =
+                [|
+                    {
+                        Name = "Mercedes"
+                        Year = 2018
+                        Nickname = Some "Jessy"
+                        Spec = None
+                    }
+                    {
+                        Name = "Honda"
+                        Year = 2021
+                        Nickname = None
+                        Spec = None
+                    }
+                |]
+        }
 
-    let yaml = """name: Jack
+    let yaml =
+        """name: Jack
 momentOfBirth: 1983-04-21T20:21:03.0040000
 kidsSeat: 1
 cars:
@@ -95,36 +114,42 @@ cars:
 - name: Honda
   year: 2021
 """
-    let sut = SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
-                .Build()
+
+    let sut =
+        SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+            .Build()
 
     let person = sut.Serialize(jackTheDriver)
     Assert.Equal(yaml.Clean(), person.Clean())
 
 [<Fact>]
-let Serialize_YamlWithObjectOptions_OmitNull() =
-    let jackTheDriver = {
-        Name = "Jack"
-        MomentOfBirth = DateTime(1983, 4, 21, 20, 21, 03, 4)
-        KidsSeat = Some 1
-        Cars = [|
-            { Name = "Mercedes"
-              Year = 2018
-              Nickname = None
-              Spec = Some {
-                EngineType = "V6"
-                DriveType = "AWD"
-              } };
-            { Name = "Honda"
-              Year = 2021
-              Nickname = None
-              Spec = None }
-        |]
-    }
+let Serialize_YamlWithObjectOptions_OmitNull () =
+    let jackTheDriver =
+        {
+            Name = "Jack"
+            MomentOfBirth = DateTime(1983, 4, 21, 20, 21, 03, 4)
+            KidsSeat = Some 1
+            Cars =
+                [|
+                    {
+                        Name = "Mercedes"
+                        Year = 2018
+                        Nickname = None
+                        Spec = Some { EngineType = "V6"; DriveType = "AWD" }
+                    }
+                    {
+                        Name = "Honda"
+                        Year = 2021
+                        Nickname = None
+                        Spec = None
+                    }
+                |]
+        }
 
-    let yaml = """name: Jack
+    let yaml =
+        """name: Jack
 momentOfBirth: 1983-04-21T20:21:03.0040000
 kidsSeat: 1
 cars:
@@ -136,91 +161,97 @@ cars:
 - name: Honda
   year: 2021
 """
-    let sut = SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
-                .Build()
+
+    let sut =
+        SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+            .Build()
 
     let person = sut.Serialize(jackTheDriver)
     Assert.Equal(yaml.Clean(), person.Clean())
 
 [<CLIMutable>]
-type TestSeq = {
-  name: string
-  numbers: int seq
-}
+[<NoComparison>]
+type TestSeq = { name: string; numbers: int seq }
 
 [<Fact>]
-let Serialize_YamlSeq() =
-    let jackTheDriver = {
-        name = "Jack"
-        numbers = [ 12; 2; 2 ]
-    }
+let Serialize_YamlSeq () =
+    let jackTheDriver =
+        {
+            name = "Jack"
+            numbers = [ 12; 2; 2 ]
+        }
 
-    let yaml = """name: Jack
+    let yaml =
+        """name: Jack
 numbers:
 - 12
 - 2
 - 2
 """
-    let sut = SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
-                .Build()
+
+    let sut =
+        SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+            .Build()
 
     let person = sut.Serialize(jackTheDriver)
     Assert.Equal(yaml.Clean(), person.Clean())
 
 [<CLIMutable>]
-type TestList = {
-  name: string
-  numbers: int list
-}
+type TestList = { name: string; numbers: int list }
 
 [<Fact>]
-let Serialize_YamlList() =
-    let jackTheDriver = {
-        name = "Jack"
-        numbers = [ 12; 2; 2 ]
-    }
+let Serialize_YamlList () =
+    let jackTheDriver =
+        {
+            name = "Jack"
+            numbers = [ 12; 2; 2 ]
+        }
 
-    let yaml = """name: Jack
+    let yaml =
+        """name: Jack
 numbers:
 - 12
 - 2
 - 2
 """
-    let sut = SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
-                .Build()
+
+    let sut =
+        SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+            .Build()
 
     let person = sut.Serialize(jackTheDriver)
     Assert.Equal(yaml.Clean(), person.Clean())
 
 [<CLIMutable>]
-type TestArray = {
-  name: string
-  numbers: int array
-}
+type TestArray = { name: string; numbers: int array }
 
 [<Fact>]
-let Serialize_YamlArray() =
-    let jackTheDriver = {
-        name = "Jack"
-        numbers = [| 12; 2; 2 |]
-    }
+let Serialize_YamlArray () =
+    let jackTheDriver =
+        {
+            name = "Jack"
+            numbers = [| 12; 2; 2 |]
+        }
 
-    let yaml = """name: Jack
+    let yaml =
+        """name: Jack
 numbers:
 - 12
 - 2
 - 2
 """
-    let sut = SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
-                .Build()
+
+    let sut =
+        SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+            .Build()
 
     let person = sut.Serialize(jackTheDriver)
     Assert.Equal(yaml.Clean(), person.Clean())

--- a/YamlDotNet.Fsharp.Test/StringExtensions.fs
+++ b/YamlDotNet.Fsharp.Test/StringExtensions.fs
@@ -7,9 +7,9 @@ type StringExtensions() =
     [<Extension>]
     static member NormalizeNewLines(x: string) =
         x.Replace("\r\n", "\n").Replace("\n", System.Environment.NewLine)
+
     [<Extension>]
-    static member TrimNewLines(x: string) =
-        x.TrimEnd('\r').TrimEnd('\n')
+    static member TrimNewLines(x: string) = x.TrimEnd('\r').TrimEnd('\n')
+
     [<Extension>]
-    static member Clean(x: string) =
-        x.NormalizeNewLines().TrimNewLines()
+    static member Clean(x: string) = x.NormalizeNewLines().TrimNewLines()

--- a/YamlDotNet.Fsharp.Test/YamlDotNet.Fsharp.Test.fsproj
+++ b/YamlDotNet.Fsharp.Test/YamlDotNet.Fsharp.Test.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0;net47</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -6,7 +6,7 @@
     <SignAssembly>true</SignAssembly>
     <LangVersion></LangVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <WarningLevel>5</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StringExtensions.fs" />
@@ -15,9 +15,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\YamlDotNet\YamlDotNet.csproj" />

--- a/YamlDotNet.Samples.Fsharp/DeserializeObjectGraph.fs
+++ b/YamlDotNet.Samples.Fsharp/DeserializeObjectGraph.fs
@@ -24,6 +24,7 @@ type Address =
       State: string }
 
 [<CLIMutable>]
+[<NoComparison>]
 type Order =
     { Receipt: string
       Date: DateTime

--- a/YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.fsproj
+++ b/YamlDotNet.Samples.Fsharp/YamlDotNet.Samples.Fsharp.fsproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion></LangVersion>
+    <WarningLevel>5</WarningLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/YamlDotNet.Samples/UseTypeConverters.cs
+++ b/YamlDotNet.Samples/UseTypeConverters.cs
@@ -33,7 +33,7 @@ namespace YamlDotNet.Samples
 {
     public class UseTypeConverters
     {
-        ITestOutputHelper output;
+        private readonly ITestOutputHelper output;
 
         public UseTypeConverters(ITestOutputHelper output)
         {

--- a/YamlDotNet.Test/Analyzers/StaticGenerator/RootCollectionTests.cs
+++ b/YamlDotNet.Test/Analyzers/StaticGenerator/RootCollectionTests.cs
@@ -80,7 +80,7 @@ a: hello
 b: world
 ";
 
-            var actual = (IDictionary<object, object>) deserializer.Deserialize<object>(yaml);
+            var actual = (IDictionary<object, object>)deserializer.Deserialize<object>(yaml);
             Assert.Equal("hello", actual["a"]);
             Assert.Equal("world", actual["b"]);
         }
@@ -96,9 +96,9 @@ b:
  Test: world
 ";
 
-            var actual = (IDictionary<object, object>) deserializer.Deserialize<object>(yaml);
-            Assert.Equal("hello", ((IDictionary<object,object>)actual["a"])["Test"]);
-            Assert.Equal("world", ((IDictionary<object,object>)actual["b"])["Test"]);
+            var actual = (IDictionary<object, object>)deserializer.Deserialize<object>(yaml);
+            Assert.Equal("hello", ((IDictionary<object, object>)actual["a"])["Test"]);
+            Assert.Equal("world", ((IDictionary<object, object>)actual["b"])["Test"]);
         }
     }
     [YamlSerializable]

--- a/YamlDotNet.Test/Core/ScannerTests.cs
+++ b/YamlDotNet.Test/Core/ScannerTests.cs
@@ -367,7 +367,7 @@ namespace YamlDotNet.Test.Core
                 }
             }
 
-            Assert.True(false, "Did not find a comment");
+            Assert.Fail("Did not find a comment");
         }
 
         [Fact]
@@ -463,7 +463,7 @@ namespace YamlDotNet.Test.Core
         [Fact]
         public void Keys_can_start_with_colons_in_nested_block()
         {
-           AssertSequenceOfTokensFrom(Yaml.ScannerForText("root:\n  :first: 1\n  :second: 2"),
+            AssertSequenceOfTokensFrom(Yaml.ScannerForText("root:\n  :first: 1\n  :second: 2"),
                 StreamStart,
                 BlockMappingStart,
                 Key,
@@ -484,9 +484,9 @@ namespace YamlDotNet.Test.Core
         }
 
         [Fact]
-        public void Keys_can_start_with_colons_after_quoted_values() 
+        public void Keys_can_start_with_colons_after_quoted_values()
         {
-           AssertSequenceOfTokensFrom(Yaml.ScannerForText(":first: '1'\n:second: 2"),
+            AssertSequenceOfTokensFrom(Yaml.ScannerForText(":first: '1'\n:second: 2"),
                 StreamStart,
                 BlockMappingStart,
                 Key,
@@ -502,9 +502,9 @@ namespace YamlDotNet.Test.Core
         }
 
         [Fact]
-        public void Keys_can_start_with_colons_after_single_quoted_values_in_nested_block() 
+        public void Keys_can_start_with_colons_after_single_quoted_values_in_nested_block()
         {
-           AssertSequenceOfTokensFrom(Yaml.ScannerForText("xyz:\n  :hello: 'world'\n  :goodbye: world"),
+            AssertSequenceOfTokensFrom(Yaml.ScannerForText("xyz:\n  :hello: 'world'\n  :goodbye: world"),
                 StreamStart,
                 BlockMappingStart,
                 Key,
@@ -525,26 +525,26 @@ namespace YamlDotNet.Test.Core
         }
 
         [Fact]
-        public void Keys_can_start_with_colons_after_double_quoted_values_in_nested_block() 
+        public void Keys_can_start_with_colons_after_double_quoted_values_in_nested_block()
         {
-           AssertSequenceOfTokensFrom(Yaml.ScannerForText("xyz:\n  :hello: \"world\"\n  :goodbye: world"),
-                StreamStart,
-                BlockMappingStart,
-                Key,
-                PlainScalar("xyz"),
-                Value,
-                BlockMappingStart,
-                Key,
-                PlainScalar(":hello"),
-                Value,
-                DoubleQuotedScalar("world"),
-                Key,
-                PlainScalar(":goodbye"),
-                Value,
-                PlainScalar("world"),
-                BlockEnd,
-                BlockEnd,
-                StreamEnd);
+            AssertSequenceOfTokensFrom(Yaml.ScannerForText("xyz:\n  :hello: \"world\"\n  :goodbye: world"),
+                 StreamStart,
+                 BlockMappingStart,
+                 Key,
+                 PlainScalar("xyz"),
+                 Value,
+                 BlockMappingStart,
+                 Key,
+                 PlainScalar(":hello"),
+                 Value,
+                 DoubleQuotedScalar("world"),
+                 Key,
+                 PlainScalar(":goodbye"),
+                 Value,
+                 PlainScalar("world"),
+                 BlockEnd,
+                 BlockEnd,
+                 StreamEnd);
         }
 
         [Fact]

--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -41,7 +41,7 @@ namespace YamlDotNet.Test.RepresentationModel
             var stream = new YamlStream();
             stream.Load(Yaml.ReaderFrom("02-scalar-in-imp-doc.yaml"));
 
-            Assert.Equal(1, stream.Documents.Count);
+            Assert.Single(stream.Documents);
             Assert.IsType<YamlScalarNode>(stream.Documents[0].RootNode);
             Assert.Equal("a scalar", ((YamlScalarNode)stream.Documents[0].RootNode).Value);
             Assert.Equal(YamlNodeType.Scalar, stream.Documents[0].RootNode.NodeType);
@@ -79,7 +79,7 @@ namespace YamlDotNet.Test.RepresentationModel
             var stream = new YamlStream();
             stream.Load(Yaml.ReaderFrom("backwards-alias.yaml"));
 
-            Assert.Equal(1, stream.Documents.Count);
+            Assert.Single(stream.Documents);
             Assert.IsType<YamlSequenceNode>(stream.Documents[0].RootNode);
 
             var sequence = (YamlSequenceNode)stream.Documents[0].RootNode;
@@ -97,7 +97,7 @@ namespace YamlDotNet.Test.RepresentationModel
             var stream = new YamlStream();
             stream.Load(Yaml.ReaderFrom("forward-alias.yaml"));
 
-            Assert.Equal(1, stream.Documents.Count);
+            Assert.Single(stream.Documents);
             Assert.IsType<YamlSequenceNode>(stream.Documents[0].RootNode);
 
             var sequence = (YamlSequenceNode)stream.Documents[0].RootNode;

--- a/YamlDotNet.Test/Serialization/BufferedDeserialization/KeyValueTypeDiscriminatorTests.cs
+++ b/YamlDotNet.Test/Serialization/BufferedDeserialization/KeyValueTypeDiscriminatorTests.cs
@@ -1,4 +1,4 @@
-// This file is part of YamlDotNet - A .NET library for YAML.
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
 // Copyright (c) Antoine Aubry and contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -37,7 +37,8 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddKeyValueTypeDiscriminator<KubernetesResource>(
                         "kind",
                         new Dictionary<string, Type>()
@@ -45,7 +46,7 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                             { "Namespace", typeof(KubernetesNamespace) },
                             { "Service", typeof(KubernetesService) }
                         });
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 40)
                 .Build();
@@ -59,7 +60,8 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddKeyValueTypeDiscriminator<KubernetesResource>(
                         "kind",
                         new Dictionary<string, Type>()
@@ -67,7 +69,7 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                             { "Namespace", typeof(KubernetesNamespace) },
                             { "Service", typeof(KubernetesService) }
                         });
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 40)
                 .Build();
@@ -76,13 +78,14 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
             resources[0].Should().BeOfType<KubernetesNamespace>();
             resources[1].Should().BeOfType<KubernetesService>();
         }
-        
+
         [Fact]
         public void KeyValueTypeDiscriminator_WithObjectBaseType_Single()
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddKeyValueTypeDiscriminator<object>(
                         "kind",
                         new Dictionary<string, Type>()
@@ -90,7 +93,7 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                             { "Namespace", typeof(KubernetesNamespace) },
                             { "Service", typeof(KubernetesService) }
                         });
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 40)
                 .Build();
@@ -104,7 +107,8 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddKeyValueTypeDiscriminator<object>(
                         "kind",
                         new Dictionary<string, Type>()
@@ -112,7 +116,7 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                             { "Namespace", typeof(KubernetesNamespace) },
                             { "Service", typeof(KubernetesService) }
                         });
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 30)
                 .Build();
@@ -127,7 +131,8 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddKeyValueTypeDiscriminator<IKubernetesResource>(
                         "kind",
                         new Dictionary<string, Type>()
@@ -135,7 +140,7 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                             { "Namespace", typeof(KubernetesNamespace) },
                             { "Service", typeof(KubernetesService) }
                         });
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 40)
                 .Build();
@@ -149,7 +154,8 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddKeyValueTypeDiscriminator<IKubernetesResource>(
                         "kind",
                         new Dictionary<string, Type>()
@@ -157,7 +163,7 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                             { "Namespace", typeof(KubernetesNamespace) },
                             { "Service", typeof(KubernetesService) }
                         });
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 30)
                 .Build();
@@ -172,7 +178,8 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddKeyValueTypeDiscriminator<KubernetesResource>(
                         "kind",
                         new Dictionary<string, Type>()
@@ -185,11 +192,11 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                         {
                             { "Service", typeof(KubernetesService) }
                         });
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 40)
                 .Build();
-            
+
             var resources = bufferedDeserializer.Deserialize<List<KubernetesResource>>(ListOfKubernetesYaml);
             resources[0].Should().BeOfType<KubernetesNamespace>();
             resources[1].Should().BeOfType<KubernetesService>();

--- a/YamlDotNet.Test/Serialization/BufferedDeserialization/TypeDiscriminatingNodeDeserializerTests.cs
+++ b/YamlDotNet.Test/Serialization/BufferedDeserialization/TypeDiscriminatingNodeDeserializerTests.cs
@@ -1,4 +1,4 @@
-// This file is part of YamlDotNet - A .NET library for YAML.
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
 // Copyright (c) Antoine Aubry and contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -37,9 +37,10 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
-                        options.AddKeyValueTypeDiscriminator<object>("kind", new Dictionary<string, Type>());
-                    },
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
+                    options.AddKeyValueTypeDiscriminator<object>("kind", new Dictionary<string, Type>());
+                },
                     maxDepth: 2,
                     maxLength: 40)
                 .Build();
@@ -51,15 +52,16 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
               .WithInnerException<ArgumentOutOfRangeException>()
               .Where(e => e.InnerException.Message.Contains("Parser buffer exceeded max depth"));
         }
-        
+
         [Fact]
         public void TypeDiscriminatingNodeDeserializer_ThrowsWhen_MaxLengthExceeded()
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
-                        options.AddKeyValueTypeDiscriminator<object>("kind", new Dictionary<string, Type>());
-                    },
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
+                    options.AddKeyValueTypeDiscriminator<object>("kind", new Dictionary<string, Type>());
+                },
                     maxDepth: 3,
                     maxLength: 20)
                 .Build();

--- a/YamlDotNet.Test/Serialization/BufferedDeserialization/UniqueKeyTypeDiscriminatorTests.cs
+++ b/YamlDotNet.Test/Serialization/BufferedDeserialization/UniqueKeyTypeDiscriminatorTests.cs
@@ -1,4 +1,4 @@
-// This file is part of YamlDotNet - A .NET library for YAML.
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
 // Copyright (c) Antoine Aubry and contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -37,7 +37,8 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddUniqueKeyTypeDiscriminator<ICharacter>(
                         new Dictionary<string, Type>()
                         {
@@ -45,7 +46,7 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                             { "avgDailyMeows", typeof(Cat) }
                         }
                     );
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 10)
                 .Build();
@@ -60,7 +61,8 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
         {
             var bufferedDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeDiscriminatingNodeDeserializer(options => {
+                .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
                     options.AddUniqueKeyTypeDiscriminator<object>(
                         new Dictionary<string, Type>()
                         {
@@ -68,7 +70,7 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
                             { "avgDailyMeows", typeof(Cat) }
                         }
                     );
-                    },
+                },
                     maxDepth: 3,
                     maxLength: 10)
                 .Build();

--- a/YamlDotNet.Test/Serialization/HiddenPropertyTests.cs
+++ b/YamlDotNet.Test/Serialization/HiddenPropertyTests.cs
@@ -36,7 +36,7 @@ namespace YamlDotNet.Test.Serialization
 
             public object Value => this.value;
 
-            [YamlIgnore] 
+            [YamlIgnore]
             public object SetOnly { set => this.value = value; }
 
             [YamlIgnore]

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -2447,7 +2447,7 @@ Null: true
             Assert.Equal(1, test.OnSerializedCallCount);
             Assert.Equal(1, test.OnSerializingCallCount);
         }
-        
+
         [Fact]
         public void SerializeConcurrently()
         {
@@ -2459,7 +2459,7 @@ Null: true
                 // Failures don't occur consistently - running repeatedly increases the chances
                 RunTest();
             }
-            
+
             Assert.Empty(exceptions);
 
             void RunTest()
@@ -2469,7 +2469,7 @@ Null: true
                 var control = new SemaphoreSlim(0, threadCount);
 
                 var serializer = new SerializerBuilder().Build();
-            
+
                 for (var i = 0; i < threadCount; i++)
                 {
                     threads.Add(new Thread(Serialize));
@@ -2480,7 +2480,7 @@ Null: true
                 // Release them all simultaneously to try to maximise concurrency
                 control.Release(threadCount);
                 threads.ForEach(t => t.Join());
-                
+
                 void Serialize()
                 {
                     control.Wait();

--- a/YamlDotNet.Test/Serialization/YamlCommentTests.cs
+++ b/YamlDotNet.Test/Serialization/YamlCommentTests.cs
@@ -1,4 +1,25 @@
-﻿using System;
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/YamlDotNet.Test/YamlDotNet.Test.csproj
+++ b/YamlDotNet.Test/YamlDotNet.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0;net47</TargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/YamlDotNet/YamlDotNet.csproj
+++ b/YamlDotNet/YamlDotNet.csproj
@@ -44,10 +44,6 @@
     <DefineConstants>$(DefineConstants);RELEASE;TRACE;SIGNED</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-
   <Target Name="Info" BeforeTargets="CoreCompile">
     <Message Importance="high" Text=" " Condition="'$(RealTargetFramework)' != ''" />
     <Message Importance="high" Text="==== Building $(RealTargetFramework) $(Empty.PadRight($([MSBuild]::Subtract(100, $(RealTargetFramework.Length))), '='))" Condition="'$(RealTargetFramework)' != ''" />


### PR DESCRIPTION
Configures warnings as errors
Runs formatting checks on release build (difference between formatting check enabled and disabled is about 40 seconds on my laptop)
Fixes all formatting issues

I opted to only run the formatting checks during the release build due to the significant increase in time to build.

Fixes #968