### PR TITLE
Add support for uninitialized instance creation during deserialization

### DIFF
--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -768,7 +768,7 @@ year_of_birth: 1983
 car:
   name: Mercedes
   year: 2018";
-            var actual = deserializer.Deserialize<PersonWithCardRecord>(yaml);
+            var actual = deserializer.Deserialize<PersonRecordWithCarRecord>(yaml);
             Assert.Equal("Jack", actual.Name);
             Assert.Equal(1983, actual.YearOfBirth);
             Assert.Equal("Mercedes", actual.Car.Name);
@@ -778,9 +778,8 @@ car:
         public record class PersonRecordClass(string Name, int Age);
         public record struct PersonRecordStruct(string Name, int Age);
 
-        public record PersonWithCardRecord(string Name, int YearOfBirth, CarRecord Car);
+        public record PersonRecordWithCarRecord(string Name, int YearOfBirth, CarRecord Car);
         public record CarRecord(string Name, int Year);
-
 #endif
 
 #nullable enable

--- a/YamlDotNet.Test/Serialization/DeserializerTest.cs
+++ b/YamlDotNet.Test/Serialization/DeserializerTest.cs
@@ -242,7 +242,7 @@ b: &number 1
 
             var yaml = FormattableString.Invariant($"Value: {expected}");
 
-            // It needs explicitly specifying maximum precision for value roundtrip. 
+            // It needs explicitly specifying maximum precision for value roundtrip.
             if (expected is float floatValue)
             {
                 yaml = $"Value: {floatValue.ToString("G9", CultureInfo.InvariantCulture)}";
@@ -694,6 +694,93 @@ Property: test-property";
             NullValue = 3
 
         }
+#endif
+
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void RecordClassWithPositionalProperties()
+        {
+            var deserializer = new DeserializerBuilder()
+                .EnableUnstableAttemptUninitializedInstance()
+                .Build();
+            var yaml = @"
+Name: Jack
+Age: 43";
+            var actual = deserializer.Deserialize<PersonRecordClass>(yaml);
+            Assert.Equal("Jack", actual.Name);
+            Assert.Equal(43, actual.Age);
+        }
+
+        [Fact]
+        public void RecordStructWithPositionalProperties()
+        {
+            var deserializer = new DeserializerBuilder()
+                .EnableUnstableAttemptUninitializedInstance()
+                .Build();
+            var yaml = @"
+Name: Jack
+Age: 43";
+            var actual = deserializer.Deserialize<PersonRecordStruct>(yaml);
+            Assert.Equal("Jack", actual.Name);
+            Assert.Equal(43, actual.Age);
+        }
+
+        [Fact]
+        public void RecordClassWithPositionalPropertiesWithNamingConvention()
+        {
+            var deserializer = new DeserializerBuilder()
+                .EnableUnstableAttemptUninitializedInstance()
+                .WithNamingConvention(LowerCaseNamingConvention.Instance)
+                .Build();
+            var yaml = @"
+name: Jack
+age: 43";
+            var actual = deserializer.Deserialize<PersonRecordClass>(yaml);
+            Assert.Equal("Jack", actual.Name);
+            Assert.Equal(43, actual.Age);
+        }
+
+        [Fact]
+        public void RecordStructWithPositionalPropertiesWithNamingConvention()
+        {
+            var deserializer = new DeserializerBuilder()
+                .EnableUnstableAttemptUninitializedInstance()
+                .WithNamingConvention(LowerCaseNamingConvention.Instance)
+                .Build();
+            var yaml = @"
+name: Jack
+age: 43";
+            var actual = deserializer.Deserialize<PersonRecordStruct>(yaml);
+            Assert.Equal("Jack", actual.Name);
+            Assert.Equal(43, actual.Age);
+        }
+
+        [Fact]
+        public void NestedRecordClassWithPositionalPropertiesWithNamingConvention()
+        {
+            var deserializer = new DeserializerBuilder()
+                .EnableUnstableAttemptUninitializedInstance()
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                .Build();
+            var yaml = @"
+name: Jack
+year_of_birth: 1983
+car:
+  name: Mercedes
+  year: 2018";
+            var actual = deserializer.Deserialize<PersonWithCardRecord>(yaml);
+            Assert.Equal("Jack", actual.Name);
+            Assert.Equal(1983, actual.YearOfBirth);
+            Assert.Equal("Mercedes", actual.Car.Name);
+            Assert.Equal(2018, actual.Car.Year);
+        }
+
+        public record class PersonRecordClass(string Name, int Age);
+        public record struct PersonRecordStruct(string Name, int Age);
+
+        public record PersonWithCardRecord(string Name, int YearOfBirth, CarRecord Car);
+        public record CarRecord(string Name, int Year);
+
 #endif
 
 #nullable enable

--- a/YamlDotNet/Serialization/BuilderSkeleton.cs
+++ b/YamlDotNet/Serialization/BuilderSkeleton.cs
@@ -96,6 +96,16 @@ namespace YamlDotNet.Serialization
         }
 
         /// <summary>
+        /// Calling this will attempt to create an uninitialized instance during deserialization, possibly allowing certain types.
+        /// </summary>
+        /// <remarks>This setting is UNSTABLE.</remarks>
+        public TBuilder EnableUnstableAttemptUninitializedInstance()
+        {
+            settings.UnstableAttemptUninitializedInstance = true;
+            return Self;
+        }
+
+        /// <summary>
         /// Sets the <see cref="INamingConvention" /> that will be used by the (de)serializer.
         /// </summary>
         public TBuilder WithNamingConvention(INamingConvention namingConvention)

--- a/YamlDotNet/Serialization/ObjectFactories/DefaultObjectFactory.cs
+++ b/YamlDotNet/Serialization/ObjectFactories/DefaultObjectFactory.cs
@@ -25,7 +25,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using RuntimeSerialization = System.Runtime.Serialization;
 using YamlDotNet.Serialization.Callbacks;
+using System.Runtime.CompilerServices;
 
 namespace YamlDotNet.Serialization.ObjectFactories
 {
@@ -108,6 +110,14 @@ namespace YamlDotNet.Serialization.ObjectFactories
             try
             {
                 return Activator.CreateInstance(type, settings.AllowPrivateConstructors)!;
+            }
+            catch (MissingMethodException) when (settings.UnstableAttemptUninitializedInstance && !type.IsAbstract)
+            {
+#if NET5_0_OR_GREATER
+                return RuntimeHelpers.GetUninitializedObject(type);
+#else
+                return RuntimeSerialization.FormatterServices.GetUninitializedObject(type);
+#endif
             }
             catch (Exception err)
             {

--- a/YamlDotNet/Serialization/ObjectFactories/DefaultObjectFactory.cs
+++ b/YamlDotNet/Serialization/ObjectFactories/DefaultObjectFactory.cs
@@ -25,9 +25,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using RuntimeSerialization = System.Runtime.Serialization;
 using YamlDotNet.Serialization.Callbacks;
-using System.Runtime.CompilerServices;
 
 namespace YamlDotNet.Serialization.ObjectFactories
 {
@@ -111,7 +111,7 @@ namespace YamlDotNet.Serialization.ObjectFactories
             {
                 return Activator.CreateInstance(type, settings.AllowPrivateConstructors)!;
             }
-            catch (MissingMethodException) when (settings.UnstableAttemptUninitializedInstance && !type.IsAbstract)
+            catch (MissingMethodException) when (settings.UnstableAttemptUninitializedInstance)
             {
 #if NET5_0_OR_GREATER
                 return RuntimeHelpers.GetUninitializedObject(type);

--- a/YamlDotNet/Serialization/Settings.cs
+++ b/YamlDotNet/Serialization/Settings.cs
@@ -27,5 +27,10 @@ namespace YamlDotNet.Serialization
         /// If true then private, parameterless constructors will be invoked if a public one is not available.
         /// </summary>
         public bool AllowPrivateConstructors { get; set; }
+
+        /// <summary>
+        /// If true then constructors with positional properties will attempt to invoke if a public one is not available.
+        /// </summary>
+        public bool UnstableAttemptUninitializedInstance { get; set; }
     }
 }

--- a/YamlDotNet/Serialization/Settings.cs
+++ b/YamlDotNet/Serialization/Settings.cs
@@ -29,7 +29,7 @@ namespace YamlDotNet.Serialization
         public bool AllowPrivateConstructors { get; set; }
 
         /// <summary>
-        /// If true then constructors with positional properties will attempt to invoke if a public one is not available.
+        /// If true then will attempt to create an uninitialized instance during deserialization, possibly allowing certain type, such as <c>record</c>s with positional properties.
         /// </summary>
         public bool UnstableAttemptUninitializedInstance { get; set; }
     }


### PR DESCRIPTION
Add support for uninitialized instance creation during deserialization, mainly to address positional properties records.

* Added `UnstableAttemptUninitializedInstance` setting and related method `EnableUnstableAttemptUninitializedInstance` in `BuilderSkeleton`.
* Now if `DefaultObjectFactory` fails while the option is on it tries `RuntimeHelpers`/`RuntimeSerialization`.
* Added proper tests with positional properties records.

---

So something like:
```cs
public record class Person(string Name, int Age);
```

```cs
var deserializer = new DeserializerBuilder()
    .EnableUnstableAttemptUninitializedInstance()
    .Build();

deserializer.Deserialize<Person>(input);
```

would work.