### PR TITLE
Disable fsharp on AOT/Trimming

### DIFF
--- a/YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
+++ b/YamlDotNet.Core7AoTCompileTest/YamlDotNet.Core7AoTCompileTest.csproj
@@ -6,6 +6,8 @@
     <PublishAot>true</PublishAot>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <Nullable>enable</Nullable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-AOT|AnyCPU' ">

--- a/YamlDotNet/Helpers/DefaultFsharpHelper.cs
+++ b/YamlDotNet/Helpers/DefaultFsharpHelper.cs
@@ -1,0 +1,85 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.Helpers
+{
+    public class DefaultFsharpHelper : IFsharpHelper
+    {
+        private static bool IsFsharpCore(Type t)
+        {
+            return t.Namespace == "Microsoft.FSharp.Core";
+        }
+
+        public bool IsOptionType(Type t)
+        {
+            return IsFsharpCore(t) && t.Name == "FSharpOption`1";
+        }
+
+        public Type? GetOptionUnderlyingType(Type t)
+        {
+            return t.IsGenericType && IsOptionType(t) ? t.GenericTypeArguments[0] : null;
+        }
+
+        public object? GetValue(IObjectDescriptor objectDescriptor)
+        {
+            if (!IsOptionType(objectDescriptor.Type))
+            {
+                throw new InvalidOperationException("Should not be called on non-Option<> type");
+            }
+
+            if (objectDescriptor.Value is null)
+            {
+                return null;
+            }
+
+            return objectDescriptor.Type.GetProperty("Value").GetValue(objectDescriptor.Value);
+        }
+
+        public bool IsFsharpListType(Type t)
+        {
+            return t.Namespace == "Microsoft.FSharp.Collections" && t.Name == "FSharpList`1";
+        }
+
+        public object? CreateFsharpListFromArray(Type t, Type itemsType, Array arr)
+        {
+            if (!IsFsharpListType(t))
+            {
+                return null;
+            }
+
+            var fsharpList =
+                t.Assembly
+                .GetType("Microsoft.FSharp.Collections.ListModule")
+                .GetMethod("OfArray")
+                .MakeGenericMethod(itemsType)
+                .Invoke(null, [arr]);
+
+            return fsharpList;
+        }
+    }
+}

--- a/YamlDotNet/Helpers/IFsharpHelper.cs
+++ b/YamlDotNet/Helpers/IFsharpHelper.cs
@@ -24,18 +24,12 @@ using YamlDotNet.Serialization;
 
 namespace YamlDotNet.Helpers
 {
-    public static class FsharpHelper
+    public interface IFsharpHelper
     {
-        public static IFsharpHelper? Instance { get; set; }
-
-        public static bool IsOptionType(Type t) => Instance?.IsOptionType(t) ?? false;
-
-        public static Type? GetOptionUnderlyingType(Type t) => Instance?.GetOptionUnderlyingType(t);
-
-        public static object? GetValue(IObjectDescriptor objectDescriptor) => Instance?.GetValue(objectDescriptor);
-
-        public static bool IsFsharpListType(Type t) => Instance?.IsFsharpListType(t) ?? false;
-
-        public static object? CreateFsharpListFromArray(Type t, Type itemsType, Array arr) => Instance?.CreateFsharpListFromArray(t, itemsType, arr);
+        bool IsOptionType(Type t);
+        Type? GetOptionUnderlyingType(Type t);
+        object? GetValue(IObjectDescriptor objectDescriptor);
+        bool IsFsharpListType(Type t);
+        object? CreateFsharpListFromArray(Type t, Type itemsType, Array arr);
     }
 }

--- a/YamlDotNet/Helpers/NullFsharpHelper.cs
+++ b/YamlDotNet/Helpers/NullFsharpHelper.cs
@@ -24,18 +24,19 @@ using YamlDotNet.Serialization;
 
 namespace YamlDotNet.Helpers
 {
-    public static class FsharpHelper
+    /// <summary>
+    /// Empty implementation of the fsharphelper to allow trimming of csharp applications.
+    /// </summary>
+    public class NullFsharpHelper : IFsharpHelper
     {
-        public static IFsharpHelper? Instance { get; set; }
+        public object? CreateFsharpListFromArray(Type t, Type itemsType, Array arr) => null;
 
-        public static bool IsOptionType(Type t) => Instance?.IsOptionType(t) ?? false;
+        public Type? GetOptionUnderlyingType(Type t) => null;
 
-        public static Type? GetOptionUnderlyingType(Type t) => Instance?.GetOptionUnderlyingType(t);
+        public object? GetValue(IObjectDescriptor objectDescriptor) => null;
 
-        public static object? GetValue(IObjectDescriptor objectDescriptor) => Instance?.GetValue(objectDescriptor);
+        public bool IsFsharpListType(Type t) => false;
 
-        public static bool IsFsharpListType(Type t) => Instance?.IsFsharpListType(t) ?? false;
-
-        public static object? CreateFsharpListFromArray(Type t, Type itemsType, Array arr) => Instance?.CreateFsharpListFromArray(t, itemsType, arr);
+        public bool IsOptionType(Type t) => false;
     }
 }

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -485,6 +485,11 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public IDeserializer Build()
         {
+            if (FsharpHelper.Instance == null)
+            {
+                FsharpHelper.Instance = new DefaultFsharpHelper();
+            }
+
             return Deserializer.FromValueDeserializer(BuildValueDeserializer());
         }
 

--- a/YamlDotNet/Serialization/SerializerBuilder.cs
+++ b/YamlDotNet/Serialization/SerializerBuilder.cs
@@ -688,6 +688,11 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public ISerializer Build()
         {
+            if (FsharpHelper.Instance == null)
+            {
+                FsharpHelper.Instance = new DefaultFsharpHelper();
+            }
+
             return Serializer.FromValueSerializer(BuildValueSerializer(), emitterSettings);
         }
 

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -37,6 +37,7 @@ using YamlDotNet.Serialization.TypeInspectors;
 using YamlDotNet.Serialization.TypeResolvers;
 using YamlDotNet.Serialization.Utilities;
 using YamlDotNet.Serialization.ValueDeserializers;
+using YamlDotNet.Helpers;
 
 namespace YamlDotNet.Serialization
 {


### PR DESCRIPTION
Disables some of the FSharp specific functionality when doing AOT/Trimming. AOT/Trimming is not fully supported by .NET for FSharp.

Fixes #1012 