### PR TITLE
Improve type fidelity in UnquotedStringTypeDeserialization test

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -239,7 +239,7 @@ b: &number 1
             var deserializer = new DeserializerBuilder()
                 .WithAttemptingUnquotedStringTypeDeserialization().Build();
 
-            var yaml = $"Value: {expected}";
+            var yaml = FormattableString.Invariant($"Value: {expected}");
 
 #if NETFRAMEWORK
             // It needs explicitly specifying maximum precision for value roundtrip. 
@@ -255,6 +255,7 @@ b: &number 1
 
             var resultDict = deserializer.Deserialize<IDictionary<string, object>>(yaml);
             Assert.True(resultDict.ContainsKey("Value"));
+            Assert.Equal(expected.GetType(), resultDict["Value"].GetType());
             Assert.Equal(expected, resultDict["Value"]);
         }
 


### PR DESCRIPTION
Improve type fidelity in UnquotedStringTypeDeserialization test

Use FormattableString.Invariant for culture-invariant YAML formatting. Add assertion to verify deserialized value type matches expected type.

WithAttemptingUnquotedStringTypeDeserialization supports floating point numbers (single/double), but with hard-coded match of '.' as decimal separator only.

fixes #1075
