### PR TITLE
perf: Optimize regular numbers parse logics

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -221,6 +221,44 @@ b: &number 1
         }
 
         [Theory]
+        [InlineData(System.Byte.MinValue)]
+        [InlineData(System.Byte.MaxValue)]
+        [InlineData(System.Int16.MinValue)]
+        [InlineData(System.Int16.MaxValue)]
+        [InlineData(System.Int32.MinValue)]
+        [InlineData(System.Int32.MaxValue)]
+        [InlineData(System.Int64.MinValue)]
+        [InlineData(System.Int64.MaxValue)]
+        [InlineData(System.UInt64.MaxValue)]
+        [InlineData(System.Single.MinValue)]
+        [InlineData(System.Single.MaxValue)]
+        [InlineData(System.Double.MinValue)]
+        [InlineData(System.Double.MaxValue)]
+        public void UnquotedStringTypeDeserialization_RegularNumbers(object expected)
+        {
+            var deserializer = new DeserializerBuilder()
+                .WithAttemptingUnquotedStringTypeDeserialization().Build();
+
+            var yaml = $"Value: {expected}";
+
+#if NETFRAMEWORK
+            // It needs explicitly specifying maximum precision for value roundtrip. 
+            if (expected is float floatValue)
+            {
+                yaml = $"Value: {floatValue:G9}";
+            }
+            if (expected is double doubleValue)
+            {
+                yaml = $"Value: {doubleValue:G17}";
+            }
+#endif
+
+            var resultDict = deserializer.Deserialize<IDictionary<string, object>>(yaml);
+            Assert.True(resultDict.ContainsKey("Value"));
+            Assert.Equal(expected, resultDict["Value"]);
+        }
+
+        [Theory]
         [InlineData(".nan", System.Single.NaN)]
         [InlineData(".NaN", System.Single.NaN)]
         [InlineData(".NAN", System.Single.NaN)]

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -382,17 +382,16 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                     }
                     else if (Regex.IsMatch(v, @"[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?")) //regular number
                     {
-#pragma warning disable format
-                        if      ( byte.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var byteValue  )) { result = byteValue;  }
-                        else if (short.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var shortValue )) { result = shortValue; }
-                        else if (  int.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var intValue   )) { result = intValue;   }
-                        else if ( long.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var longValue  )) { result = longValue;  }
-                        else if (ulong.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var ulongValue )) { result = ulongValue; }
+                        if (byte.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var byteValue)) { result = byteValue; }
+                        else if (short.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var shortValue)) { result = shortValue; }
+                        else if (int.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var intValue)) { result = intValue; }
+                        else if (long.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var longValue)) { result = longValue; }
+                        else if (ulong.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var ulongValue)) { result = ulongValue; }
 #if NETFRAMEWORK
-                        else if ( float.TryParse(v, NumberStyles.Float | NumberStyles.AllowThousands, formatter.NumberFormat, out var floatValue)) { result = floatValue; }
-                        else if (double.TryParse(v, NumberStyles.Float | NumberStyles.AllowThousands, formatter.NumberFormat, out var doubleValue)) { result = doubleValue; }
+                        else if (float.TryParse(v, NumberStyles.Float, formatter.NumberFormat, out var floatValue)) { result = floatValue; }
+                        else if (double.TryParse(v, NumberStyles.Float, formatter.NumberFormat, out var doubleValue)) { result = doubleValue; }
 #else
-                        else if (double.TryParse(v, NumberStyles.Float | NumberStyles.AllowThousands, formatter.NumberFormat, out var doubleValue))
+                        else if (double.TryParse(v, NumberStyles.Float, formatter.NumberFormat, out var doubleValue))
                         {
                             var floatValue = (float)doubleValue;
                             if (!float.IsNaN(floatValue) && !float.IsInfinity(floatValue)) // .NET 6 or later support float.IsNormal
@@ -405,7 +404,6 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                             }
                         }
 #endif
-#pragma warning restore format
                         else
                         {
                             //we couldn't parse it, default to string, It's probably too big

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -394,7 +394,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                         else if (double.TryParse(v, NumberStyles.Float, formatter.NumberFormat, out var doubleValue))
                         {
                             var floatValue = (float)doubleValue;
-                            if (!float.IsNaN(floatValue) && !float.IsInfinity(floatValue)) // .NET 6 or later support float.IsNormal
+                            if (!float.IsNaN(floatValue) && !float.IsInfinity(floatValue))
                             {
                                 result = floatValue;
                             }


### PR DESCRIPTION
This PR intended to optimize performance for number deserialization by changing Parse to `TryParse` method. 
It's discussed at https://github.com/aaubry/YamlDotNet/pull/794

Additionally this PR fix `double` value deserialization problems that are found on UnitTests.

**What's Changes**
- Replace existing regular number `Parse` logics with `TryParse` method.
- Separate `float`/`double` parse logics for `.NET Framework`.
- Add code path for .NET that parse text as `double`, then checks float value ranges. 
- Add related unit tests (`UnquotedStringTypeDeserialization_RegularNumbers`)

**.NET Behavior differences**
On .NET Framework.  `float.Parse((double.MaxValue + 1).ToString())` throw `OverflowException`.
But on .NET Core. It returns PosititiveInfinite(`∞`).

These behavior differences are described at [Single.Parse Method](https://learn.microsoft.com/en-us/dotnet/api/system.single.parse?view=net-8.0) page.

> In .NET Core 3.0 and later, values that are too large to represent are rounded to [PositiveInfinity] or
> [NegativeInfinity](https://learn.microsoft.com/en-us/dotnet/api/system.single.negativeinfinity?view=net-8.0#system-single-negativeinfinity) as required by the IEEE 754 specification. 
> In prior versions, including .NET Framework, parsing a value that was too large to represent resulted in failure.

On current implementation. 
Values outside the range of the `float` type are converted to `-∞`/`∞`.
So I've added logics to check float value ranges.