### PR TITLE
Add Failing Test for Null Type Serialization

### DIFF
--- a/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTestHelper.cs
@@ -383,6 +383,7 @@ namespace YamlDotNet.Test.Serialization
         public Point MyPoint { get; set; }
         public int? MyNullableWithValue { get; set; }
         public int? MyNullableWithoutValue { get; set; }
+        public Type MyType { get; set; }
 
         public Example()
         {
@@ -393,6 +394,7 @@ namespace YamlDotNet.Test.Serialization
             MyTimeSpan = TimeSpan.FromHours(1);
             MyPoint = new Point(100, 200);
             MyNullableWithValue = 8;
+            MyType = typeof(string);
         }
     }
 

--- a/YamlDotNet.Test/Serialization/SerializationTests.cs
+++ b/YamlDotNet.Test/Serialization/SerializationTests.cs
@@ -951,6 +951,14 @@ y:
         }
 
         [Fact]
+        public void CanSerializeNullType()
+        {
+            var serializer = new SerializerBuilder().Build();
+            var yaml = serializer.Serialize(new Example { MyType = null });
+            yaml.Should().Contain($"MyType: {Environment.NewLine}");
+        }
+
+        [Fact]
         public void SerializationOfNumericsAsJsonRountTrip()
         {
             var serializer = new SerializerBuilder().JsonCompatible().Build();


### PR DESCRIPTION
Added a test to demonstrate a bug where CLR types can't be serialised if they're null.