### PR TITLE
Support YamlConverterAttribute in attribute overrides

### DIFF
--- a/YamlDotNet.Test/Serialization/TypeConverterAttributeTests.cs
+++ b/YamlDotNet.Test/Serialization/TypeConverterAttributeTests.cs
@@ -30,6 +30,45 @@ namespace YamlDotNet.Test.Serialization
     public class TypeConverterAttributeTests
     {
         [Fact]
+        public void TestConverterInAttributeOverride_Deserializes()
+        {
+            var deserializer = new DeserializerBuilder()
+                .WithAttributeOverride<OuterClassWithoutAttribute>(
+                    c => c.Value,
+                    new YamlConverterAttribute(typeof(AttributedTypeConverter)))
+                .WithTypeConverter(new AttributedTypeConverter())
+                .Build();
+            var yaml = @"Value:
+  abc: def";
+            var actual = deserializer.Deserialize<OuterClassWithoutAttribute>(yaml);
+            Assert.Equal("abc", actual.Value.Key);
+            Assert.Equal("def", actual.Value.Value);
+        }
+
+        [Fact]
+        public void TestConverterInAttributeOverride_Serializes()
+        {
+            var serializer = new SerializerBuilder()
+                .WithAttributeOverride<OuterClassWithoutAttribute>(
+                    c => c.Value,
+                    new YamlConverterAttribute(typeof(AttributedTypeConverter)))
+                .WithTypeConverter(new AttributedTypeConverter())
+                .Build();
+            var o = new OuterClassWithoutAttribute
+            {
+                Value = new ValueClass
+                {
+                    Key = "abc",
+                    Value = "def"
+                }
+            };
+            var actual = serializer.Serialize(o).NormalizeNewLines().TrimNewLines();
+            var expected = @"Value:
+  abc: def".NormalizeNewLines().TrimNewLines();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void TestConverterOnAttribute_Deserializes()
         {
             var deserializer = new DeserializerBuilder().WithTypeConverter(new AttributedTypeConverter()).Build();
@@ -91,6 +130,11 @@ namespace YamlDotNet.Test.Serialization
         public class OuterClass
         {
             [YamlConverter(typeof(AttributedTypeConverter))]
+            public ValueClass Value { get; set; }
+        }
+
+        public class OuterClassWithoutAttribute
+        {
             public ValueClass Value { get; set; }
         }
 

--- a/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
+++ b/YamlDotNet/Serialization/YamlAttributeOverridesInspector.cs
@@ -81,7 +81,8 @@ namespace YamlDotNet.Serialization
                 set { baseDescriptor.TypeOverride = value; }
             }
 
-            public Type? ConverterType => baseDescriptor.ConverterType;
+            public Type? ConverterType =>
+                GetCustomAttribute<YamlConverterAttribute>()?.ConverterType ?? baseDescriptor.ConverterType;
 
             public int Order
             {


### PR DESCRIPTION
This PR adds support for the `YamlConverterAttribute` in the attribute overrides. The allows the configuration of the deserializer as follows:
```
new DeserializerBuilder()
    .WithAttributeOverride<OuterClassWithoutAttribute>(
        c => c.Value,
        new YamlConverterAttribute(typeof(AttributedTypeConverter)))
    .WithTypeConverter(new AttributedTypeConverter())
    .Build();
```

This way, the `YamlConverterAttribute` is more aligned with e.g. the `YamlMemberAttribute` and it is possible to specify a custom converter for a specific property without modifying the model classes.