### PR TITLE
fix #1031

### DIFF
--- a/YamlDotNet.Analyzers.StaticGenerator/TypeFactoryGenerator.cs
+++ b/YamlDotNet.Analyzers.StaticGenerator/TypeFactoryGenerator.cs
@@ -89,10 +89,14 @@ namespace YamlDotNet.Analyzers.StaticGenerator
                 write("using System;", true);
                 write("using System.Collections.Generic;", true);
 
-                var namespaceName = syntaxReceiver.YamlStaticContextType?.ContainingNamespace.ContainingNamespace;
+                var namespaceName = syntaxReceiver.YamlStaticContextType?.ContainingNamespace?.Name;
+                var isGlobalNamespace = string.IsNullOrEmpty(namespaceName);
 
-                write($"namespace {syntaxReceiver.YamlStaticContextType?.GetNamespace() ?? "YamlDotNet.Static"}", true);
-                write("{", true); indent();
+                if (!isGlobalNamespace)
+                {
+                    write($"namespace {namespaceName}", true);
+                    write("{", true); indent();
+                }
 
                 new StaticContextFile(write, indent, unindent, _context).Write(syntaxReceiver);
                 new StaticObjectFactoryFile(write, indent, unindent, _context).Write(syntaxReceiver);
@@ -101,7 +105,10 @@ namespace YamlDotNet.Analyzers.StaticGenerator
                 new StaticTypeInspectorFile(write, indent, unindent, _context).Write(syntaxReceiver);
                 new ObjectAccessorFileGenerator(write, indent, unindent, _context).Write(syntaxReceiver);
 
-                unindent(); write("}", true);
+                if (!isGlobalNamespace)
+                {
+                    unindent(); write("}", true);
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
## What cause the issue

In line 94

https://github.com/aaubry/YamlDotNet/blob/b8ac2a98ffcc12434eff6c6abb75b38ad1b1ab04/YamlDotNet.Analyzers.StaticGenerator/TypeFactoryGenerator.cs#L92-L98

When the StaticContext to be generated is in the global namespace, `syntaxReceiver.YamlStaticContextType?.GetNamespace()` returns an empty string instead of null. As a result, the `??` operator does not take effect.

So, the generated code in `YamlDotNetAutoGraph.g.cs` ends up as follows:
```CSharp
...
namespace 
{
    ...
```
Since there is no identifier following `namespace`, the compilation fails.

## About unit test case

Due to the stringent conditions required to trigger this issue, I am unsure how to write a unit test. Should I create a new console project to reproduce the issue?

## A potential problem

When the auto-generated `StaticContext` is in the global namespace, other classes, such as `StaticObjectFactory`, will also be created in the global namespace. This could potentially conflict with other classes.