### PR TITLE
Static deserializer builder needed the default maximum recursion

### DIFF
--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -121,6 +121,8 @@ namespace YamlDotNet.Serialization
                 { typeof(PreventUnknownTagsNodeTypeResolver), _ => new PreventUnknownTagsNodeTypeResolver() },
                 { typeof(DefaultContainersNodeTypeResolver), _ => new DefaultContainersNodeTypeResolver() }
             };
+
+            maximumRecursion = 130;
         }
 
         protected override StaticDeserializerBuilder Self { get { return this; } }
@@ -459,11 +461,16 @@ namespace YamlDotNet.Serialization
         }
 
         /// <summary>
-        /// Sets the maximum recursion that is allowed while deserializing.
+        /// Sets the maximum recursion that is allowed while building the object graph. Must be > 0. Default is 130.
         /// </summary>
         /// <remarks>
         /// Setting this limit is strongly recommended when parsing untrusted input since
-        /// deeply nested objects will lead to a stack overflow.
+        /// deeply nested objects will lead to a stack overflow. When using the default configuration
+        /// on Windows the maximum you should allow is ~130 as anything over that will lead to a stack overflow
+        /// when the max recursion exception is thrown. Linux OS allows for ~475 with .net 10 and the exception will be
+        /// thrown correctly without causing a stack overflow. This does not take into account the depth of
+        /// your application call stack. This is if YamlDotNet is called from the top of the stack. Windows with
+        /// .NET 8 only allows for ~130. On .NET 10 and Windows you can safely use ~152.
         /// </remarks>
         public StaticDeserializerBuilder WithMaximumRecursion(int maximumRecursion)
         {


### PR DESCRIPTION
## Welcome!

Needed to add the maximum recursion to the static deserializer builder to complete the security finding.