### PR TITLE
Use string interning

### DIFF
--- a/YamlDotNet/Core/AnchorName.cs
+++ b/YamlDotNet/Core/AnchorName.cs
@@ -39,12 +39,17 @@ namespace YamlDotNet.Core
 
         public AnchorName(string value)
         {
-            this.value = value ?? throw new ArgumentNullException(nameof(value));
+            if (value != null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
 
             if (!AnchorPattern.IsMatch(value))
             {
                 throw new ArgumentException($"Anchor cannot be empty or contain disallowed characters: []{{}},\nThe value was '{value}'.", nameof(value));
             }
+            
+            this.value = string.Intern(value);
         }
 
         public override string ToString() => value ?? "[empty]";

--- a/YamlDotNet/Core/Events/Scalar.cs
+++ b/YamlDotNet/Core/Events/Scalar.cs
@@ -79,7 +79,7 @@ namespace YamlDotNet.Core.Events
         public Scalar(AnchorName anchor, TagName tag, string value, ScalarStyle style, bool isPlainImplicit, bool isQuotedImplicit, Mark start, Mark end, bool isKey = false)
             : base(anchor, tag, start, end)
         {
-            this.Value = value;
+            this.Value = (isKey || value.Length < 40) ? string.Intern(value) : value;
             this.Style = style;
             this.IsPlainImplicit = isPlainImplicit;
             this.IsQuotedImplicit = isQuotedImplicit;

--- a/YamlDotNet/Core/TagName.cs
+++ b/YamlDotNet/Core/TagName.cs
@@ -39,7 +39,7 @@ namespace YamlDotNet.Core
 
         public TagName(string value)
         {
-            this.value = value ?? throw new ArgumentNullException(nameof(value));
+            this.value = string.Intern(value);
 
             if (value.Length == 0)
             {


### PR DESCRIPTION
This cuts about 20% of parsing cost and probably more in final object graph size, depending on input data.

In terms of the LoadLarge benchmark:

| Method           | Mean     | Error   | StdDev   | Gen0      | Gen1      | Gen2      | Allocated |
|-----------------:|---------:|--------:|---------:|----------:|----------:|----------:|----------:|
| LoadLarge before | 136.9 ms | 3.11 ms | 9.03 ms  | 7500.0000 | 3500.0000 | 1500.0000 |  39.65 MB |
| LoadLarge after  | 114.4 ms | 3.70 ms | 10.67 ms | 6000.0000 | 2000.0000 | 1000.0000 |  39.65 MB |

This is just a simple string.Intern call. It might make sense to emplyor pass a pool, like a XmlNameTable does with XML, to save on scalar objects not just strings.

