### PR TITLE
Bring back stack trace to YamlException.ToString

### DIFF
--- a/YamlDotNet.Test/Core/YamlExceptionTests.cs
+++ b/YamlDotNet.Test/Core/YamlExceptionTests.cs
@@ -29,35 +29,35 @@ namespace YamlDotNet.Test.Core
     public class YamlExceptionTests
     {
         [Fact]
-        public void VerifyToStringWithEmptyMarks()
+        public void VerifyMessageWithEmptyMarks()
         {
             var exception = new YamlException(Mark.Empty, Mark.Empty, "Test exception message");
-            exception.ToString().Should().Be("(Line: 1, Col: 1, Idx: 0) - (Line: 1, Col: 1, Idx: 0): Test exception message");
-            exception.Message.Should().Be("Test exception message");
+            exception.Message.Should().Be("(Line: 1, Col: 1, Idx: 0) - (Line: 1, Col: 1, Idx: 0): Test exception message");
+            exception.Reason.Should().Be("Test exception message");
         }
 
         [Fact]
-        public void VerifyToStringWithNonEmptyMarks()
+        public void VerifyMessageWithNonEmptyMarks()
         {
             var exception = new YamlException(new Mark(1, 1, 1), new Mark(10, 10, 10), "Test exception message");
-            exception.ToString().Should().Be("(Line: 1, Col: 1, Idx: 1) - (Line: 10, Col: 10, Idx: 10): Test exception message");
-            exception.Message.Should().Be("Test exception message");
+            exception.Message.Should().Be("(Line: 1, Col: 1, Idx: 1) - (Line: 10, Col: 10, Idx: 10): Test exception message");
+            exception.Reason.Should().Be("Test exception message");
         }
 
         [Fact]
-        public void VerifyToStringWithInnerExceptionAndMarks()
+        public void VerifyMessageWithInnerExceptionAndMarks()
         {
             var exception = new YamlException(new Mark(1, 1, 1), new Mark(10, 10, 10), "Test exception message", new InvalidOperationException("Test inner exception"));
-            exception.ToString().Should().Be("(Line: 1, Col: 1, Idx: 1) - (Line: 10, Col: 10, Idx: 10): Test exception message");
-            exception.Message.Should().Be("Test exception message");
+            exception.Message.Should().Be("(Line: 1, Col: 1, Idx: 1) - (Line: 10, Col: 10, Idx: 10): Test exception message");
+            exception.Reason.Should().Be("Test exception message");
         }
 
         [Fact]
-        public void VerifyToStringWithInnerException()
+        public void VerifyMessageWithInnerException()
         {
             var exception = new YamlException("Test exception message", new InvalidOperationException("Test inner exception"));
-            exception.ToString().Should().Be("(Line: 1, Col: 1, Idx: 0) - (Line: 1, Col: 1, Idx: 0): Test exception message");
-            exception.Message.Should().Be("Test exception message");
+            exception.Message.Should().Be("(Line: 1, Col: 1, Idx: 0) - (Line: 1, Col: 1, Idx: 0): Test exception message");
+            exception.Reason.Should().Be("Test exception message");
         }
     }
 }

--- a/YamlDotNet/Core/YamlException.cs
+++ b/YamlDotNet/Core/YamlException.cs
@@ -39,30 +39,36 @@ namespace YamlDotNet.Core
         public Mark End { get; }
 
         /// <summary>
+        /// Gets the reason that originated the exception.
+        /// </summary>
+        public string Reason { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="YamlException"/> class.
         /// </summary>
-        /// <param name="message">The message.</param>
-        public YamlException(string message)
-            : this(Mark.Empty, Mark.Empty, message)
+        /// <param name="reason">The message.</param>
+        public YamlException(string reason)
+            : this(Mark.Empty, Mark.Empty, reason)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlException"/> class.
         /// </summary>
-        public YamlException(in Mark start, in Mark end, string message)
-            : this(start, end, message, null)
+        public YamlException(in Mark start, in Mark end, string reason)
+            : this(start, end, reason, null)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlException"/> class.
         /// </summary>
-        public YamlException(in Mark start, in Mark end, string message, Exception? innerException)
-            : base(message, innerException)
+        public YamlException(in Mark start, in Mark end, string reason, Exception? innerException)
+            : base(null, innerException)
         {
             Start = start;
             End = end;
+            Reason = reason;
         }
 
         /// <summary>
@@ -75,9 +81,6 @@ namespace YamlDotNet.Core
         {
         }
 
-        public override string ToString()
-        {
-            return $"({Start}) - ({End}): {Message}";
-        }
+        public override string Message => $"({Start}) - ({End}): {Reason}";
     }
 }


### PR DESCRIPTION
This PR introduce `Reason` property in `YamlException` to bring back default functionality of `ToString` method.
Fixes #999 