### PR TITLE
Fix JSON serialization for UTF-32 characters.

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -887,6 +887,15 @@ y:
         }
 
         [Fact]
+        public void SerializationOfUtf32WorksInJson()
+        {
+            var obj = new { TestProperty = "Sea life \U0001F99E" };
+
+            SerializerBuilder.JsonCompatible().Build().Serialize(obj).Trim().Should()
+                .Be(@"{""TestProperty"": ""Sea life \uD83E\uDD9E""}");
+        }
+
+        [Fact]
         // Todo: this is actually roundtrip
         public void DeserializationOfDefaultsWorkInJson()
         {

--- a/YamlDotNet/Core/Emitter.cs
+++ b/YamlDotNet/Core/Emitter.cs
@@ -66,6 +66,7 @@ namespace YamlDotNet.Core
         private bool isWhitespace;
         private bool isIndentation;
         private readonly bool forceIndentLess;
+        private readonly bool useUtf16SurrogatePair;
         private readonly string newLine;
 
         private bool isDocumentEndWritten;
@@ -148,6 +149,7 @@ namespace YamlDotNet.Core
             this.maxSimpleKeyLength = settings.MaxSimpleKeyLength;
             this.skipAnchorName = settings.SkipAnchorName;
             this.forceIndentLess = !settings.IndentSequences;
+            this.useUtf16SurrogatePair = settings.UseUtf16SurrogatePairs;
             this.newLine = settings.NewLine;
 
             this.output = output;
@@ -1189,8 +1191,20 @@ namespace YamlDotNet.Core
                             {
                                 if (index + 1 < value.Length && IsLowSurrogate(value[index + 1]))
                                 {
-                                    Write('U');
-                                    Write(char.ConvertToUtf32(character, value[index + 1]).ToString("X08", CultureInfo.InvariantCulture));
+                                    if (useUtf16SurrogatePair)
+                                    {
+                                        Write('u');
+                                        Write(code.ToString("X04", CultureInfo.InvariantCulture));
+                                        Write('\\');
+                                        Write('u');
+                                        Write(((ushort)value[index + 1]).ToString("X04", CultureInfo.InvariantCulture));
+                                    }
+                                    else
+                                    {
+                                        Write('U');
+                                        Write(char.ConvertToUtf32(character, value[index + 1]).ToString("X08", CultureInfo.InvariantCulture));
+                                    }
+
                                     index++;
                                 }
                                 else

--- a/YamlDotNet/Core/EmitterSettings.cs
+++ b/YamlDotNet/Core/EmitterSettings.cs
@@ -63,13 +63,22 @@ namespace YamlDotNet.Core
         /// </summary>
         public bool IndentSequences { get; }
 
+        /// <summary>
+        /// If true, then 4-byte UTF-32 characters are broken into two 2-byte code-points.
+        /// </summary>
+        /// <remarks>
+        /// This ensures compatibility with JSON format, as it does not allow '\Uxxxxxxxxx'
+        /// and instead expects two escaped 2-byte character '\uxxxx\uxxxx'.
+        /// </remarks>
+        public bool UseUtf16SurrogatePairs { get; }
+
         public static readonly EmitterSettings Default = new EmitterSettings();
 
         public EmitterSettings()
         {
         }
 
-        public EmitterSettings(int bestIndent, int bestWidth, bool isCanonical, int maxSimpleKeyLength, bool skipAnchorName = false, bool indentSequences = false, string? newLine = null)
+        public EmitterSettings(int bestIndent, int bestWidth, bool isCanonical, int maxSimpleKeyLength, bool skipAnchorName = false, bool indentSequences = false, bool useUtf16SurrogatePairs = false, string? newLine = null)
         {
             if (bestIndent < 2 || bestIndent > 9)
             {
@@ -92,6 +101,7 @@ namespace YamlDotNet.Core
             MaxSimpleKeyLength = maxSimpleKeyLength;
             SkipAnchorName = skipAnchorName;
             IndentSequences = indentSequences;
+            UseUtf16SurrogatePairs = useUtf16SurrogatePairs;
             NewLine = newLine ?? Environment.NewLine;
         }
 
@@ -104,6 +114,7 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
+                UseUtf16SurrogatePairs,
                 NewLine
             );
         }
@@ -117,6 +128,7 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
+                UseUtf16SurrogatePairs,
                 NewLine
             );
         }
@@ -130,6 +142,7 @@ namespace YamlDotNet.Core
                 maxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
+                UseUtf16SurrogatePairs,
                 NewLine
             );
         }
@@ -143,6 +156,7 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
+                UseUtf16SurrogatePairs,
                 newLine
             );
         }
@@ -167,6 +181,7 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 true,
                 IndentSequences,
+                UseUtf16SurrogatePairs,
                 NewLine
             );
         }
@@ -179,6 +194,21 @@ namespace YamlDotNet.Core
                 IsCanonical,
                 MaxSimpleKeyLength,
                 SkipAnchorName,
+                true,
+                UseUtf16SurrogatePairs,
+                NewLine
+            );
+        }
+
+        public EmitterSettings WithUtf16SurrogatePairs()
+        {
+            return new EmitterSettings(
+                BestIndent,
+                BestWidth,
+                IsCanonical,
+                MaxSimpleKeyLength,
+                SkipAnchorName,
+                IndentSequences,
                 true,
                 NewLine
             );

--- a/YamlDotNet/Core/EmitterSettings.cs
+++ b/YamlDotNet/Core/EmitterSettings.cs
@@ -78,7 +78,7 @@ namespace YamlDotNet.Core
         {
         }
 
-        public EmitterSettings(int bestIndent, int bestWidth, bool isCanonical, int maxSimpleKeyLength, bool skipAnchorName = false, bool indentSequences = false, bool useUtf16SurrogatePairs = false, string? newLine = null)
+        public EmitterSettings(int bestIndent, int bestWidth, bool isCanonical, int maxSimpleKeyLength, bool skipAnchorName = false, bool indentSequences = false, string? newLine = null, bool useUtf16SurrogatePairs = false)
         {
             if (bestIndent < 2 || bestIndent > 9)
             {
@@ -101,8 +101,8 @@ namespace YamlDotNet.Core
             MaxSimpleKeyLength = maxSimpleKeyLength;
             SkipAnchorName = skipAnchorName;
             IndentSequences = indentSequences;
-            UseUtf16SurrogatePairs = useUtf16SurrogatePairs;
             NewLine = newLine ?? Environment.NewLine;
+            UseUtf16SurrogatePairs = useUtf16SurrogatePairs;
         }
 
         public EmitterSettings WithBestIndent(int bestIndent)
@@ -114,8 +114,8 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
-                UseUtf16SurrogatePairs,
-                NewLine
+                NewLine,
+                UseUtf16SurrogatePairs
             );
         }
 
@@ -128,8 +128,8 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
-                UseUtf16SurrogatePairs,
-                NewLine
+                NewLine,
+                UseUtf16SurrogatePairs
             );
         }
 
@@ -142,8 +142,8 @@ namespace YamlDotNet.Core
                 maxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
-                UseUtf16SurrogatePairs,
-                NewLine
+                NewLine,
+                UseUtf16SurrogatePairs
             );
         }
 
@@ -156,8 +156,8 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
-                UseUtf16SurrogatePairs,
-                newLine
+                newLine,
+                UseUtf16SurrogatePairs
             );
         }
 
@@ -181,8 +181,8 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 true,
                 IndentSequences,
-                UseUtf16SurrogatePairs,
-                NewLine
+                NewLine,
+                UseUtf16SurrogatePairs
             );
         }
 
@@ -195,8 +195,8 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 SkipAnchorName,
                 true,
-                UseUtf16SurrogatePairs,
-                NewLine
+                NewLine,
+                UseUtf16SurrogatePairs
             );
         }
 
@@ -209,8 +209,8 @@ namespace YamlDotNet.Core
                 MaxSimpleKeyLength,
                 SkipAnchorName,
                 IndentSequences,
-                true,
-                NewLine
+                NewLine,
+                true
             );
         }
     }

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -366,7 +366,8 @@ namespace YamlDotNet.Serialization
         {
             this.emitterSettings = this.emitterSettings
                                        .WithMaxSimpleKeyLength(int.MaxValue)
-                                       .WithoutAnchorName();
+                                       .WithoutAnchorName()
+                                       .WithUtf16SurrogatePairs();
 
             return this
                 .WithTypeConverter(new GuidConverter(true), w => w.InsteadOf<GuidConverter>())

--- a/YamlDotNet/Serialization/StaticSerializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticSerializerBuilder.cs
@@ -370,7 +370,8 @@ namespace YamlDotNet.Serialization
         {
             this.emitterSettings = this.emitterSettings
                                        .WithMaxSimpleKeyLength(int.MaxValue)
-                                       .WithoutAnchorName();
+                                       .WithoutAnchorName()
+                                       .WithUtf16SurrogatePairs();
 
             return this
                 .WithTypeConverter(new GuidConverter(true), w => w.InsteadOf<GuidConverter>())


### PR DESCRIPTION
When serializing the data in JSON-compatible form, 4-byte UTF32 characters need to be split into two 2-byte code points.

This change fixes that by introducing new emitter setting `UseUtf16SurrogatePairs`, which is set when JSON-compatible builder is requested.

Fixes https://github.com/aaubry/YamlDotNet/issues/997