### PR TITLE
Add max depth handling to StaticDeserializerBuilder (builds on #1072)

### DIFF
--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -442,7 +442,7 @@ namespace YamlDotNet.Serialization
         /// </summary>
         public IValueDeserializer BuildValueDeserializer()
         {
-            var valueDeserializer = new NodeValueDeserializer(
+            IValueDeserializer valueDeserializer = new NodeValueDeserializer(
                     nodeDeserializerFactories.BuildComponentList(),
                     nodeTypeResolverFactories.BuildComponentList(),
                     typeConverter,


### PR DESCRIPTION
This PR builds on top of #1072 and adds the same max depth handling to `StaticDeserializerBuilder.cs`, as mentioned in the [review comments](https://github.com/aaubry/YamlDotNet/pull/1072#discussion_r2674971522).

Happy to adjust if needed.