### PR TITLE
Allow specifying a maximum recursion for the deserializer

### DIFF
--- a/YamlDotNet.Test/Serialization/MaximumRecursionTests.cs
+++ b/YamlDotNet.Test/Serialization/MaximumRecursionTests.cs
@@ -1,0 +1,83 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.Test.Serialization;
+
+public class MaximumRecursionTests
+{
+    [Fact]
+    public void Given_DeeplyNestedObject_Serializer_Should_Throw_MaximumRecursionLevelReachedException_When_WithMaximumRecursion_Is_Specified()
+    {
+        var deeplyNested = Enumerable.Range(1, 10)
+            .Aggregate(Array.Empty<object>(), (root, _) => [root]);
+
+        var sut = new SerializerBuilder()
+            .WithMaximumRecursion(5)
+            .Build();
+
+        Assert.Throws<MaximumRecursionLevelReachedException>(() => sut.Serialize(deeplyNested));
+    }
+
+    [Fact]
+    public void Given_DeeplyNestedSequence_Deserializer_Should_Throw_MaximumRecursionLevelReachedException_When_WithMaximumRecursion_Is_Specified()
+    {
+        var deeplyNested = "[[[[[[[[[[]]]]]]]]]]";
+
+        var sut = new DeserializerBuilder()
+            .WithMaximumRecursion(5)
+            .Build();
+
+        Assert.Throws<MaximumRecursionLevelReachedException>(() => sut.Deserialize(deeplyNested));
+    }
+
+    [Fact]
+    public void Given_DeeplyNestedMapping_Deserializer_Should_Throw_MaximumRecursionLevelReachedException_When_WithMaximumRecursion_Is_Specified()
+    {
+        var deeplyNested = "{ a: { a: { a: { a: { a: { a: { a: 0 } } } } } } }";
+
+        var sut = new DeserializerBuilder()
+            .WithMaximumRecursion(5)
+            .Build();
+
+        Assert.Throws<MaximumRecursionLevelReachedException>(() => sut.Deserialize(deeplyNested));
+    }
+
+    [Fact]
+    public void Given_DeeplyNestedMappingAndSequenceMix_Deserializer_Should_Throw_MaximumRecursionLevelReachedException_When_WithMaximumRecursion_Is_Specified()
+    {
+        var deeplyNested = "[ { a: [ { a: { a: 0 } } ] } ]";
+
+        var sut = new DeserializerBuilder()
+            .WithMaximumRecursion(5)
+            .Build();
+
+        Assert.Throws<MaximumRecursionLevelReachedException>(() => sut.Deserialize(deeplyNested));
+    }
+}

--- a/YamlDotNet/Core/RecursionLevel.cs
+++ b/YamlDotNet/Core/RecursionLevel.cs
@@ -43,11 +43,11 @@ namespace YamlDotNet.Core
         /// and throws <see cref="MaximumRecursionLevelReachedException"/>
         /// if <see cref="Maximum"/> is reached.
         /// </summary>
-        public void Increment()
+        public void Increment(in Mark start, in Mark end)
         {
             if (!TryIncrement())
             {
-                throw new MaximumRecursionLevelReachedException("Maximum level of recursion reached");
+                throw new MaximumRecursionLevelReachedException(start, end, "Maximum level of recursion reached");
             }
         }
 

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -303,7 +303,7 @@ namespace YamlDotNet.RepresentationModel
         /// </summary>
         internal override IEnumerable<YamlNode> SafeAllNodes(RecursionLevel level)
         {
-            level.Increment();
+            level.Increment(Start, End);
             yield return this;
             foreach (var child in children)
             {

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -218,7 +218,7 @@ namespace YamlDotNet.RepresentationModel
         /// </summary>
         internal override IEnumerable<YamlNode> SafeAllNodes(RecursionLevel level)
         {
-            level.Increment();
+            level.Increment(Start, End);
             yield return this;
             foreach (var child in children)
             {

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -485,7 +485,7 @@ namespace YamlDotNet.Serialization
         /// Sets the maximum recursion that is allowed while building the object graph.
         /// </summary>
         /// <remarks>
-        /// Setting this limit is stringly recommended when parsing untrusted input since
+        /// Setting this limit is strongly recommended when parsing untrusted input since
         /// deeply nested objects will lead to a stack overflow.
         /// </remarks>
         public DeserializerBuilder WithMaximumRecursion(int maximumRecursion)

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -61,6 +61,7 @@ namespace YamlDotNet.Serialization
         private bool attemptUnknownTypeDeserialization;
         private bool enforceNullability;
         private bool caseInsensitivePropertyMatching;
+        private int? maximumRecursion;
 
         /// <summary>
         /// Initializes a new <see cref="DeserializerBuilder" /> using the default component registrations.

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -453,4 +453,22 @@ namespace YamlDotNet.Serialization
             );
         }
     }
+
+    /// <summary>
+    /// Sets the maximum recursion that is allowed while deserializing.
+    /// </summary>
+    /// <remarks>
+    /// Setting this limit is strongly recommended when parsing untrusted input since
+    /// deeply nested objects will lead to a stack overflow.
+    /// </remarks>
+    public StaticDeserializerBuilder WithMaximumRecursion(int maximumRecursion)
+    {
+        if (maximumRecursion <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumRecursion), $"The maximum recursion specified ({maximumRecursion}) is invalid. It should be a positive integer.");
+        }
+
+        this.maximumRecursion = maximumRecursion;
+        return this;
+    }
 }

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -442,15 +442,20 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public IValueDeserializer BuildValueDeserializer()
         {
-            return new AliasValueDeserializer(
-                new NodeValueDeserializer(
+            var valueDeserializer = new NodeValueDeserializer(
                     nodeDeserializerFactories.BuildComponentList(),
                     nodeTypeResolverFactories.BuildComponentList(),
                     typeConverter,
                     enumNamingConvention,
                     BuildTypeInspector()
-                )
-            );
+                );
+
+            if (maximumRecursion != null)
+            {
+                valueDeserializer = new MaximumRecursionValueDeserializer(valueDeserializer, maximumRecursion.Value);
+            }
+
+            return new AliasValueDeserializer(valueDeserializer);
         }
 
         /// <summary>

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -442,7 +442,7 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public IValueDeserializer BuildValueDeserializer()
         {
-            var valueDeserializer = new NodeValueDeserializer(
+            IValueDeserializer valueDeserializer = new NodeValueDeserializer(
                     nodeDeserializerFactories.BuildComponentList(),
                     nodeTypeResolverFactories.BuildComponentList(),
                     typeConverter,

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -452,23 +452,23 @@ namespace YamlDotNet.Serialization
                 )
             );
         }
-    }
 
-    /// <summary>
-    /// Sets the maximum recursion that is allowed while deserializing.
-    /// </summary>
-    /// <remarks>
-    /// Setting this limit is strongly recommended when parsing untrusted input since
-    /// deeply nested objects will lead to a stack overflow.
-    /// </remarks>
-    public StaticDeserializerBuilder WithMaximumRecursion(int maximumRecursion)
-    {
-        if (maximumRecursion <= 0)
+        /// <summary>
+        /// Sets the maximum recursion that is allowed while deserializing.
+        /// </summary>
+        /// <remarks>
+        /// Setting this limit is strongly recommended when parsing untrusted input since
+        /// deeply nested objects will lead to a stack overflow.
+        /// </remarks>
+        public StaticDeserializerBuilder WithMaximumRecursion(int maximumRecursion)
         {
-            throw new ArgumentOutOfRangeException(nameof(maximumRecursion), $"The maximum recursion specified ({maximumRecursion}) is invalid. It should be a positive integer.");
-        }
+            if (maximumRecursion <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumRecursion), $"The maximum recursion specified ({maximumRecursion}) is invalid. It should be a positive integer.");
+            }
 
-        this.maximumRecursion = maximumRecursion;
-        return this;
+            this.maximumRecursion = maximumRecursion;
+            return this;
+        }
     }
 }

--- a/YamlDotNet/Serialization/Utilities/SerializerState.cs
+++ b/YamlDotNet/Serialization/Utilities/SerializerState.cs
@@ -36,9 +36,15 @@ namespace YamlDotNet.Serialization.Utilities
         public T Get<T>()
             where T : class, new()
         {
+            return Get(static () => new T());
+        }
+
+        public T Get<T>(Func<T> factory)
+            where T : class
+        {
             if (!items.TryGetValue(typeof(T), out var value))
             {
-                value = new T();
+                value = factory();
                 items.Add(typeof(T), value);
             }
             return (T)value;

--- a/YamlDotNet/Serialization/ValueDeserializers/MaximumRecursionValueDeserializer.cs
+++ b/YamlDotNet/Serialization/ValueDeserializers/MaximumRecursionValueDeserializer.cs
@@ -1,0 +1,53 @@
+﻿// This file is part of YamlDotNet - A .NET library for YAML.
+// Copyright (c) Antoine Aubry and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization.Utilities;
+
+namespace YamlDotNet.Serialization.ValueDeserializers;
+
+public sealed class MaximumRecursionValueDeserializer : IValueDeserializer
+{
+    private readonly IValueDeserializer innerDeserializer;
+    private readonly int maximumRecursion;
+
+    public MaximumRecursionValueDeserializer(IValueDeserializer innerDeserializer, int maximumRecursion)
+    {
+        this.innerDeserializer = innerDeserializer ?? throw new ArgumentNullException(nameof(innerDeserializer));
+        this.maximumRecursion = maximumRecursion;
+    }
+
+    public object? DeserializeValue(IParser parser, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
+    {
+        var counter = state.Get(() => new RecursionLevel(maximumRecursion));
+
+        counter.Increment(parser.Current.Start, parser.Current.End);
+        var result = innerDeserializer.DeserializeValue(parser, expectedType, state, nestedObjectDeserializer);
+        counter.Decrement();
+
+        return result;
+    }
+}


### PR DESCRIPTION
This adds a `WithMaximumRecursion` method to `DeserializerBuilder`. It allows to limit the maximum allowed depth when deserializing a document. This is particularly useful when parsing untrusted YAML as allowing unbounded depth may lead to a stack overflow which might crash the process.

The signature of the method is the same as the one on `SerializerBuilder`, but in this case there is no default limit as adding one would be a breaking change.

I did reuse the existing `RecursionLevel` class to control the recursion but had to make a few adjustments as I felt it was useful to have the start and end markers in the exception. It was also necessary to add an overload to the SerializerState class to enable constructors with parameters.

I have added a few tests for both methods since the one on `SerializerBuilder` didn't have any.