### PR TITLE
Update testing libraries and migrate FluentAssertions syntax

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,13 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Bullseye" Version="4.1.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FakeItEasy" Version="6.2.1" />
-    <PackageVersion Include="FluentAssertions" Version="4.19.2" />
+    <PackageVersion Include="FakeItEasy" Version="8.3.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="FSharp.Core" Version="8.0.400" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Nullable" Version="1.3.1" />
     <PackageVersion Include="ObjectLayoutInspector" Version="0.1.2" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />

--- a/YamlDotNet.Test/Core/EmitterTests.cs
+++ b/YamlDotNet.Test/Core/EmitterTests.cs
@@ -57,10 +57,11 @@ namespace YamlDotNet.Test.Core
             var emittedText = EmittedTextFrom(originalEvents);
             var emittedEvents = ParsingEventsOf(emittedText);
 
-            emittedEvents.ShouldAllBeEquivalentTo(originalEvents,
-                opt => opt.Excluding(@event => @event.Start)
-                          .Excluding(@event => @event.End)
-                          .Excluding((ParsingEvent @event) => ((DocumentEnd)@event).IsImplicit));
+            emittedEvents.Should().BeEquivalentTo(originalEvents, opt => opt
+                .Excluding(@event => @event.Start)
+                .Excluding(@event => @event.End)
+                .Excluding(@event => ((DocumentEnd)@event).IsImplicit)
+            );
         }
 
         private IList<ParsingEvent> ParsingEventsOf(string text)

--- a/YamlDotNet.Test/Core/InsertionQueueTests.cs
+++ b/YamlDotNet.Test/Core/InsertionQueueTests.cs
@@ -267,7 +267,7 @@ namespace YamlDotNet.Test.Core
 
             Action action = () => queue.Dequeue();
 
-            action.ShouldThrow<InvalidOperationException>();
+            action.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -279,7 +279,7 @@ namespace YamlDotNet.Test.Core
             queue.Dequeue();
             Action action = () => queue.Dequeue();
 
-            action.ShouldThrow<InvalidOperationException>();
+            action.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -314,7 +314,7 @@ namespace YamlDotNet.Test.Core
             PerformTimes(2, queue.Dequeue);
             Action action = () => queue.Dequeue();
 
-            action.ShouldThrow<InvalidOperationException>();
+            action.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]

--- a/YamlDotNet.Test/Core/LookAheadBufferTests.cs
+++ b/YamlDotNet.Test/Core/LookAheadBufferTests.cs
@@ -206,7 +206,7 @@ namespace YamlDotNet.Test.Core
             buffer.Peek(3);
             Action action = () => buffer.Skip(5);
 
-            action.ShouldThrow<ArgumentOutOfRangeException>();
+            action.Should().Throw<ArgumentOutOfRangeException>();
         }
 
         private static LookAheadBuffer CreateBuffer(TextReader reader, int capacity)

--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -29,7 +29,6 @@ using Xunit;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.RepresentationModel;
-using YamlDotNet.Serialization.Schemas;
 
 namespace YamlDotNet.Test.RepresentationModel
 {
@@ -57,7 +56,7 @@ namespace YamlDotNet.Test.RepresentationModel
 
             var accessAllNodes = new Action(() => stream.Documents.Single().AllNodes.ToList());
 
-            accessAllNodes.ShouldThrow<MaximumRecursionLevelReachedException>("because the document is infinitely recursive.");
+            accessAllNodes.Should().Throw<MaximumRecursionLevelReachedException>("because the document is infinitely recursive.");
         }
 
         [Theory]

--- a/YamlDotNet.Test/Serialization/BufferedDeserialization/KeyValueTypeDiscriminatorTests.cs
+++ b/YamlDotNet.Test/Serialization/BufferedDeserialization/KeyValueTypeDiscriminatorTests.cs
@@ -21,10 +21,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using Xunit;
-using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 

--- a/YamlDotNet.Test/Serialization/BufferedDeserialization/TypeDiscriminatingNodeDeserializerTests.cs
+++ b/YamlDotNet.Test/Serialization/BufferedDeserialization/TypeDiscriminatingNodeDeserializerTests.cs
@@ -21,7 +21,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using Xunit;
 using YamlDotNet.Core;
@@ -47,10 +46,10 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
 
             Action act = () => bufferedDeserializer.Deserialize<object>(KubernetesServiceYaml);
             act
-              .ShouldThrow<YamlException>()
+              .Should().Throw<YamlException>()
               .WithMessage("Failed to buffer yaml node")
               .WithInnerException<ArgumentOutOfRangeException>()
-              .Where(e => e.InnerException.Message.Contains("Parser buffer exceeded max depth"));
+              .WithMessage("Parser buffer exceeded max depth*");
         }
 
         [Fact]
@@ -68,10 +67,10 @@ namespace YamlDotNet.Test.Serialization.BufferedDeserialization
 
             Action act = () => bufferedDeserializer.Deserialize<object>(KubernetesServiceYaml);
             act
-              .ShouldThrow<YamlException>()
+              .Should().Throw<YamlException>()
               .WithMessage("Failed to buffer yaml node")
               .WithInnerException<ArgumentOutOfRangeException>()
-              .Where(e => e.InnerException.Message.Contains("Parser buffer exceeded max length"));
+              .WithMessage("Parser buffer exceeded max length*");
         }
 
         public const string KubernetesServiceYaml = @"

--- a/YamlDotNet.Test/Serialization/BufferedDeserialization/UniqueKeyTypeDiscriminatorTests.cs
+++ b/YamlDotNet.Test/Serialization/BufferedDeserialization/UniqueKeyTypeDiscriminatorTests.cs
@@ -21,10 +21,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using Xunit;
-using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 

--- a/YamlDotNet.Test/Serialization/DateOnlyConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/DateOnlyConverterTests.cs
@@ -75,7 +75,7 @@ namespace YamlDotNet.Test.Serialization
 
             Action action = () => { converter.ReadYaml(parser, typeof(DateOnly), null); };
 
-            action.ShouldThrow<FormatException>();
+            action.Should().Throw<FormatException>();
         }
 
         /// <summary>

--- a/YamlDotNet.Test/Serialization/DateTime8601ConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/DateTime8601ConverterTests.cs
@@ -20,11 +20,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FakeItEasy;
 using Xunit;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;

--- a/YamlDotNet.Test/Serialization/DateTimeConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/DateTimeConverterTests.cs
@@ -74,7 +74,7 @@ namespace YamlDotNet.Test.Serialization
 
             Action action = () => { converter.ReadYaml(parser, typeof(DateTime), null); };
 
-            action.ShouldThrow<FormatException>();
+            action.Should().Throw<FormatException>();
         }
 
         /// <summary>

--- a/YamlDotNet.Test/Serialization/DateTimeOffsetConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/DateTimeOffsetConverterTests.cs
@@ -66,7 +66,7 @@ namespace YamlDotNet.Test.Serialization
 
             Action action = () => { converter.ReadYaml(parser, typeof(DateTimeOffset), null); };
 
-            action.ShouldThrow<FormatException>();
+            action.Should().Throw<FormatException>();
         }
 
         [Fact]

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -301,14 +301,14 @@ name: Jake
                 .Build();
 
             Action act = () => sut.Deserialize<Person>(yaml);
-            act.ShouldThrow<YamlException>("Because there are duplicate name keys with concrete class");
+            act.Should().Throw<YamlException>("Because there are duplicate name keys with concrete class");
             act = () => sut.Deserialize<IDictionary<object, object>>(yaml);
-            act.ShouldThrow<YamlException>("Because there are duplicate name keys with dictionary");
+            act.Should().Throw<YamlException>("Because there are duplicate name keys with dictionary");
 
             var stream = Yaml.ReaderFrom("backreference.yaml");
             var parser = new MergingParser(new Parser(stream));
             act = () => sut.Deserialize<Dictionary<string, Dictionary<string, string>>>(parser);
-            act.ShouldThrow<YamlException>("Because there are duplicate name keys with merging parser");
+            act.Should().Throw<YamlException>("Because there are duplicate name keys with merging parser");
         }
 
         [Fact]
@@ -325,14 +325,14 @@ name: Jake
                 .Build();
 
             Action act = () => sut.Deserialize<Person>(yaml);
-            act.ShouldNotThrow<YamlException>("Because duplicate key checking is not enabled");
+            act.Should().NotThrow<YamlException>("Because duplicate key checking is not enabled");
             act = () => sut.Deserialize<IDictionary<object, object>>(yaml);
-            act.ShouldNotThrow<YamlException>("Because duplicate key checking is not enabled");
+            act.Should().NotThrow<YamlException>("Because duplicate key checking is not enabled");
 
             var stream = Yaml.ReaderFrom("backreference.yaml");
             var parser = new MergingParser(new Parser(stream));
             act = () => sut.Deserialize<Dictionary<string, Dictionary<string, string>>>(parser);
-            act.ShouldNotThrow<YamlException>("Because duplicate key checking is not enabled");
+            act.Should().NotThrow<YamlException>("Because duplicate key checking is not enabled");
         }
 
         [Fact]

--- a/YamlDotNet.Test/Serialization/HiddenPropertyTests.cs
+++ b/YamlDotNet.Test/Serialization/HiddenPropertyTests.cs
@@ -94,7 +94,7 @@ getAndSet: getAndSet
                 .Build();
 
             Action action = () => { d.Deserialize<DuplicatePropertyDerived<string>>(yaml); };
-            action.ShouldThrow<YamlException>();
+            action.Should().Throw<YamlException>();
         }
     }
 }

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -35,7 +35,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using FakeItEasy;
 using FluentAssertions;
-using FluentAssertions.Common;
 using Xunit;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
@@ -107,7 +106,7 @@ namespace YamlDotNet.Test.Serialization
         {
             Action action = () => Deserializer.Deserialize<bool>(UsingReaderFor("not-a-boolean"));
 
-            action.ShouldThrow<YamlException>().WithInnerException<FormatException>();
+            action.Should().Throw<YamlException>().WithInnerException<FormatException>();
         }
 
         [Fact]
@@ -217,7 +216,7 @@ namespace YamlDotNet.Test.Serialization
 
             Action action = () => SerializerBuilder.EnsureRoundtrip().Build().Serialize(new StringWriter(), obj, typeof(CircularReference));
 
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -225,7 +224,7 @@ namespace YamlDotNet.Test.Serialization
         {
             Action action = () => Deserializer.Deserialize<object>(UsingReaderFor("%Y"));
 
-            action.ShouldThrow<SyntaxErrorException>()
+            action.Should().Throw<SyntaxErrorException>()
                 .WithMessage("While scanning a directive, found unexpected end of stream.");
         }
 
@@ -234,7 +233,7 @@ namespace YamlDotNet.Test.Serialization
         {
             Action action = () => Deserializer.Deserialize<object>(UsingReaderFor("%Y "));
 
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -247,7 +246,7 @@ namespace YamlDotNet.Test.Serialization
 
             result.Should().BeOfType<Point>().And
                 .Subject.As<Point>()
-                .ShouldBeEquivalentTo(new { X = 10, Y = 20 }, o => o.ExcludingMissingMembers());
+                .Should().BeEquivalentTo(new { X = 10, Y = 20 }, o => o.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -365,7 +364,7 @@ Value: foo");
 
             Action action = () => Deserializer.Deserialize<Example>(UsingReaderFor(text));
 
-            action.ShouldThrow<AnchorNotFoundException>();
+            action.Should().Throw<AnchorNotFoundException>();
         }
 
         [Fact]
@@ -384,7 +383,7 @@ Value: foo");
                     .Build()
             );
 
-            result.ShouldBeEquivalentTo(obj);
+            result.Should().BeEquivalentTo(obj);
         }
 
         [Fact]
@@ -403,7 +402,7 @@ Value: foo");
                     .Build()
             );
 
-            result.ShouldBeEquivalentTo(obj);
+            result.Should().BeEquivalentTo(obj);
         }
 
         [Fact]
@@ -508,7 +507,7 @@ Value: foo");
 
             result.SomeScalar.Should().Be("Hello");
             result.RegularBase.Should().BeOfType<Derived>().And
-                .Subject.As<Derived>().ShouldBeEquivalentTo(new { ChildProp = "bar" }, o => o.ExcludingMissingMembers());
+                .Subject.As<Derived>().Should().BeEquivalentTo(new { ChildProp = "bar" }, o => o.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -532,7 +531,7 @@ Value: foo");
             );
 
             result.BaseWithSerializeAs.Should().BeOfType<Base>().And
-                .Subject.As<Base>().ShouldBeEquivalentTo(new { ParentProp = "foo" }, o => o.ExcludingMissingMembers());
+                .Subject.As<Base>().Should().BeEquivalentTo(new { ParentProp = "foo" }, o => o.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -553,7 +552,7 @@ Value: foo");
             var result = DoRoundtripFromObjectTo<InterfaceExample>(obj);
 
             result.Derived.Should().BeOfType<Derived>().And
-                .Subject.As<IDerived>().ShouldBeEquivalentTo(new { BaseProperty = "foo", DerivedProperty = "bar" }, o => o.ExcludingMissingMembers());
+                .Subject.As<IDerived>().Should().BeEquivalentTo(new { BaseProperty = "foo", DerivedProperty = "bar" }, o => o.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -603,8 +602,7 @@ Value: foo");
 
             var result = Deserializer.Deserialize(stream);
 
-            result.Should().BeAssignableTo<IList>().And
-                .Subject.As<IList>().Should().Equal(new[] { "one", "two", "three" });
+            result.Should().BeEquivalentTo(new[] { "one", "two", "three" });
         }
 
         [Fact]
@@ -705,7 +703,7 @@ Value: foo");
 
             var result = Deserializer.Deserialize<List<Dictionary<string, string>>>(stream);
 
-            result.ShouldBeEquivalentTo(new[] {
+            result.Should().BeEquivalentTo(new[] {
                 new Dictionary<string, string> {
                     { "connection", "conn1" },
                     { "path", "path1" }
@@ -730,8 +728,8 @@ Value: foo");
             var one = Deserializer.Deserialize<Simple>(reader);
             var two = Deserializer.Deserialize<Simple>(reader);
 
-            one.ShouldBeEquivalentTo(new { aaa = "111" });
-            two.ShouldBeEquivalentTo(new { aaa = "222" });
+            one.Should().BeEquivalentTo(new { aaa = "111" });
+            two.Should().BeEquivalentTo(new { aaa = "222" });
         }
 
         [Fact]
@@ -752,9 +750,9 @@ Value: foo");
             var three = Deserializer.Deserialize<Simple>(reader);
 
             reader.Accept<StreamEnd>(out var _).Should().BeTrue("reader should have reached StreamEnd");
-            one.ShouldBeEquivalentTo(new { aaa = "111" });
-            two.ShouldBeEquivalentTo(new { aaa = "222" });
-            three.ShouldBeEquivalentTo(new { aaa = "333" });
+            one.Should().BeEquivalentTo(new { aaa = "111" });
+            two.Should().BeEquivalentTo(new { aaa = "222" });
+            three.Should().BeEquivalentTo(new { aaa = "333" });
         }
 
         [Fact]
@@ -1128,7 +1126,7 @@ y:
 
             Action action = () => Serializer.Serialize(new StringWriter(), obj);
 
-            action.ShouldNotThrow<TargetException>();
+            action.Should().NotThrow<TargetException>();
         }
 
         [Fact]
@@ -2027,7 +2025,7 @@ a: *anchor1
 b: &anchor1 test0
 c: *anchor1");
 
-            action.ShouldThrow<AnchorNotFoundException>();
+            action.Should().Throw<AnchorNotFoundException>();
         }
 
         [Fact]
@@ -2560,7 +2558,7 @@ Null: true
             var serializer = new SerializerBuilder().WithEnumNamingConvention(CamelCaseNamingConvention.Instance).Build();
             ScalarStyle style = ScalarStyle.Plain;
             var serialized = serializer.Serialize(style);
-            Assert.Equal("plain", serialized.RemoveNewLines());
+            Assert.Equal("plain", serialized.Replace("\r\n", "").Replace("\n", ""));
         }
 
         [Fact]

--- a/YamlDotNet.Test/Serialization/TimeOnlyConverterTests.cs
+++ b/YamlDotNet.Test/Serialization/TimeOnlyConverterTests.cs
@@ -75,7 +75,7 @@ namespace YamlDotNet.Test.Serialization
 
             Action action = () => { converter.ReadYaml(parser, typeof(TimeOnly), null); };
 
-            action.ShouldThrow<FormatException>();
+            action.Should().Throw<FormatException>();
         }
 
         /// <summary>

--- a/YamlDotNet.Test/Serialization/TypeConverterAttributeTests.cs
+++ b/YamlDotNet.Test/Serialization/TypeConverterAttributeTests.cs
@@ -20,10 +20,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;

--- a/YamlDotNet.Test/Serialization/YamlCommentTests.cs
+++ b/YamlDotNet.Test/Serialization/YamlCommentTests.cs
@@ -50,7 +50,7 @@ namespace YamlDotNet.Test.Serialization
 
             var deserializer = new Deserializer();
             Action action = () => deserializer.Deserialize<Person>(result);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
 
             var lines = SplitByLines(result);
 
@@ -69,7 +69,7 @@ namespace YamlDotNet.Test.Serialization
 
             var deserializer = new Deserializer();
             Action action = () => deserializer.Deserialize<MultilineComment>(result);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
 
             var lines = SplitByLines(result);
 
@@ -86,7 +86,7 @@ namespace YamlDotNet.Test.Serialization
         {
             var serializer = new Serializer();
             Action action = () => serializer.Serialize(new NullComment());
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
         #endregion
 
@@ -102,7 +102,7 @@ namespace YamlDotNet.Test.Serialization
 
             var deserializer = new Deserializer();
             Action action = () => deserializer.Deserialize<Person[]>(result);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
 
             var lines = SplitByLines(result);
             var indent = GetIndent(1);
@@ -128,7 +128,7 @@ namespace YamlDotNet.Test.Serialization
 
             var deserializer = new Deserializer();
             Action action = () => deserializer.Deserialize<Garage>(result);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
 
             var lines = SplitByLines(result);
             var indent1 = GetIndent(1);
@@ -159,7 +159,7 @@ namespace YamlDotNet.Test.Serialization
 
             var deserializer = new Deserializer();
             Action action = () => deserializer.Deserialize<Garage>(result);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
 
             var lines = SplitByLines(result);
             var indent1 = GetIndent(1);
@@ -195,7 +195,7 @@ namespace YamlDotNet.Test.Serialization
 
             var deserializer = new Deserializer();
             Action action = () => deserializer.Deserialize<Garage>(result);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
 
             var lines = SplitByLines(result);
             var indent1 = GetIndent(1);

--- a/YamlDotNet.Test/YamlTests.cs
+++ b/YamlDotNet.Test/YamlTests.cs
@@ -110,7 +110,7 @@ theOtherThing:";
 #endif
             Action act = () => Yaml.Text(BadlyIndentedLines);
 
-            act.ShouldThrowExactly<ArgumentException>().WithMessage(expectedMessage);
+            act.Should().ThrowExactly<ArgumentException>().WithMessage(expectedMessage);
         }
     }
 }


### PR DESCRIPTION
With master and NET SDK 9 the restore process fails due to insecure dependencies in FluentAssertions and FakeItEasy dependency paths:

```
\YamlDotNet.Samples\YamlDotNet.Samples.csproj : error NU1903: Warning As Error: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
\YamlDotNet.Test\YamlDotNet.Test.csproj : error NU1903: Warning As Error: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
\YamlDotNet.Samples\YamlDotNet.Samples.csproj : error NU1903: Warning As Error: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
\YamlDotNet.Test\YamlDotNet.Test.csproj : error NU1903: Warning As Error: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
```

Upgraded to latest versions and fixed syntax.