### PR TITLE
Add a parse method wrapper and caching to fix AoT compilation

### DIFF
--- a/YamlDotNet.Analyzers.StaticGenerator/StaticTypeInspectorFile.cs
+++ b/YamlDotNet.Analyzers.StaticGenerator/StaticTypeInspectorFile.cs
@@ -155,6 +155,38 @@ namespace YamlDotNet.Analyzers.StaticGenerator
             Write("return value.ToString();");
             UnIndent(); Write("}");
 
+            Write("public bool HasParseMethod(Type type)");
+            Write("{"); Indent();
+            foreach (var o in syntaxReceiver.Classes)
+            {
+                var classObject = o.Value;
+                if (classObject.ModuleSymbol.GetMembers("Parse").OfType<IMethodSymbol>().Any(m => m.IsStatic && m.Parameters.Length == 1 && m.Parameters[0].Type.SpecialType == SpecialType.System_String))
+                {
+                    Write($"if (type == typeof({classObject.ModuleSymbol.GetFullName().Replace("?", string.Empty)}))");
+                    Write("{"); Indent();
+                    Write("return true;");
+                    UnIndent(); Write("}");
+                }
+            }
+            Write("return false;");
+            UnIndent(); Write("}");
+
+            Write("public object Parse(string value, Type expectedType)");
+            Write("{"); Indent();
+            foreach (var o in syntaxReceiver.Classes)
+            {
+                var classObject = o.Value;
+                if (classObject.ModuleSymbol.GetMembers("Parse").OfType<IMethodSymbol>().Any(m => m.IsStatic && m.Parameters.Length == 1 && m.Parameters[0].Type.SpecialType == SpecialType.System_String))
+                {
+                    Write($"if (expectedType == typeof({classObject.ModuleSymbol.GetFullName().Replace("?", string.Empty)}))");
+                    Write("{"); Indent();
+                    Write($"return {classObject.ModuleSymbol.GetFullName().Replace("?", string.Empty)}.Parse(value);");
+                    UnIndent(); Write("}");
+                }
+            }
+            Write("throw new InvalidOperationException($\"Type '{expectedType.FullName}' does not have a static Parse method.\");");
+            UnIndent(); Write("}");
+
             UnIndent(); Write("}");
         }
 

--- a/YamlDotNet.Analyzers.StaticGenerator/StaticTypeInspectorFile.cs
+++ b/YamlDotNet.Analyzers.StaticGenerator/StaticTypeInspectorFile.cs
@@ -176,7 +176,14 @@ namespace YamlDotNet.Analyzers.StaticGenerator
             foreach (var o in syntaxReceiver.Classes)
             {
                 var classObject = o.Value;
-                if (classObject.ModuleSymbol.GetMembers("Parse").OfType<IMethodSymbol>().Any(m => m.IsStatic && m.Parameters.Length == 1 && m.Parameters[0].Type.SpecialType == SpecialType.System_String))
+                if (classObject.ModuleSymbol
+                        .GetMembers("Parse")
+                        .OfType<IMethodSymbol>()
+                        .Any(m => m.DeclaredAccessibility == Accessibility.Public &&
+                                m.IsStatic &&
+                                m.Parameters.Length == 1 &&
+                                m.Parameters[0].Type.SpecialType == SpecialType.System_String &&
+                                SymbolEqualityComparer.Default.Equals(m.ReturnType, classObject.ModuleSymbol)))
                 {
                     Write($"if (expectedType == typeof({classObject.ModuleSymbol.GetFullName().Replace("?", string.Empty)}))");
                     Write("{"); Indent();

--- a/YamlDotNet.Core7AoTCompileTest/Program.cs
+++ b/YamlDotNet.Core7AoTCompileTest/Program.cs
@@ -32,6 +32,7 @@ using YamlDotNet.Core;
 using YamlDotNet.Core7AoTCompileTest.Model;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.Callbacks;
+using YamlDotNet.Serialization.NamingConventions;
 
 string yaml = string.Create(CultureInfo.InvariantCulture, $@"MyBool: true
 hi: 1
@@ -106,6 +107,7 @@ var input = new StringReader(yaml);
 
 var aotContext = new YamlDotNet.Core7AoTCompileTest.StaticContext();
 var deserializer = new StaticDeserializerBuilder(aotContext)
+    .WithNamingConvention(UnderscoredNamingConvention.Instance)
     .Build();
 
 var x = deserializer.Deserialize<PrimitiveTypes>(input);
@@ -189,16 +191,17 @@ Console.WriteLine("==============");
 Console.WriteLine("Serialized:");
 
 var serializer = new StaticSerializerBuilder(aotContext)
+    .WithNamingConvention(UnderscoredNamingConvention.Instance)
     .Build();
 
 var output = serializer.Serialize(x);
 Console.WriteLine(output);
 Console.WriteLine("============== Done with the primary object");
 
-yaml = @"- myArray:
+yaml = @"- my_array:
   - 1
   - 2
-- myArray:
+- my_array:
   - 3
   - 4
 ";

--- a/YamlDotNet.Test/Serialization/MergingParserTests.cs
+++ b/YamlDotNet.Test/Serialization/MergingParserTests.cs
@@ -162,53 +162,60 @@ Level3: {}
             // Timebox this test to avoid infinite loops in case of bugs.
             // 30 seconds should be more than enough for this test to run even on a slow machine, and if it takes longer than that,
             // it's likely that the merging parser is not correctly counting events and enforcing the limit.
-            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             cancellationTokenSource.Token.Register(() =>
             {
                 throw new TimeoutException("The test took too long, likely due to an infinite loop in the merging parser.");
             });
 
-            await Task.Run(() =>
+            try
             {
-                var sb = new StringBuilder();
-
-                // Base anchor
-                sb.AppendLine("a0: &a0");
-                sb.AppendLine("  x: 1");
-                sb.AppendLine();
-
-                // Each level merges the previous anchor TWICE (fanout=2), doubling event count
-                for (int i = 1; i <= 25; i++)
+                await Task.Run(() =>
                 {
-                    sb.AppendLine($"a{i}: &a{i}");
-                    sb.AppendLine($"  <<: *a{i - 1}");  // first merge
-                    sb.AppendLine($"  <<: *a{i - 1}");  // second merge
+                    var sb = new StringBuilder();
+
+                    // Base anchor
+                    sb.AppendLine("a0: &a0");
+                    sb.AppendLine("  x: 1");
                     sb.AppendLine();
-                }
 
-                sb.AppendLine("final:");
-                sb.AppendLine("  <<: *a25");
-
-                var yaml = sb.ToString();
-                var parser = new Parser(new StringReader(yaml));
-                var mergingParser = new MergingParser(parser, 1000);
-                try
-                {
-                    while (mergingParser.MoveNext())
+                    // Each level merges the previous anchor TWICE (fanout=2), doubling event count
+                    for (int i = 1; i <= 25; i++)
                     {
-                        //move through everything, we're in a timebox so if this takes too long, the cancellation token will trigger and fail the test
+                        sb.AppendLine($"a{i}: &a{i}");
+                        sb.AppendLine($"  <<: *a{i - 1}");  // first merge
+                        sb.AppendLine($"  <<: *a{i - 1}");  // second merge
+                        sb.AppendLine();
                     }
-                }
-                catch (YamlException ex) when (ex.Message.Contains("Too many parsing events"))
-                {
-                    // Expected exception, test passes
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    throw new Exception($"Unexpected exception", ex);
-                }
-            }, cancellationTokenSource.Token);
+
+                    sb.AppendLine("final:");
+                    sb.AppendLine("  <<: *a25");
+
+                    var yaml = sb.ToString();
+                    var parser = new Parser(new StringReader(yaml));
+                    var mergingParser = new MergingParser(parser, 1000);
+                    try
+                    {
+                        while (mergingParser.MoveNext())
+                        {
+                            //move through everything, we're in a timebox so if this takes too long, the cancellation token will trigger and fail the test
+                        }
+                    }
+                    catch (YamlException ex) when (ex.Message.Contains("Too many parsing events"))
+                    {
+                        // Expected exception, test passes
+                        return;
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"Unexpected exception", ex);
+                    }
+                }, cancellationTokenSource.Token);
+            }
+            catch (TimeoutException ex)
+            {
+                Assert.Fail($"Test failed due to timeout: {ex.Message}");
+            }
         }
 
         [Fact]
@@ -217,42 +224,51 @@ Level3: {}
             // Timebox this test to avoid infinite loops in case of bugs.
             // 30 seconds should be more than enough for this test to run even on a slow machine, and if it takes longer than that,
             // it's likely that the merging parser is not correctly counting events and enforcing the limit.
-            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             cancellationTokenSource.Token.Register(() =>
             {
                 throw new TimeoutException("The test took too long, likely due to an infinite loop in the merging parser.");
             });
 
-            await Task.Run(() =>
+            try
             {
-                var sb = new StringBuilder();
-                sb.AppendLine("base: &base");
-                for (var i = 0; i < 25; i++)
+                await Task.Run(() =>
                 {
-                    sb.AppendLine($"  k{i}: v{i}");
-                }
-
-                sb.AppendLine();
-                for (var i = 0; i < 35; i++)
-                {
-                    sb.AppendLine($"entry{i}:");
-                    sb.AppendLine("  <<: *base");
-                    sb.AppendLine();
-                }
-
-                var parser = new Parser(new StringReader(sb.ToString()));
-                var mergingParser = new MergingParser(parser, 1000);
-
-                Action parse = () =>
-                {
-                    while (mergingParser.MoveNext())
+                    var sb = new StringBuilder();
+                    sb.AppendLine("base: &base");
+                    for (var i = 0; i < 25; i++)
                     {
+                        sb.AppendLine($"  k{i}: v{i}");
                     }
-                };
 
-                parse.Should().Throw<YamlException>()
-                    .Where(ex => ex.Message.Contains("Too many parsing events"));
-            }, cancellationTokenSource.Token);
+                    sb.AppendLine();
+                    for (var i = 0; i < 35; i++)
+                    {
+                        sb.AppendLine($"entry{i}:");
+                        sb.AppendLine("  <<: *base");
+                        sb.AppendLine();
+                    }
+
+                    var parser = new Parser(new StringReader(sb.ToString()));
+                    var mergingParser = new MergingParser(parser, 1000);
+                    var totalParsedEvents = 0;
+                    Action parse = () =>
+                    {
+                        while (mergingParser.MoveNext())
+                        {
+                            totalParsedEvents++;
+                        }
+                    };
+
+                    parse.Should().Throw<YamlException>()
+                        .Where(ex => ex.Message.Contains("Too many parsing events"));
+                    Console.WriteLine($"Total parsed events before exception: {totalParsedEvents}");
+                }, cancellationTokenSource.Token);
+            }
+            catch (TimeoutException ex)
+            {
+                Assert.Fail($"Test failed due to timeout: {ex.Message}");
+            }
         }
 
         [Fact]

--- a/YamlDotNet/Serialization/ITypeInspector.cs
+++ b/YamlDotNet/Serialization/ITypeInspector.cs
@@ -66,5 +66,19 @@ namespace YamlDotNet.Serialization
         /// <param name="enumValue"></param>
         /// <returns></returns>
         string GetEnumValue(object enumValue);
+
+        /// <summary>
+        /// Indicates whether the specified type has a static Parse method that can be used to convert a string to an instance of that type.
+        /// </summary>
+        /// <param name="type">The type to check for a static Parse method.</param>
+        /// <returns>True if the type has a static Parse method; otherwise, false.</returns>
+        bool HasParseMethod(Type type);
+
+        /// <summary> Converts a string to an instance of the specified type using a static Parse method.
+        /// </summary>
+        /// <param name="value">The string value to convert.</param>
+        /// <param name="expectedType">The type to convert the string to.</param>
+        /// <returns>An instance of the specified type.</returns>
+        object? Parse(string value, Type expectedType);
     }
 }

--- a/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
+++ b/YamlDotNet/Serialization/NodeDeserializers/ScalarNodeDeserializer.cs
@@ -147,17 +147,9 @@ namespace YamlDotNet.Serialization.NodeDeserializers
                         // TimeSpan, DateTimeOffset, Guid, IPAddress, and others.
                         // This is especially important for the static/AOT deserialization
                         // path where the typeConverter is a NullTypeConverter.
-                        var parseMethod = underlyingType.GetPublicStaticMethod("Parse", typeof(string), typeof(IFormatProvider));
-                        if (parseMethod != null)
+                        if (typeInspector.HasParseMethod(underlyingType))
                         {
-                            try
-                            {
-                                value = parseMethod.Invoke(null, new object[] { scalar.Value, CultureInfo.InvariantCulture });
-                            }
-                            catch (System.Reflection.TargetInvocationException ex) when (ex.InnerException != null)
-                            {
-                                throw ex.InnerException;
-                            }
+                            value = typeInspector.Parse(scalar.Value, underlyingType);
                         }
                         else
                         {

--- a/YamlDotNet/Serialization/TypeInspectors/CachedTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/CachedTypeInspector.cs
@@ -36,6 +36,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
         private readonly ConcurrentDictionary<Type, List<IPropertyDescriptor>> cache = new ConcurrentDictionary<Type, List<IPropertyDescriptor>>();
         private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, string>> enumNameCache = new ConcurrentDictionary<Type, ConcurrentDictionary<string, string>>();
         private readonly ConcurrentDictionary<object, string> enumValueCache = new ConcurrentDictionary<object, string>();
+        private readonly ConcurrentDictionary<Type, bool> hasParseMethodCache = new ConcurrentDictionary<Type, bool>();
 
         public CachedTypeInspector(ITypeInspector innerTypeDescriptor)
         {
@@ -74,5 +75,12 @@ namespace YamlDotNet.Serialization.TypeInspectors
             },
             (container, innerTypeDescriptor));
         }
+
+        public override bool HasParseMethod(Type type)
+        {
+            return hasParseMethodCache.GetOrAdd(type, t => innerTypeDescriptor.HasParseMethod(t));
+        }
+
+        public override object? Parse(string value, Type expectedType) => innerTypeDescriptor.Parse(value, expectedType);
     }
 }

--- a/YamlDotNet/Serialization/TypeInspectors/CachedTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/CachedTypeInspector.cs
@@ -78,7 +78,8 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
         public override bool HasParseMethod(Type type)
         {
-            return hasParseMethodCache.GetOrAdd(type, t => innerTypeDescriptor.HasParseMethod(t));
+            return hasParseMethodCache.GetOrAdd(type, static (t, typeDescriptor) =>
+                typeDescriptor.HasParseMethod(t), innerTypeDescriptor);
         }
 
         public override object? Parse(string value, Type expectedType) => innerTypeDescriptor.Parse(value, expectedType);

--- a/YamlDotNet/Serialization/TypeInspectors/CompositeTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/CompositeTypeInspector.cs
@@ -94,7 +94,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
         public override object? Parse(string value, Type expectedType)
         {
-            var parsableInspector = typeInspectors.Where(i => i.HasParseMethod(expectedType)).FirstOrDefault();
+            var parsableInspector = typeInspectors.FirstOrDefault(i => i.HasParseMethod(expectedType));
 
             if (parsableInspector == null)
             {

--- a/YamlDotNet/Serialization/TypeInspectors/CompositeTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/CompositeTypeInspector.cs
@@ -86,5 +86,22 @@ namespace YamlDotNet.Serialization.TypeInspectors
             return typeInspectors
                 .SelectMany(i => i.GetProperties(type, container));
         }
+
+        public override bool HasParseMethod(Type type)
+        {
+            return typeInspectors.Any(i => i.HasParseMethod(type));
+        }
+
+        public override object? Parse(string value, Type expectedType)
+        {
+            var parsableInspector = typeInspectors.Where(i => i.HasParseMethod(expectedType)).FirstOrDefault();
+
+            if (parsableInspector == null)
+            {
+                throw new ArgumentOutOfRangeException(nameof(expectedType), $"No inspector with a Parse method for type {expectedType.FullName} was found.");
+            }
+
+            return parsableInspector.Parse(value, expectedType);
+        }
     }
 }

--- a/YamlDotNet/Serialization/TypeInspectors/NamingConventionTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/NamingConventionTypeInspector.cs
@@ -57,5 +57,9 @@ namespace YamlDotNet.Serialization.TypeInspectors
                     return new PropertyDescriptor(p) { Name = namingConvention.Apply(p.Name) };
                 });
         }
+
+        public override bool HasParseMethod(Type type) => this.innerTypeDescriptor.HasParseMethod(type);
+
+        public override object? Parse(string value, Type expectedType) => this.innerTypeDescriptor.Parse(value, expectedType);
     }
 }

--- a/YamlDotNet/Serialization/TypeInspectors/ReadableAndWritablePropertiesTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReadableAndWritablePropertiesTypeInspector.cs
@@ -46,5 +46,9 @@ namespace YamlDotNet.Serialization.TypeInspectors
             return innerTypeDescriptor.GetProperties(type, container)
                 .Where(p => p.CanWrite);
         }
+
+        public override bool HasParseMethod(Type type) => this.innerTypeDescriptor.HasParseMethod(type);
+
+        public override object? Parse(string value, Type expectedType) => this.innerTypeDescriptor.Parse(value, expectedType);
     }
 }

--- a/YamlDotNet/Serialization/TypeInspectors/ReflectionTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReflectionTypeInspector.cs
@@ -71,7 +71,7 @@ namespace YamlDotNet.Serialization.TypeInspectors
             return result!;
         }
 
-        public override bool HasParseMethod(Type type) => type.GetMethod("Parse", [typeof(string)]) != null;
+        public override bool HasParseMethod(Type type) => type.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static, null, [typeof(string)], null) != null;
 
         public override object? Parse(string value, Type expectedType)
         {

--- a/YamlDotNet/Serialization/TypeInspectors/ReflectionTypeInspector.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/ReflectionTypeInspector.cs
@@ -71,5 +71,18 @@ namespace YamlDotNet.Serialization.TypeInspectors
             return result!;
         }
 
+        public override bool HasParseMethod(Type type) => type.GetMethod("Parse", [typeof(string)]) != null;
+
+        public override object? Parse(string value, Type expectedType)
+        {
+            var method = expectedType.GetMethod("Parse", [typeof(string)]);
+
+            if (method == null)
+            {
+                throw new InvalidOperationException($"Type '{expectedType.FullName}' does not have a static Parse method.");
+            }
+
+            return method.Invoke(null, new object[] { value });
+        }
     }
 }

--- a/YamlDotNet/Serialization/TypeInspectors/TypeInspectorSkeleton.cs
+++ b/YamlDotNet/Serialization/TypeInspectors/TypeInspectorSkeleton.cs
@@ -73,5 +73,9 @@ namespace YamlDotNet.Serialization.TypeInspectors
 
             return property;
         }
+
+        public abstract bool HasParseMethod(Type type);
+
+        public abstract object? Parse(string value, Type expectedType);
     }
 }

--- a/YamlDotNet/Serialization/Utilities/ReflectionTypeConverter.cs
+++ b/YamlDotNet/Serialization/Utilities/ReflectionTypeConverter.cs
@@ -28,6 +28,5 @@ namespace YamlDotNet.Serialization.Utilities
     {
         public object? ChangeType(object? value, Type expectedType, ITypeInspector typeInspector) => ChangeType(value, expectedType, NullNamingConvention.Instance, typeInspector);
         public object? ChangeType(object? value, Type expectedType, INamingConvention enumNamingConvention, ITypeInspector typeInspector) => TypeConverter.ChangeType(value, expectedType, enumNamingConvention, typeInspector);
-
     }
 }

--- a/YamlDotNet/Serialization/YamlAttributesTypeInspector.cs
+++ b/YamlDotNet/Serialization/YamlAttributesTypeInspector.cs
@@ -70,5 +70,9 @@ namespace YamlDotNet.Serialization
                 })
                 .OrderBy(p => p.Order);
         }
+
+        public override bool HasParseMethod(Type type) => this.innerTypeDescriptor.HasParseMethod(type);
+
+        public override object? Parse(string value, Type expectedType) => this.innerTypeDescriptor.Parse(value, expectedType);
     }
 }


### PR DESCRIPTION
Fixes #1098

This is a breaking change in the TypeInspectorSkeleton class and adds 2 methods to ITypeInspector. Quick fix to resolve those breaking changes in your own custom TypeInspector is to return `false` on the `HasParseMethod` method and return `null` or throw an exception on the `Parse` method.