### PR TITLE
More unbounded recursion

### DIFF
--- a/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
+++ b/YamlDotNet.Test/RepresentationModel/YamlStreamTests.cs
@@ -290,6 +290,22 @@ stringWriter.ToString().NormalizeNewLines().TrimNewLines());
             Assert.Equal("-\"\" should be zero", nodes[2].ToString());
         }
 
+        [Fact]
+        public void RecursiveStackOverflow_StopAt100()
+        {
+            var untrustedYaml = new string('[', 101) + new string(']', 101);
+            var stream = new YamlStream();
+            Assert.Throws<InvalidOperationException>(() => stream.Load(new StringReader(untrustedYaml)));
+        }
+
+        [Fact]
+        public void RecursiveStackOverflow_Allow100()
+        {
+            var untrustedYaml = new string('[', 100) + new string(']', 100);
+            var stream = new YamlStream();
+            stream.Load(new StringReader(untrustedYaml));
+        }
+
         private void RoundtripTest(string yamlFileName)
         {
             var original = new YamlStream();

--- a/YamlDotNet/RepresentationModel/DocumentLoadingState.cs
+++ b/YamlDotNet/RepresentationModel/DocumentLoadingState.cs
@@ -31,8 +31,16 @@ namespace YamlDotNet.RepresentationModel
     /// </summary>
     internal class DocumentLoadingState
     {
+        public const int MaxReadDepthDefault = 100;
         private readonly Dictionary<AnchorName, YamlNode> anchors = [];
         private readonly List<YamlNode> nodesWithUnresolvedAliases = [];
+        private int currentDepth;
+        private readonly int maxDepth;
+
+        public DocumentLoadingState(int maxDepth)
+        {
+            this.maxDepth = maxDepth;
+        }
 
         /// <summary>
         /// Adds the specified node to the anchor list.
@@ -99,6 +107,28 @@ namespace YamlDotNet.RepresentationModel
             {
                 node.ResolveAliases(this);
             }
+        }
+
+        /// <summary>
+        /// Increment the depth of the current node nesting. It also tests to make sure the maximum depth is not exceeded.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public void Nest()
+        {
+            currentDepth++;
+
+            if (maxDepth > 0 && currentDepth > maxDepth)
+            {
+                throw new InvalidOperationException("The maximum depth has been exceeded.");
+            }
+        }
+
+        /// <summary>
+        /// Decrement the depth of the current node nesting.
+        /// </summary>
+        public void Unnest()
+        {
+            currentDepth--;
         }
     }
 }

--- a/YamlDotNet/RepresentationModel/YamlDocument.cs
+++ b/YamlDotNet/RepresentationModel/YamlDocument.cs
@@ -58,9 +58,9 @@ namespace YamlDotNet.RepresentationModel
         /// <summary>
         /// Initializes a new instance of the <see cref="YamlDocument"/> class.
         /// </summary>
-        internal YamlDocument(IParser parser)
+        internal YamlDocument(IParser parser, int maxDepth)
         {
-            var state = new DocumentLoadingState();
+            var state = new DocumentLoadingState(maxDepth);
 
             parser.Consume<DocumentStart>();
 

--- a/YamlDotNet/RepresentationModel/YamlMappingNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlMappingNode.cs
@@ -51,6 +51,11 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
+        /// Gets or sets the maximum depth for reading the mapping node.
+        /// </summary>
+        public int MaxDepth { get; set; } = DocumentLoadingState.MaxReadDepthDefault;
+
+        /// <summary>
         /// Gets or sets the style of the node.
         /// </summary>
         /// <value>The style.</value>
@@ -381,7 +386,7 @@ namespace YamlDotNet.RepresentationModel
 
         void IYamlConvertible.Read(IParser parser, Type expectedType, ObjectDeserializer nestedObjectDeserializer)
         {
-            Load(parser, new DocumentLoadingState());
+            Load(parser, new DocumentLoadingState(MaxDepth));
         }
 
         void IYamlConvertible.Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)

--- a/YamlDotNet/RepresentationModel/YamlNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlNode.cs
@@ -80,24 +80,32 @@ namespace YamlDotNet.RepresentationModel
         /// <returns>Returns the node that has been parsed.</returns>
         internal static YamlNode ParseNode(IParser parser, DocumentLoadingState state)
         {
-            if (parser.Accept<Scalar>(out var _))
+            state.Nest();
+            try
             {
-                return new YamlScalarNode(parser, state);
-            }
+                if (parser.Accept<Scalar>(out var _))
+                {
+                    return new YamlScalarNode(parser, state);
+                }
 
-            if (parser.Accept<SequenceStart>(out var _))
-            {
-                return new YamlSequenceNode(parser, state);
-            }
+                if (parser.Accept<SequenceStart>(out var _))
+                {
+                    return new YamlSequenceNode(parser, state);
+                }
 
-            if (parser.Accept<MappingStart>(out var _))
-            {
-                return new YamlMappingNode(parser, state);
-            }
+                if (parser.Accept<MappingStart>(out var _))
+                {
+                    return new YamlMappingNode(parser, state);
+                }
 
-            if (parser.TryConsume<AnchorAlias>(out var alias))
+                if (parser.TryConsume<AnchorAlias>(out var alias))
+                {
+                    return state.TryGetNode(alias.Value, out var node) ? node : new YamlAliasNode(alias.Value);
+                }
+            }
+            finally
             {
-                return state.TryGetNode(alias.Value, out var node) ? node : new YamlAliasNode(alias.Value);
+                state.Unnest();
             }
 
             throw new ArgumentException("The current event is of an unsupported type.", nameof(parser));

--- a/YamlDotNet/RepresentationModel/YamlScalarNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlScalarNode.cs
@@ -63,6 +63,11 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
+        /// Gets or sets the maximum depth for reading the scalar node.
+        /// </summary>
+        public int MaxDepth { get; set; } = DocumentLoadingState.MaxReadDepthDefault;
+
+        /// <summary>
         /// Gets or sets the style of the node.
         /// </summary>
         /// <value>The style.</value>
@@ -224,7 +229,7 @@ namespace YamlDotNet.RepresentationModel
 
         void IYamlConvertible.Read(IParser parser, Type expectedType, ObjectDeserializer nestedObjectDeserializer)
         {
-            Load(parser, new DocumentLoadingState());
+            Load(parser, new DocumentLoadingState(MaxDepth));
         }
 
         void IYamlConvertible.Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)

--- a/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
+++ b/YamlDotNet/RepresentationModel/YamlSequenceNode.cs
@@ -51,6 +51,11 @@ namespace YamlDotNet.RepresentationModel
         }
 
         /// <summary>
+        /// Gets or sets the maximum depth for reading the sequence node.
+        /// </summary>
+        public int MaxDepth { get; set; } = DocumentLoadingState.MaxReadDepthDefault;
+
+        /// <summary>
         /// Gets or sets the style of the node.
         /// </summary>
         /// <value>The style.</value>
@@ -292,7 +297,7 @@ namespace YamlDotNet.RepresentationModel
 
         void IYamlConvertible.Read(IParser parser, Type expectedType, ObjectDeserializer nestedObjectDeserializer)
         {
-            Load(parser, new DocumentLoadingState());
+            Load(parser, new DocumentLoadingState(MaxDepth));
         }
 
         void IYamlConvertible.Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)

--- a/YamlDotNet/RepresentationModel/YamlStream.cs
+++ b/YamlDotNet/RepresentationModel/YamlStream.cs
@@ -34,6 +34,11 @@ namespace YamlDotNet.RepresentationModel
         private readonly List<YamlDocument> documents = [];
 
         /// <summary>
+        /// Gets or sets the maximum depth for reading the YAML stream.
+        /// </summary>
+        public int MaxDepth { get; set; } = 100;
+
+        /// <summary>
         /// Gets the documents inside the stream.
         /// </summary>
         /// <value>The documents.</value>
@@ -98,7 +103,7 @@ namespace YamlDotNet.RepresentationModel
             parser.Consume<StreamStart>();
             while (!parser.TryConsume<StreamEnd>(out var _))
             {
-                var document = new YamlDocument(parser);
+                var document = new YamlDocument(parser, MaxDepth);
                 documents.Add(document);
             }
         }

--- a/YamlDotNet/RepresentationModel/YamlStream.cs
+++ b/YamlDotNet/RepresentationModel/YamlStream.cs
@@ -36,7 +36,7 @@ namespace YamlDotNet.RepresentationModel
         /// <summary>
         /// Gets or sets the maximum depth for reading the YAML stream.
         /// </summary>
-        public int MaxDepth { get; set; } = 100;
+        public int MaxDepth { get; set; } = DocumentLoadingState.MaxReadDepthDefault;
 
         /// <summary>
         /// Gets the documents inside the stream.

--- a/YamlDotNet/Serialization/DeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/DeserializerBuilder.cs
@@ -129,7 +129,7 @@ namespace YamlDotNet.Serialization
                 { typeof(DefaultContainersNodeTypeResolver), _ => new DefaultContainersNodeTypeResolver() }
             };
 
-            maximumRecursion = 130;
+            maximumRecursion = 100;
         }
 
         protected override DeserializerBuilder Self { get { return this; } }
@@ -484,7 +484,7 @@ namespace YamlDotNet.Serialization
         }
 
         /// <summary>
-        /// Sets the maximum recursion that is allowed while building the object graph. Must be > 0. Default is 130.
+        /// Sets the maximum recursion that is allowed while building the object graph. Must be > 0. Default is 100.
         /// </summary>
         /// <remarks>
         /// Setting this limit is strongly recommended when parsing untrusted input since
@@ -493,7 +493,7 @@ namespace YamlDotNet.Serialization
         /// when the max recursion exception is thrown. Linux OS allows for ~475 with .net 10 and the exception will be
         /// thrown correctly without causing a stack overflow. This does not take into account the depth of
         /// your application call stack. This is if YamlDotNet is called from the top of the stack. Windows with
-        /// .NET 8 only allows for ~130. On .NET 10 and Windows you can safely use ~152.
+        /// .NET 8 only allows for ~130. On .NET 10 and Windows you can safely use ~150.
         /// </remarks>
         public DeserializerBuilder WithMaximumRecursion(int maximumRecursion)
         {

--- a/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
+++ b/YamlDotNet/Serialization/StaticDeserializerBuilder.cs
@@ -122,7 +122,7 @@ namespace YamlDotNet.Serialization
                 { typeof(DefaultContainersNodeTypeResolver), _ => new DefaultContainersNodeTypeResolver() }
             };
 
-            maximumRecursion = 130;
+            maximumRecursion = 100;
         }
 
         protected override StaticDeserializerBuilder Self { get { return this; } }
@@ -461,7 +461,7 @@ namespace YamlDotNet.Serialization
         }
 
         /// <summary>
-        /// Sets the maximum recursion that is allowed while building the object graph. Must be > 0. Default is 130.
+        /// Sets the maximum recursion that is allowed while building the object graph. Must be > 0. Default is 100.
         /// </summary>
         /// <remarks>
         /// Setting this limit is strongly recommended when parsing untrusted input since
@@ -470,7 +470,7 @@ namespace YamlDotNet.Serialization
         /// when the max recursion exception is thrown. Linux OS allows for ~475 with .net 10 and the exception will be
         /// thrown correctly without causing a stack overflow. This does not take into account the depth of
         /// your application call stack. This is if YamlDotNet is called from the top of the stack. Windows with
-        /// .NET 8 only allows for ~130. On .NET 10 and Windows you can safely use ~152.
+        /// .NET 8 only allows for ~130. On .NET 10 and Windows you can safely use ~150.
         /// </remarks>
         public StaticDeserializerBuilder WithMaximumRecursion(int maximumRecursion)
         {


### PR DESCRIPTION
* 4 more classes with unbounded recursion when deserializing.
* Changed default max recursion depth in the deserializer builders to be 100 to allow more headroom for consuming applications.