### PR TITLE
perf: Optimize number parse logics

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -259,6 +259,27 @@ b: &number 1
         }
 
         [Theory]
+        [InlineData(System.Byte.MinValue)]
+        [InlineData(System.Byte.MaxValue)]
+        [InlineData(System.Int16.MinValue)]
+        [InlineData(System.Int16.MaxValue)]
+        [InlineData(System.Int32.MinValue)]
+        [InlineData(System.Int32.MaxValue)]
+        [InlineData(System.Int64.MinValue)]
+        [InlineData(System.Int64.MaxValue)]
+        public void UnquotedStringTypeDeserialization_HexNumbers(object expected)
+        {
+            var deserializer = new DeserializerBuilder()
+                .WithAttemptingUnquotedStringTypeDeserialization().Build();
+
+            var yaml = $"Value: 0x{expected:X2}";
+
+            var resultDict = deserializer.Deserialize<IDictionary<string, object>>(yaml);
+            Assert.True(resultDict.ContainsKey("Value"));
+            Assert.Equal(expected, resultDict["Value"]);
+        }
+
+        [Theory]
         [InlineData(".nan", System.Single.NaN)]
         [InlineData(".NaN", System.Single.NaN)]
         [InlineData(".NAN", System.Single.NaN)]

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -354,20 +354,20 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                 case "FALSE":
                     return false;
                 default:
-                    if (Regex.IsMatch(v, "0x[0-9a-fA-F]+")) //base16 number
+                    if (Regex.IsMatch(v, "^0x[0-9a-fA-F]+$")) //base16 number
                     {
-                        if (TryAndSwallow(() => Convert.ToByte(v, 16), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt16(v, 16), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt32(v, 16), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToInt64(v, 16), out result)) { }
-                        else if (TryAndSwallow(() => Convert.ToUInt64(v, 16), out result)) { }
+                        if (byte.TryParse(v, NumberStyles.AllowHexSpecifier, formatter.NumberFormat, out var byteValue)) { result = byteValue; }
+                        else if (short.TryParse(v, NumberStyles.AllowHexSpecifier, formatter.NumberFormat, out var shortValue)) { result = shortValue; }
+                        else if (int.TryParse(v, NumberStyles.AllowHexSpecifier, formatter.NumberFormat, out var intValue)) { result = intValue; }
+                        else if (long.TryParse(v, NumberStyles.AllowHexSpecifier, formatter.NumberFormat, out var longValue)) { result = longValue; }
+                        else if (ulong.TryParse(v, NumberStyles.AllowHexSpecifier, formatter.NumberFormat, out var ulongValue)) { result = ulongValue; }
                         else
                         {
                             //we couldn't parse it, default to a string. It's probably to big.
                             result = v;
                         }
                     }
-                    else if (Regex.IsMatch(v, "0o[0-9a-fA-F]+")) //base8 number
+                    else if (Regex.IsMatch(v, "^0o[0-9a-fA-F]+$")) //base8 number
                     {
                         if (TryAndSwallow(() => Convert.ToByte(v, 8), out result)) { }
                         else if (TryAndSwallow(() => Convert.ToInt16(v, 8), out result)) { }
@@ -380,7 +380,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                             result = v;
                         }
                     }
-                    else if (Regex.IsMatch(v, @"[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?")) //regular number
+                    else if (Regex.IsMatch(v, @"^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$")) //regular number
                     {
                         if (byte.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var byteValue)) { result = byteValue; }
                         else if (short.TryParse(v, NumberStyles.Integer, formatter.NumberFormat, out var shortValue)) { result = shortValue; }

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -356,6 +356,7 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                 default:
                     if (Regex.IsMatch(v, "^0x[0-9a-fA-F]+$")) //base16 number
                     {
+                        v = v.Substring(2);
                         if (byte.TryParse(v, NumberStyles.AllowHexSpecifier, formatter.NumberFormat, out var byteValue)) { result = byteValue; }
                         else if (short.TryParse(v, NumberStyles.AllowHexSpecifier, formatter.NumberFormat, out var shortValue)) { result = shortValue; }
                         else if (int.TryParse(v, NumberStyles.AllowHexSpecifier, formatter.NumberFormat, out var intValue)) { result = intValue; }


### PR DESCRIPTION
This PR intended to fix following issues.

**1. Change number checks to more strict regex**
It's discussed at https://github.com/aaubry/YamlDotNet/pull/990#issuecomment-2405797524
When parsing scalar values. whitespaces are already ignored by scanner.
So there is no needs using  `partial regex match`.

**2. Change Hex string format parse logics not to throw exceptions**
Same as integer/float string format. (That is fixed at #990)